### PR TITLE
Change defaultvalue for initial vouchers

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -96,7 +96,7 @@ return [
 
     // Voucher calculation
     'voucher_settings'        => [
-        'initial_vouchers'   => 2,
+        'initial_vouchers'   => 0,
         'shifts_per_voucher' => 1,
     ],
 


### PR DESCRIPTION
Initial voucher set to zero to reflect the new way we distribute vouchers at congress