### PR TITLE
UrlGeneratorInterface and "Legacy URL" support

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -43,6 +43,9 @@ return [
         '1' => 'Engelsystem dark'
     ],
 
+    // Rewrite URLs with mod_rewrite
+    'rewrite_urls'            => true,
+
     // Number of News shown on one site
     'display_news'            => 6,
 

--- a/src/Routing/LegacyUrlGenerator.php
+++ b/src/Routing/LegacyUrlGenerator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Engelsystem\Routing;
+
+class LegacyUrlGenerator extends UrlGenerator
+{
+    /**
+     * @param string $path
+     * @param array  $parameters
+     * @return string
+     */
+    public function to($path, $parameters = [])
+    {
+        $page = ltrim($path, '/');
+        if (!empty($page)) {
+            $page = str_replace('-', '_', $page);
+            $parameters = array_merge(['p' => $page], $parameters);
+        }
+
+        $uri = parent::to('index.php', $parameters);
+        $uri = preg_replace('~(/index\.php)+~', '/index.php', $uri);
+
+        return $uri;
+    }
+}

--- a/src/Routing/RoutingServiceProvider.php
+++ b/src/Routing/RoutingServiceProvider.php
@@ -8,7 +8,14 @@ class RoutingServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $urlGenerator = $this->app->make(UrlGenerator::class);
+        $config = $this->app->get('config');
+        $class = UrlGenerator::class;
+        if (!$config->get('rewrite_urls', true)) {
+            $class = LegacyUrlGenerator::class;
+        }
+
+        $urlGenerator = $this->app->make($class);
         $this->app->instance('routing.urlGenerator', $urlGenerator);
+        $this->app->bind(UrlGeneratorInterface::class, 'routing.urlGenerator');
     }
 }

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Engelsystem\Routing;
 
-class UrlGenerator
+class UrlGenerator implements UrlGeneratorInterface
 {
     /**
      * @param string $path

--- a/src/Routing/UrlGeneratorInterface.php
+++ b/src/Routing/UrlGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Engelsystem\Routing;
+
+interface UrlGeneratorInterface
+{
+    /**
+     * @param string $path
+     * @param array  $parameters
+     * @return string
+     */
+    public function to($path, $parameters = []);
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,7 +5,7 @@ use Engelsystem\Application;
 use Engelsystem\Config\Config;
 use Engelsystem\Http\Request;
 use Engelsystem\Renderer\Renderer;
-use Engelsystem\Routing\UrlGenerator;
+use Engelsystem\Routing\UrlGeneratorInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -114,7 +114,7 @@ function session($key = null, $default = null)
 /**
  * @param string $path
  * @param array  $parameters
- * @return UrlGenerator|string
+ * @return UrlGeneratorInterface|string
  */
 function url($path = null, $parameters = [])
 {

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -7,7 +7,7 @@ use Engelsystem\Config\Config;
 use Engelsystem\Container\Container;
 use Engelsystem\Http\Request;
 use Engelsystem\Renderer\Renderer;
-use Engelsystem\Routing\UrlGenerator;
+use Engelsystem\Routing\UrlGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -171,8 +171,7 @@ class HelpersTest extends TestCase
      */
     public function testUrl()
     {
-        $urlGeneratorMock = $this->getMockBuilder(UrlGenerator::class)
-            ->getMock();
+        $urlGeneratorMock = $this->getMockForAbstractClass(UrlGeneratorInterface::class);
 
         $this->getAppMock('routing.urlGenerator', $urlGeneratorMock);
         $this->assertEquals($urlGeneratorMock, url());

--- a/tests/Unit/Routing/LegacyUrlGeneratorTest.php
+++ b/tests/Unit/Routing/LegacyUrlGeneratorTest.php
@@ -5,32 +5,32 @@ namespace Engelsystem\Test\Unit\Routing;
 use Engelsystem\Application;
 use Engelsystem\Container\Container;
 use Engelsystem\Http\Request;
-use Engelsystem\Routing\UrlGenerator;
+use Engelsystem\Routing\LegacyUrlGenerator;
 use Engelsystem\Routing\UrlGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 
-class UrlGeneratorTest extends TestCase
+class LegacyUrlGeneratorTest extends TestCase
 {
     public function provideLinksTo()
     {
         return [
-            ['/foo/path', '/foo/path', 'http://foo.bar/foo/path', [], 'http://foo.bar/foo/path'],
-            ['foo', '/foo', 'https://foo.bar/foo', [], 'https://foo.bar/foo'],
-            ['foo', '/foo', 'http://f.b/foo', ['test' => 'abc', 'bla' => 'foo'], 'http://f.b/foo?test=abc&bla=foo'],
+            ['/', 'http://foo.bar/index.php', [], 'http://foo.bar/index.php'],
+            ['/foo-path', 'http://foo.bar/index.php/index.php', [], 'http://foo.bar/index.php?p=foo_path'],
+            ['/foo', 'http://foo.bar/index.php/index.php',  [], 'http://foo.bar/index.php?p=foo'],
+            ['foo', 'http://foo.bar/index.php', ['test' => 'abc'], 'http://foo.bar/index.php?p=foo&test=abc'],
         ];
     }
 
     /**
      * @dataProvider provideLinksTo
-     * @covers       \Engelsystem\Routing\UrlGenerator::to
+     * @covers       \Engelsystem\Routing\LegacyUrlGenerator::to
      *
-     * @param string   $path
-     * @param string   $willReturn
      * @param string   $urlToPath
+     * @param string   $willReturn
      * @param string[] $arguments
      * @param string   $expectedUrl
      */
-    public function testTo($urlToPath, $path, $willReturn, $arguments, $expectedUrl)
+    public function testTo($urlToPath, $willReturn, $arguments, $expectedUrl)
     {
         $app = new Container();
         Application::setInstance($app);
@@ -40,12 +40,12 @@ class UrlGeneratorTest extends TestCase
 
         $request->expects($this->once())
             ->method('getUriForPath')
-            ->with($path)
+            ->with('/index.php')
             ->willReturn($willReturn);
 
         $app->instance('request', $request);
 
-        $urlGenerator = new UrlGenerator();
+        $urlGenerator = new LegacyUrlGenerator();
         $this->assertInstanceOf(UrlGeneratorInterface::class, $urlGenerator);
 
         $url = $urlGenerator->to($urlToPath, $arguments);

--- a/tests/Unit/Routing/RoutingServiceProviderTest.php
+++ b/tests/Unit/Routing/RoutingServiceProviderTest.php
@@ -2,10 +2,13 @@
 
 namespace Engelsystem\Test\Unit\Routing;
 
+use Engelsystem\Config\Config;
+use Engelsystem\Routing\LegacyUrlGenerator;
 use Engelsystem\Routing\RoutingServiceProvider;
 use Engelsystem\Routing\UrlGenerator;
+use Engelsystem\Routing\UrlGeneratorInterface;
 use Engelsystem\Test\Unit\ServiceProviderTest;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 class RoutingServiceProviderTest extends ServiceProviderTest
 {
@@ -14,16 +17,48 @@ class RoutingServiceProviderTest extends ServiceProviderTest
      */
     public function testRegister()
     {
-        /** @var PHPUnit_Framework_MockObject_MockObject|UrlGenerator $urlGenerator */
-        $urlGenerator = $this->getMockBuilder(UrlGenerator::class)
-            ->getMock();
+        $app = $this->getApp(['make', 'instance', 'bind', 'get']);
+        /** @var MockObject|Config $config */
+        $config = $this->getMockBuilder(Config::class)->getMock();
+        /** @var MockObject|UrlGeneratorInterface $urlGenerator */
+        $urlGenerator = $this->getMockForAbstractClass(UrlGeneratorInterface::class);
+        /** @var MockObject|UrlGeneratorInterface $legacyUrlGenerator */
+        $legacyUrlGenerator = $this->getMockForAbstractClass(UrlGeneratorInterface::class);
 
-        $app = $this->getApp();
+        $config->expects($this->atLeastOnce())
+            ->method('get')
+            ->with('rewrite_urls')
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false
+            );
 
-        $this->setExpects($app, 'make', [UrlGenerator::class], $urlGenerator);
-        $this->setExpects($app, 'instance', ['routing.urlGenerator', $urlGenerator]);
+        $this->setExpects($app, 'get', ['config'], $config, $this->atLeastOnce());
+
+        $app->expects($this->atLeastOnce())
+            ->method('make')
+            ->withConsecutive(
+                [UrlGenerator::class],
+                [LegacyUrlGenerator::class]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $urlGenerator,
+                $legacyUrlGenerator
+            );
+        $app->expects($this->atLeastOnce())
+            ->method('instance')
+            ->withConsecutive(
+                ['routing.urlGenerator', $urlGenerator],
+                ['routing.urlGenerator', $legacyUrlGenerator]
+            );
+        $this->setExpects(
+            $app, 'bind',
+            [UrlGeneratorInterface::class, 'routing.urlGenerator'], null,
+            $this->atLeastOnce()
+        );
 
         $serviceProvider = new RoutingServiceProvider($app);
+        $serviceProvider->register();
         $serviceProvider->register();
     }
 }


### PR DESCRIPTION
Some changes that I have laying around, build for #425 (404 on every site) and never vreated a pull request.

Should we support the old "legacy" link structure? It could be interesting for servers that have no mod_rewrite (or similar configuration) active.