### PR TITLE
Allow dot in user name

### DIFF
--- a/includes/model/User_model.php
+++ b/includes/model/User_model.php
@@ -273,7 +273,7 @@ function User_ids()
  */
 function User_validate_Nick($nick)
 {
-    return preg_replace('/([^\p{L}\p{N}-_ ]+)/ui', '', trim($nick));
+    return preg_replace('/([^\p{L}\p{N}-_. ]+)/ui', '', trim($nick));
 }
 
 /**


### PR DESCRIPTION
0f273988 changed the regular expression for user names. The new regex does not allow dots anymore in user names, stripping them silently. We already have at least one user with a dot in their name who can't
login now anymore (see ticket 2017121479000228).