### PR TITLE
Hinweis auf Git submodules beim Auschecken ergänzt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
  * Webserver mit PHP-Anbindung, z.B. lighttpd, nginx oder Apache
 
 ## Vorgehen:
- * Auschecken der Dateien vom `master` unter https://github.com/engelsystem/engelsystem.git
+ * Klonen des `master` inkl. submodules in lokales Verzeichnis: `git clone --recursive https://github.com/engelsystem/engelsystem.git`
  * Der Webserver muss Schreibrechte auf das Verzeichnis `import` bekommen, für alle anderen Dateien reichen Leserechte.
  * Der Webserver muss auf `public` als http-root zeigen.
  * Empfehlung: Dirlisting sollte deaktiviert sein.


### PR DESCRIPTION
Hintergrund: beim Installieren nach Anleitung ohne Initialisierung der
Submodule schlägt das require auf /../vendor/parsedown/Parsedown.php
fehl, weil die entsprechenden Dateien gar nicht da sind.
