### PR TITLE
Change the color of "reset"  button in admin_arrive

### DIFF
--- a/includes/pages/admin_arrive.php
+++ b/includes/pages/admin_arrive.php
@@ -100,7 +100,10 @@ function admin_arrive()
         $usr['actions'] = form([
             form_hidden('action', $usr->state->arrived ? 'reset' : 'arrived'),
             form_hidden('user', $usr->id),
-            form_submit('submit', $usr->state->arrived ? __('reset') : __('arrived'), 'btn-xs'),
+            form_submit(
+                'submit', $usr->state->arrived ? __('reset') : __('arrived'), 'btn-xs', true,
+                $usr->state->arrived ? 'danger' : 'primary'
+            ),
         ]);
 
         if ($usr->state->arrival_date) {

--- a/includes/sys_form.php
+++ b/includes/sys_form.php
@@ -221,9 +221,9 @@ function form_info($label, $text = '')
  * @param bool   $wrapForm
  * @return string
  */
-function form_submit($name, $label, $class = '', $wrapForm = true)
+function form_submit($name, $label, $class = '', $wrapForm = true, $buttonType = 'primary')
 {
-    $button = '<button class="btn btn-primary' . ($class ? ' ' . $class : '') . '" type="submit" name="' . $name . '">'
+    $button = '<button class="btn btn-' . $buttonType . ($class ? ' ' . $class : '') . '" type="submit" name="' . $name . '">'
         . $label
         . '</button>';
 


### PR DESCRIPTION
I thought it would be nice to have the "reset" button in a different color than the "arrived" button. This makes it a lot more obvious that an angel already has been marked as arrived to the shift coordinator/welcome angel in charge.

To facilitate this, I added an additional parameter to `form_submit()` which allows to replace the hard-coded `btn-primary` with another contextual button class. This might be useful in other places as well.