### PR TITLE
Dokumentation clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To report bugs use [engelsystem/issues](https://github.com/engelsystem/engelsyst
  * Recommended: Directory Listing should be disabled.
  * There must a be MySQL database created with a user who has full rights to that database.
  * If necessary, create a ```config/config.php``` to override values from ```config/config.default.php```.
+   * To remove values from the `available_themes`, `locales` or `tshirt_sizes` lists the config file has to be renamed.
  * To import the database the ```bin/migrate``` script has to be called.
  * In the browser, login with credentials ```admin```:```asdfasdf``` and change the password.
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 [![GPL](https://img.shields.io/github/license/engelsystem/engelsystem.svg?maxAge=2592000)]()
 
 # Engelsystem
-
 Please visit https://engelsystem.de for a feature list.
 
 To report bugs use [engelsystem/issues](https://github.com/engelsystem/engelsystem/issues)
 
 ## Installation
-
 ### Requirements:
- * PHP >= 7.0
- * MySQL-Server >= 5.5 or MariaDB-Server >= 5.5 
+ * PHP >= 7.1
+ * MySQL-Server >= 5.7.8 or MariaDB-Server >= 10.2.2
  * Webserver, i.e. lighttpd, nginx, or Apache
  * Node >= 8 (Development/Building only)
  * Yarn (Development/Building only)
@@ -62,7 +60,8 @@ To run the unit tests use
 vendor/bin/phpunit --testsuite Unit
 ``` 
 
-If a database is configured and the engelsystem is allowed to mess around with some files, you can run feature tests. The tests can potentially delete some database entries, so they should never be run on a production system!
+If a database is configured and the engelsystem is allowed to mess around with some files, you can run feature tests.
+The tests can potentially delete some database entries, so they should never be run on a production system!
 ```bash
 vendor/bin/phpunit --testsuite Feature
 # or for unit- and feature tests:
@@ -97,11 +96,8 @@ docker build -f contrib/Dockerfile . -t engelsystem
 
 Import database
 ```bash
-docker exec -i db_container mysql -u engelsystem -pengelsystem engelsystem < db/install.sql
-docker exec -i db_container mysql -u engelsystem -pengelsystem engelsystem < db/update.sql
+docker exec -it engelsystem bin/migrate
 ```
-
-To be able to send mails a relay is needed. Set `SMTPHOST=[mail container]` to configure it.
 
 #### Scripts
 ##### bin/deploy.sh

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ To report bugs use [engelsystem/issues](https://github.com/engelsystem/engelsyst
 ## Installation
 ### Requirements:
  * PHP >= 7.1
+   * Required modules:
+     * gettext
+     * json
+     * PDO
+     * xml/libxml/SimpleXML
  * MySQL-Server >= 5.7.8 or MariaDB-Server >= 10.2.2
  * Webserver, i.e. lighttpd, nginx, or Apache
  * Node >= 8 (Development/Building only)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "ext-gettext": "*",
         "ext-json": "*",
         "ext-libxml": "*",

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -56,7 +56,7 @@ return [
         '3' => 'Engelsystem 32c3 (2015)',
         '2' => 'Engelsystem cccamp15',
         '0' => 'Engelsystem light',
-        '1' => 'Engelsystem dark'
+        '1' => 'Engelsystem dark',
     ],
 
     // Rewrite URLs with mod_rewrite
@@ -129,7 +129,7 @@ return [
         'XL-G' => 'XL Girl',
         '2XL'  => '2XL',
         '3XL'  => '3XL',
-        '4XL'  => '4XL'
+        '4XL'  => '4XL',
     ],
 
     // Session config


### PR DESCRIPTION
* Bump the required PHP to a supported version (`7.1` has security fixes support for [a year](https://secure.php.net/supported-versions.php)
* List required PHP modules (esp. `gettext` for translation)
* Clarified the configuration with lists
* Replaced manual database import texts with `bin/migrate`
* Removed outdated mail hint