### PR TITLE
Endlosschleife gefixt

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -92,7 +92,8 @@ $free_pages = array(
     'ical',
     'shifts_json_export',
     'shifts',
-    'atom' 
+    'atom',
+    'login'
 );
 
 // Gewünschte Seite/Funktion


### PR DESCRIPTION
Bei der Installation gibt der browser die Errormeldung zurück, dass die Anfrage zu oft umgeleitet würde.
Habe in Zeile 96 "login" zum array $free_pages hinzugefügt, da sonst der Abschnitt "gewünschte Seite/Funktion" sich immer wieder wiederholt ($p = "login" -> erste Bedingung (Z. 103) nicht erfüllt -> zweite Bedingung (Zeile 223) ist nicht erfüllt, da user nicht eingeloggt -> $p wird als login gesetzt (Z. 228) -> beginnt von vorne).