### PR TITLE
Fixes for unittests

### DIFF
--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -11,6 +11,7 @@ use Engelsystem\Routing\UrlGenerator;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface as StorageInterface;
 
 class HelpersTest extends TestCase
 {
@@ -130,7 +131,9 @@ class HelpersTest extends TestCase
      */
     public function testSession()
     {
+        $sessionStorage = $this->getMockForAbstractClass(StorageInterface::class);
         $sessionMock = $this->getMockBuilder(Session::class)
+            ->setConstructorArgs([$sessionStorage])
             ->getMock();
 
         $this->getAppMock('session', $sessionMock);

--- a/tests/Unit/Http/SessionServiceProviderTest.php
+++ b/tests/Unit/Http/SessionServiceProviderTest.php
@@ -109,7 +109,9 @@ class SessionServiceProviderTest extends ServiceProviderTest
      */
     private function getSessionMock()
     {
+        $sessionStorage = $this->getMockForAbstractClass(StorageInterface::class);
         return $this->getMockBuilder(Session::class)
+            ->setConstructorArgs([$sessionStorage])
             ->setMethods(['start'])
             ->getMock();
     }


### PR DESCRIPTION
```
There were 3 errors:

1) Engelsystem\Test\Unit\HelpersTest::testSession
RuntimeException: Failed to set the session handler because headers have already been sent by "/builds/github-myigel/engelsystem/vendor/phpunit/phpunit/src/Util/Printer.php" at line 112.

/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:394
/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:120
/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Session.php:39
/builds/github-myigel/engelsystem/tests/Unit/HelpersTest.php:134

2) Engelsystem\Test\Unit\Http\SessionServiceProviderTest::testRegister
RuntimeException: Failed to set the session handler because headers have already been sent by "/builds/github-myigel/engelsystem/vendor/phpunit/phpunit/src/Util/Printer.php" at line 112.

/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:394
/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:120
/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Session.php:39
/builds/github-myigel/engelsystem/tests/Unit/Http/SessionServiceProviderTest.php:114
/builds/github-myigel/engelsystem/tests/Unit/Http/SessionServiceProviderTest.php:27

3) Engelsystem\Test\Unit\Http\SessionServiceProviderTest::testIsCli
RuntimeException: Failed to set the session handler because headers have already been sent by "/builds/github-myigel/engelsystem/vendor/phpunit/phpunit/src/Util/Printer.php" at line 112.

/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:394
/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:120
/builds/github-myigel/engelsystem/vendor/symfony/http-foundation/Session/Session.php:39
/builds/github-myigel/engelsystem/tests/Unit/Http/SessionServiceProviderTest.php:114
/builds/github-myigel/engelsystem/tests/Unit/Http/SessionServiceProviderTest.php:78

ERRORS!
Tests: 78, Assertions: 159, Errors: 3.
```