### PR TITLE
Make contact email address configurable

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -6,6 +6,9 @@ $maintenance_mode = false;
 // URL to the angel faq and job description
 $faq_url = "https://events.ccc.de/congress/2013/wiki/Static:Volunteers";
 
+// contact email address, linked on every page
+$contact_email = "mailto:erzengel@lists.ccc.de";
+
 // Default-Theme auf der Startseite, 1=style1.css usw.
 $default_theme = 1;
 

--- a/public/index.php
+++ b/public/index.php
@@ -157,6 +157,7 @@ echo template_render('../templates/layout.html', array(
     'content' => msg() . $content,
     'header_toolbar' => header_toolbar(),
     'faq_url' => $faq_url,
+    'contact_email' => $contact_email,
     'locale' => locale() 
 ));
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -29,7 +29,7 @@
       <div class="col-md-12">
         <hr />
         <div class="text-center footer" style="margin-bottom: 10px;">
-          <a href="%faq_url%">FAQ</a> · <a href="mailto:erzengel@lists.ccc.de"><span class="glyphicon glyphicon-envelope"></span> Contact</a> · <a href="https://github.com/engelsystem/engelsystem/issues">Bugs / Features</a> · <a href="https://github.com/engelsystem/engelsystem/">Development
+          <a href="%faq_url%">FAQ</a> · <a href="%contact_email%"><span class="glyphicon glyphicon-envelope"></span> Contact</a> · <a href="https://github.com/engelsystem/engelsystem/issues">Bugs / Features</a> · <a href="https://github.com/engelsystem/engelsystem/">Development
             Platform</a> · <a href="?p=credits">Credits</a>
         </div>
       </div>


### PR DESCRIPTION
At the moment, the contact email address (erzengel@lists.ccc.de) is hard-coded in the template. However, users deploying their own Engelsystem instance almost certainly wish to change the address.

This PR adds a configuration variable to specify the contact email address in the expected place.