### PR TITLE
CI: Fixed xdebug dependency do be php 7.3 compatible (still in beta)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ test:
       junit: ./unittests.xml
   coverage: '/^\s*Lines:\s*(\d+(?:\.\d+)?%)/'
   before_script:
-    - apk add ${PHPIZE_DEPS} && pecl install xdebug && docker-php-ext-enable xdebug
+    - apk add ${PHPIZE_DEPS} && pecl install xdebug-beta && docker-php-ext-enable xdebug
     - curl -sS https://getcomposer.org/installer | php -- --no-ansi --install-dir /usr/local/bin/ --filename composer
     - cp -R tests/ phpunit.xml "${DOCROOT}"
     - HOMEDIR=$(pwd)


### PR DESCRIPTION
This fix is required as long as [xdebug-2.7.0](https://xdebug.org/) has not ben released to the public yet