### PR TITLE
fixed "add more angels" link target

### DIFF
--- a/includes/view/ShiftCalendarShiftRenderer.php
+++ b/includes/view/ShiftCalendarShiftRenderer.php
@@ -126,7 +126,7 @@ class ShiftCalendarShiftRenderer
         if (in_array('user_shifts_admin', $privileges)) {
             $html .= '<li class="list-group-item">';
             $html .= button(
-                    page_link_to('user_shifts', ['shift_id' => $shift['SID']]),
+                    page_link_to('user_shifts', ['edit_shift' => $shift['SID']]),
                     glyph('plus') . _('Add more angels'),
                     'btn-xs'
                 );


### PR DESCRIPTION
**Before:**

When you click "Add more angels", the sign-up form for the shift appears. I think this is not intended...?

**After:**

"Add more angels" takes you to the form where you can add or delete angels under "Needed angels".