### PR TITLE
Authenticator: Use id from user object

### DIFF
--- a/src/Helpers/Authenticator.php
+++ b/src/Helpers/Authenticator.php
@@ -104,7 +104,7 @@ class Authenticator
         $abilities = (array)$abilities;
 
         if (empty($this->permissions)) {
-            $userId = $this->session->get('uid');
+            $userId = $this->user ? $this->user->id : $this->session->get('uid');
 
             if ($userId) {
                 if ($user = $this->user()) {


### PR DESCRIPTION
While authenticating with an api key the session does not contain user id so the user object should be used.

Closes #519 (iCal/JSON export only works when logged in)