### PR TITLE
Fixed database schema to allow questions again

### DIFF
--- a/db/install.sql
+++ b/db/install.sql
@@ -288,8 +288,8 @@ CREATE TABLE IF NOT EXISTS `Questions` (
   `QID` bigint(20) NOT NULL AUTO_INCREMENT,
   `UID` int(11) NOT NULL DEFAULT '0',
   `Question` text NOT NULL,
-  `AID` int(11) NOT NULL DEFAULT '0',
-  `Answer` text NOT NULL,
+  `AID` int(11) DEFAULT NULL,
+  `Answer` text,
   PRIMARY KEY (`QID`),
   KEY `UID` (`UID`),
   KEY `AID` (`AID`)


### PR DESCRIPTION
The answer fields in Questions are now NULL by default. The previous
defaults would not fulfill the forein key contraints on line 493 of
`install.sql` and thus the creation of new (yet unanswered) questions was
not possible.
