### PR TITLE
Fix datepicker

### DIFF
--- a/includes/sys_form.php
+++ b/includes/sys_form.php
@@ -73,11 +73,12 @@ function form_date($name, $label, $value, $start_date = '', $end_date = '')
 
     return form_element($label, '
     <div class="input-group date" id="' . $dom_id . '">
-      <input type="date" name="' . $name . '" class="form-control" value="' . htmlspecialchars($value) . '">'
+      <input type="date" placeholder="YYYY-MM-DD" name="' . $name . '" class="form-control" value="' . htmlspecialchars($value) . '">'
         . '<span class="input-group-addon">' . glyph('th') . '</span>
     </div>
     <script type="text/javascript">
 			$(function(){
+        $("#' . $dom_id . '").children("input").attr("type", "text");
         $("#' . $dom_id . '").datepicker({
 				  language: "' . $shortLocale . '",
           todayBtn: "linked",


### PR DESCRIPTION
`<input type="date">` and JS datepicker combined cause trouble in some browsers, so this changes all the date input fields' type to `text` via JS so that the browser's datepicker is only used when a user has disabled JavaScript.

In addition, it adds a placeholder so the user knows which date format to use when entering the date manually.

This closes #507.