### PR TITLE
Use domain for links to '/' to fix assets/ URLs on subdirectories

### DIFF
--- a/src/Routing/LegacyUrlGenerator.php
+++ b/src/Routing/LegacyUrlGenerator.php
@@ -4,7 +4,7 @@ namespace Engelsystem\Routing;
 
 /**
  * Provides urls when webserver rewriting is disabled.
- * 
+ *
  * The urls have the form <app url>/index.php?p=<path>&<parameters>
  */
 class LegacyUrlGenerator extends UrlGenerator
@@ -24,6 +24,7 @@ class LegacyUrlGenerator extends UrlGenerator
 
         $uri = parent::linkTo('index.php', $parameters);
         $uri = preg_replace('~(/index\.php)+~', '/index.php', $uri);
+        $uri = preg_replace('~(/index\.php)$~', '/', $uri);
 
         return $uri;
     }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -4,8 +4,8 @@
     <title>%title% - Engelsystem</title>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="assets/theme%theme%.css"/>
-    <script type="text/javascript" src="assets/vendor.js"></script>
+    <link rel="stylesheet" type="text/css" href="%start_page_url%assets/theme%theme%.css"/>
+    <script type="text/javascript" src="%start_page_url%assets/vendor.js"></script>
     %atom_link%
 </head>
 <body>

--- a/tests/Unit/Routing/LegacyUrlGeneratorTest.php
+++ b/tests/Unit/Routing/LegacyUrlGeneratorTest.php
@@ -14,9 +14,9 @@ class LegacyUrlGeneratorTest extends TestCase
     public function provideLinksTo()
     {
         return [
-            ['/', 'http://foo.bar/index.php', [], 'http://foo.bar/index.php'],
+            ['/', 'http://foo.bar/index.php', [], 'http://foo.bar/'],
             ['/foo-path', 'http://foo.bar/index.php/index.php', [], 'http://foo.bar/index.php?p=foo_path'],
-            ['/foo', 'http://foo.bar/index.php/index.php',  [], 'http://foo.bar/index.php?p=foo'],
+            ['/foo', 'http://foo.bar/index.php/index.php', [], 'http://foo.bar/index.php?p=foo'],
             ['foo', 'http://foo.bar/index.php', ['test' => 'abc'], 'http://foo.bar/index.php?p=foo&test=abc'],
         ];
     }

--- a/tests/Unit/Routing/UrlGeneratorTest.php
+++ b/tests/Unit/Routing/UrlGeneratorTest.php
@@ -14,6 +14,7 @@ class UrlGeneratorTest extends TestCase
     public function provideLinksTo()
     {
         return [
+            ['/', '/', 'http://foo.bar/', [], 'http://foo.bar/'],
             ['/foo/path', '/foo/path', 'http://foo.bar/foo/path', [], 'http://foo.bar/foo/path'],
             ['foo', '/foo', 'https://foo.bar/foo', [], 'https://foo.bar/foo'],
             ['foo', '/foo', 'http://f.b/foo', ['test' => 'abc', 'bla' => 'foo'], 'http://f.b/foo?test=abc&bla=foo'],


### PR DESCRIPTION
Currently when calling `engelsystem.tld/foo/bar` the assets will be loaded from `engelsystem.tld/foo/assets/blafoo.css` when the path should be `engelsystem.tld/assets/blafoo.css`