### PR TITLE
Don't strip so much content from messages and comments

### DIFF
--- a/includes/pages/admin_questions.php
+++ b/includes/pages/admin_questions.php
@@ -51,7 +51,7 @@ function admin_questions()
 
             $unanswered_questions_table[] = [
                 'from'     => User_Nick_render($user_source),
-                'question' => str_replace("\n", '<br />', $question['Question']),
+                'question' => nl2br(htmlspecialchars($question['Question'])),
                 'answer'   => form([
                     form_textarea('answer', '', ''),
                     form_submit('submit', __('Save'))
@@ -69,9 +69,9 @@ function admin_questions()
             $answer_user_source = User::find($question['AID']);
             $answered_questions_table[] = [
                 'from'        => User_Nick_render($user_source),
-                'question'    => str_replace("\n", '<br />', $question['Question']),
+                'question'    => nl2br(htmlspecialchars($question['Question'])),
                 'answered_by' => User_Nick_render($answer_user_source),
-                'answer'      => str_replace("\n", '<br />', $question['Answer']),
+                'answer'      => nl2br(htmlspecialchars($question['Answer'])),
                 'actions'     => form([
                     form_submit('submit', __('delete'), 'btn-xs')
                 ], page_link_to('admin_questions', ['action' => 'delete', 'id' => $question['QID']]))
@@ -113,13 +113,9 @@ function admin_questions()
                     [$question_id]
                 );
                 if (!empty($question) && empty($question['AID'])) {
-                    $answer = trim(
-                        preg_replace("/([^\p{L}\p{P}\p{Z}\p{N}\n]{1,})/ui",
-                            '',
-                            strip_tags($request->input('answer'))
-                        ));
+                    $answer = trim($request->input('answer'));
 
-                    if ($answer != '') {
+                    if (!empty($answer)) {
                         DB::update('
                                 UPDATE `Questions`
                                 SET `AID`=?, `Answer`=?
@@ -132,7 +128,12 @@ function admin_questions()
                                 $question_id,
                             ]
                         );
-                        engelsystem_log('Question ' . $question['Question'] . ' answered: ' . $answer);
+                        engelsystem_log(
+                            'Question '
+                            . htmlspecialchars($question['Question'])
+                            . ' answered: '
+                            . htmlspecialchars($answer)
+                        );
                         redirect(page_link_to('admin_questions'));
                     } else {
                         return error('Enter an answer!', true);
@@ -158,7 +159,7 @@ function admin_questions()
                 );
                 if (!empty($question)) {
                     DB::delete('DELETE FROM `Questions` WHERE `QID`=? LIMIT 1', [$question_id]);
-                    engelsystem_log('Question deleted: ' . $question['Question']);
+                    engelsystem_log('Question deleted: ' . htmlspecialchars($question['Question']));
                     redirect(page_link_to('admin_questions'));
                 } else {
                     return error('No question found.', true);

--- a/includes/pages/user_messages.php
+++ b/includes/pages/user_messages.php
@@ -88,7 +88,7 @@ function user_messages()
                 'timestamp' => date('Y-m-d H:i', $message['Datum']),
                 'from'      => User_Nick_render($sender_user_source),
                 'to'        => User_Nick_render($receiver_user_source),
-                'text'      => str_replace("\n", '<br />', $message['Text'])
+                'text'      => nl2br(htmlspecialchars($message['Text']))
             ];
 
             if ($message['RUID'] == $user->id) {
@@ -167,7 +167,6 @@ function user_messages()
                 break;
 
             case 'send':
-                // @TODO: Validation?
                 if (Message_send($request->input('to'), $request->input('text'))) {
                     redirect(page_link_to('user_messages'));
                 } else {

--- a/includes/pages/user_news.php
+++ b/includes/pages/user_news.php
@@ -143,11 +143,7 @@ function user_news_comments()
         $nid = $request->input('nid');
         $news = DB::selectOne('SELECT * FROM `News` WHERE `ID`=? LIMIT 1', [$nid]);
         if ($request->hasPostData('submit') && $request->has('text')) {
-            $text = preg_replace(
-                "/([^\p{L}\p{P}\p{Z}\p{N}\n]{1,})/ui",
-                '',
-                strip_tags($request->input('text'))
-            );
+            $text = $request->input('text');
             DB::insert('
                     INSERT INTO `NewsComments` (`Refid`, `Datum`, `Text`, `UID`)
                     VALUES (?, ?, ?, ?)
@@ -159,7 +155,8 @@ function user_news_comments()
                     $user->id,
                 ]
             );
-            engelsystem_log('Created news_comment: ' . $text);
+
+            engelsystem_log('Created news_comment: ' . htmlspecialchars($text));
             $html .= success(__('Entry saved.'), true);
         }
 
@@ -227,6 +224,7 @@ function user_news()
                 $isMeeting,
             ]
         );
+
         engelsystem_log('Created news: ' . $request->postData('betreff') . ', treffen: ' . $isMeeting);
         success(__('Entry saved.'));
         redirect(page_link_to('news'));

--- a/includes/pages/user_questions.php
+++ b/includes/pages/user_questions.php
@@ -29,6 +29,7 @@ function user_questions()
             'SELECT * FROM `Questions` WHERE NOT `AID` IS NULL AND `UID`=?',
             [$user->id]
         );
+
         foreach ($answered_questions as &$question) {
             $answer_user_source = User::find($question['AID']);
             $question['answer_user'] = User_Nick_render($answer_user_source);
@@ -42,8 +43,8 @@ function user_questions()
     } else {
         switch ($request->input('action')) {
             case 'ask':
-                $question = strip_request_item_nl('question');
-                if ($question != '' && $request->hasPostData('submit')) {
+                $question = request()->get('question');
+                if (!empty($question) && $request->hasPostData('submit')) {
                     DB::insert('
                         INSERT INTO `Questions` (`UID`, `Question`)
                         VALUES (?, ?)

--- a/includes/sys_page.php
+++ b/includes/sys_page.php
@@ -197,6 +197,7 @@ function strip_request_item_nl($name, $default_value = null)
 {
     $request = request();
     if ($request->has($name)) {
+        // Only allow letters, symbols, punctuation, separators, numbers and newlines without html tags
         return preg_replace(
             "/([^\p{L}\p{S}\p{P}\p{Z}\p{N}+\n]{1,})/ui",
             '',
@@ -214,6 +215,7 @@ function strip_request_item_nl($name, $default_value = null)
  */
 function strip_item($item)
 {
+    // Only allow letters, symbols, punctuation, separators and numbers without html tags
     return preg_replace("/([^\p{L}\p{S}\p{P}\p{Z}\p{N}+]{1,})/ui", '', strip_tags($item));
 }
 

--- a/includes/view/Questions_view.php
+++ b/includes/view/Questions_view.php
@@ -12,12 +12,12 @@ function Questions_view($open_questions, $answered_questions, $ask_action)
         $question['actions'] = form([
             form_submit('submit', __('delete'), 'btn-default btn-xs')
         ], page_link_to('user_questions', ['action' => 'delete', 'id' => $question['QID']]));
-        $question['Question'] = str_replace("\n", '<br />', $question['Question']);
+        $question['Question'] = nl2br(htmlspecialchars($question['Question']));
     }
 
     foreach ($answered_questions as &$question) {
-        $question['Question'] = str_replace("\n", '<br />', $question['Question']);
-        $question['Answer'] = str_replace("\n", '<br />', $question['Answer']);
+        $question['Question'] = nl2br(htmlspecialchars($question['Question']));
+        $question['Answer'] = nl2br(htmlspecialchars($question['Answer']));
         $question['actions'] = form([
             form_submit('submit', __('delete'), 'btn-default btn-xs')
         ], page_link_to('user_questions', ['action' => 'delete', 'id' => $question['QID']]));


### PR DESCRIPTION
According to some issues (#545 ("=" removed in Questions & Answers) and #510 (htmlentities-like content in a comment gets removed)) it is really anoying that seemingly random characters are stripped from the content which prevents posting urls to rickroll videos!

This is a fix for that problem