### PR TITLE
Fixes issue:#401

### DIFF
--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -299,7 +299,7 @@ function User_shift_state_render($user)
 
     if (time() < $halfway) {
         return '<span class="text-danger moment-countdown" data-timestamp="' . $nextShift['start'] . '">'
-            . _('Shift starts %c')
+            . _('Shift started %c')
             . '</span>';
     }
 


### PR DESCRIPTION
Display "shift started" instead of "shift starts" when shift has already started.