### PR TITLE
Change Dockerfiles to first install dependencies, then copy files

### DIFF
--- a/contrib/.env
+++ b/contrib/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME="engelsystem"

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -35,10 +35,10 @@ RUN rm -f /app/import/* /app/config/config.php
 # Build the PHP container
 FROM php:7-fpm-alpine
 WORKDIR /var/www
-COPY --from=data /app/ /var/www
 RUN apk add --no-cache icu-dev gettext-dev && \
-    docker-php-ext-install intl gettext pdo_mysql && \
-    chown -R www-data:www-data /var/www/import/ /var/www/storage/ && \
+    docker-php-ext-install intl gettext pdo_mysql
+COPY --from=data /app/ /var/www
+RUN chown -R www-data:www-data /var/www/import/ /var/www/storage/ && \
     rm -r /var/www/html
 
 ENV TRUSTED_PROXIES 10.0.0.0/8,::ffff:10.0.0.0/8,\

--- a/contrib/nginx/Dockerfile
+++ b/contrib/nginx/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:8-alpine as themes
 WORKDIR /app
 RUN apk add --no-cache yarn
-COPY resources/assets/ /app/resources/assets
 COPY .babelrc package.json webpack.config.js /app/
 RUN yarn install
+COPY resources/assets/ /app/resources/assets
 RUN yarn build
 
 FROM nginx:alpine

--- a/contrib/nginx/Dockerfile
+++ b/contrib/nginx/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:8-alpine as themes
 WORKDIR /app
+RUN apk add --no-cache yarn
 COPY resources/assets/ /app/resources/assets
 COPY .babelrc package.json webpack.config.js /app/
-RUN apk add --no-cache yarn
 RUN yarn install
 RUN yarn build
 


### PR DESCRIPTION
When trying out a few improvements on the frontend (a later pull request may follow) I noticed that rebuilds of the Docker images take a long time even if only a single file in the source tree has changed. This is due to the fact that the Dockerfiles first copy files into the image and then install external dependencies via apk etc. As soon as a single file is changed, this invalidates the cache and all the external dependencies, for which the changed build context is irrelevant, need to be installed again which takes a lot of time (especially with the PHP stuff which must be compiled).

I swapped around the commands in the Dockerfiles and now rebuilds only take 20 seconds or so instead of around 3 minutes before. This makes using Docker in development a lot more fun.

P.S.: In addiiton, I added `contrib/.env` which sets `COMPOSE_PROJECT_NAME` so that the container names look better in `docker ps` etc.