### PR TITLE
Support disabling the arrival feature

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -78,6 +78,9 @@ return [
     // Only arrived angels can sign up for shifts
     'signup_requires_arrival' => false,
 
+    // Whether newly-registered user should automatically be marked as arrived
+    'autoarrive'              => false,
+
     // Number of hours that an angel has to sign out own shifts
     'last_unsubscribe'        => 3,
 

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -217,7 +217,12 @@ function guest_register()
                 ->associate($user)
                 ->save();
 
-            (new State())->user()
+            $state = new State([]);
+            if (config('autoarrive')) {
+                $state->arrived = true;
+                $state->arrival_date = new Carbon();
+            }
+            $state->user()
                 ->associate($user)
                 ->save();
 

--- a/includes/sys_menu.php
+++ b/includes/sys_menu.php
@@ -114,6 +114,10 @@ function make_navigation()
         'admin_event_config' => __('Event config'),
     ];
 
+    if (config('autoarrive')) {
+        unset($admin_pages['admin_arrive']);
+    }
+
     foreach ($admin_pages as $menu_page => $title) {
         if (auth()->can($menu_page)) {
             $admin_menu[] = toolbar_item_link(


### PR DESCRIPTION
Setting `autoarrive` to true will now cause all newly registered angels
to be automatically confirmed as arrived.