### PR TITLE
Fixes tests after #431 (Hotfix php7 syntax error)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ _vimrc_local.vim
 /config/config.php
 /test/coverage
 /public/coverage
+/coverage
 
 # Composer files
 /vendor/

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -76,7 +76,7 @@ class Handler
     protected function terminateApplicationImmediately($message = '')
     {
         echo $message;
-        die();
+        die(1);
     }
 
     /**

--- a/tests/Unit/Exceptions/HandlerTest.php
+++ b/tests/Unit/Exceptions/HandlerTest.php
@@ -61,10 +61,10 @@ class HandlerTest extends TestCase
 
         /** @var Handler|Mock $handler */
         $handler = $this->getMockBuilder(Handler::class)
-            ->setMethods(['die'])
+            ->setMethods(['terminateApplicationImmediately'])
             ->getMock();
         $handler->expects($this->once())
-            ->method('die');
+            ->method('terminateApplicationImmediately');
 
         $handler->setHandler(Handler::ENV_PRODUCTION, $handlerMock);
 


### PR DESCRIPTION
This commit fixes the tests after #431 renamed the function without running tests what causes them to terminate while running