### PR TITLE
Fix CI test job failures induced by deprecation errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/log": "^1.0",
         "swiftmailer/swiftmailer": "^6.1",
         "symfony/http-foundation": "^3.3",
-        "symfony/psr-http-message-bridge": "^1.0",
+        "symfony/psr-http-message-bridge": "~v1.1.0",
         "twig/extensions": "^1.5",
         "twig/twig": "^2.5",
         "zendframework/zend-diactoros": "^1.7"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/http-foundation": "^3.3",
         "symfony/psr-http-message-bridge": "~v1.1.0",
         "twig/extensions": "^1.5",
-        "twig/twig": "^2.5",
+        "twig/twig": "~2.6.0",
         "zendframework/zend-diactoros": "^1.7"
     },
     "require-dev": {


### PR DESCRIPTION
This fixes the `test` CI job
* https://github.com/engelsystem/engelsystem/issues/582
* another deprecation error as of twig/twig v2.7.0