### PR TITLE
Fix sign-up to shifts by supporter

### DIFF
--- a/includes/controller/shift_entries_controller.php
+++ b/includes/controller/shift_entries_controller.php
@@ -194,7 +194,7 @@ function shift_entry_add_controller()
             $angeltypes[$angeltype['id']] = $angeltype['name'];
         }
         $angeltype_select = html_select_key('angeltype_id', 'angeltype_id', $angeltypes, $type['id']);
-    } elseif (in_array('shiftentry_edit_angeltype_supporter', $privileges)) {
+    } elseif (in_array('shiftentry_edit_angeltype_supporter', $privileges) && User_is_AngelType_supporter($user, $type)) {
         $users = Users_by_angeltype($type);
         $users_select = [];
         foreach ($users as $usr) {


### PR DESCRIPTION
Any user with the `shiftentry_edit_angeltype_supporter` privilege was able to sign up any users of the correct angeltype to any shift that they could sign up themselves because the shift entry controller only checks for the global privilege an not the fact that the user is indeed supporter for the angeltype in question.

How to reproduce:

Create two unprivileged users and an angeltype. Give supporter rights for the angeltype to user 1. Give both users the `shiftentry_edit_angeltype_supporter` privilege. Create some shifts. Both users will be able to sign up each other to these shifts when they are allowed to sign up themselves. Only user 1 should be able to sign up user 2 because user 1 is supporter, but not the other way around.