### PR TITLE
Non scrollable shifts table

### DIFF
--- a/themes/base.less
+++ b/themes/base.less
@@ -30,10 +30,6 @@ body {
   }
 }
 
-.shifts-table {
-  overflow-x: scroll;
-}
-
 .row-day {
   border-top: 2px solid @gray-light;
 }


### PR DESCRIPTION
On some browsers it seems to be impossible to scroll the table to the right when width exceeds windows width. Seen on Win Firefox.
