### PR TITLE
Replace Diactoros with Symfony PsrHttpFactory and Pin Twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "illuminate/database": "5.5.*",
         "illuminate/support": "5.5.*",
         "nikic/fast-route": "^1.3",
+        "php-extended/php-http-message-factory-psr17": "^1.0",
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.0",
@@ -35,8 +36,7 @@
         "symfony/http-foundation": "^3.3",
         "symfony/psr-http-message-bridge": "^1.0",
         "twig/extensions": "^1.5",
-        "twig/twig": "~2.6.0",
-        "zendframework/zend-diactoros": "^1.7"
+        "twig/twig": "~2.6.0"
     },
     "require-dev": {
         "filp/whoops": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/http-foundation": "^3.3",
         "symfony/psr-http-message-bridge": "^1.0",
         "twig/extensions": "^1.5",
-        "twig/twig": "^2.5",
+        "twig/twig": "~2.6.0",
         "zendframework/zend-diactoros": "^1.7"
     },
     "require-dev": {

--- a/src/Http/MessageTrait.php
+++ b/src/Http/MessageTrait.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Http;
 
 
+use PhpExtended\HttpMessage\StringStream;
 use Psr\Http\Message\StreamInterface;
-use Zend\Diactoros\Stream;
 
 /**
  * @implements \Psr\Http\Message\MessageInterface
@@ -213,9 +213,7 @@ trait MessageTrait
      */
     public function getBody()
     {
-        $stream = new Stream('php://memory', 'wb+');
-        $stream->write($this->getContent());
-        $stream->rewind();
+        $stream = new StringStream($this->getContent());
 
         return $stream;
     }

--- a/src/Http/Psr7ServiceProvider.php
+++ b/src/Http/Psr7ServiceProvider.php
@@ -3,27 +3,42 @@
 namespace Engelsystem\Http;
 
 use Engelsystem\Container\ServiceProvider;
+use PhpExtended\HttpMessage\ResponseFactory;
+use PhpExtended\HttpMessage\ServerRequestFactory;
+use PhpExtended\HttpMessage\StreamFactory;
+use PhpExtended\HttpMessage\UploadedFileFactory;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 
 
 class Psr7ServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        /** @var DiactorosFactory $psr7Factory */
-        $psr7Factory = $this->app->make(DiactorosFactory::class);
-        $this->app->instance('psr7.factory', $psr7Factory);
+        foreach (
+            [
+                ServerRequestFactory::class => ['psr7.factory.request', ServerRequestFactoryInterface::class],
+                ResponseFactory::class      => ['psr7.factory.response', ResponseFactoryInterface::class],
+                UploadedFileFactory::class  => ['psr7.factory.upload', UploadedFileFactoryInterface::class],
+                StreamFactory::class        => ['psr7.factory.stream', StreamFactoryInterface::class],
+                PsrHttpFactory::class       => ['psr7.factory', HttpMessageFactoryInterface::class],
+            ] as $class => $aliases
+        ) {
+            foreach ($aliases as $alias) {
+                $this->app->bind($alias, $class);
+            }
+        }
 
-        /** @var Request $request */
-        $request = $this->app->get('request');
-        $this->app->instance('psr7.request', $request);
+        $this->app->bind('psr7.request', 'request');
         $this->app->bind(ServerRequestInterface::class, 'psr7.request');
 
-        /** @var Response $response */
-        $response = $this->app->get('response');
-        $this->app->instance('psr7.response', $response);
+        $this->app->bind('psr7.response', 'response');
         $this->app->bind(ResponseInterface::class, 'psr7.response');
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -2,13 +2,13 @@
 
 namespace Engelsystem\Http;
 
+use PhpExtended\HttpMessage\UploadedFile;
+use PhpExtended\HttpMessage\Uri;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use Zend\Diactoros\UploadedFile;
-use Zend\Diactoros\Uri;
 
 class Request extends SymfonyRequest implements ServerRequestInterface
 {
@@ -207,7 +207,7 @@ class Request extends SymfonyRequest implements ServerRequestInterface
     {
         $uri = parent::getUri();
 
-        return new Uri($uri);
+        return Uri::parseFromString($uri);
     }
 
     /**
@@ -332,11 +332,11 @@ class Request extends SymfonyRequest implements ServerRequestInterface
             /** @var SymfonyFile $file */
 
             $files[] = new UploadedFile(
-                $file->getPath(),
-                $file->getSize(),
-                $file->getError(),
                 $file->getClientOriginalName(),
-                $file->getClientMimeType()
+                $file->getRealPath(),
+                $file->getMimeType(),
+                $file->getSize(),
+                $file->getError()
             );
         }
 

--- a/tests/Unit/Http/MessageTraitRequestTest.php
+++ b/tests/Unit/Http/MessageTraitRequestTest.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Test\Unit\Http;
 
 use Engelsystem\Test\Unit\Http\Stub\MessageTraitRequestImplementation;
+use PhpExtended\HttpMessage\StringStream;
 use PHPUnit\Framework\TestCase;
-use Zend\Diactoros\Stream;
 
 class MessageTraitRequestTest extends TestCase
 {
@@ -36,11 +36,7 @@ class MessageTraitRequestTest extends TestCase
      */
     public function testWithBody()
     {
-        /** @var Stream $stream */
-        $stream = new Stream('php://memory', 'wb+');
-        $stream->write('Test content');
-        $stream->rewind();
-
+        $stream = new StringStream('Test content');
         $message = new MessageTraitRequestImplementation();
         $newMessage = $message->withBody($stream);
 

--- a/tests/Unit/Http/MessageTraitResponseTest.php
+++ b/tests/Unit/Http/MessageTraitResponseTest.php
@@ -3,11 +3,11 @@
 namespace Engelsystem\Test\Unit\Http;
 
 use Engelsystem\Test\Unit\Http\Stub\MessageTraitResponseImplementation;
+use PhpExtended\HttpMessage\StringStream;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Zend\Diactoros\Stream;
 
 class MessageTraitResponseTest extends TestCase
 {
@@ -145,11 +145,7 @@ class MessageTraitResponseTest extends TestCase
      */
     public function testWithBody()
     {
-        /** @var Stream $stream */
-        $stream = new Stream('php://memory', 'wb+');
-        $stream->write('Test content');
-        $stream->rewind();
-
+        $stream = new StringStream('Test content');
         $message = new MessageTraitResponseImplementation();
         $newMessage = $message->withBody($stream);
 

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -3,6 +3,7 @@
 namespace Engelsystem\Test\Unit\Http;
 
 use Engelsystem\Http\Request;
+use PhpExtended\HttpMessage\UploadedFile;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Psr\Http\Message\RequestInterface;
@@ -285,7 +286,7 @@ class RequestTest extends TestCase
     {
         $filename = tempnam(sys_get_temp_dir(), 'test');
         file_put_contents($filename, 'LoremIpsum!');
-        $files = [new SymfonyFile($filename, 'foo.html', 'text/html', 11)];
+        $files = [new SymfonyFile($filename, 'foo.txt', 'text/plain', 11)];
         $request = new Request([], [], [], [], $files);
 
         $uploadedFiles = $request->getUploadedFiles();
@@ -294,8 +295,8 @@ class RequestTest extends TestCase
         /** @var UploadedFileInterface $file */
         $file = $uploadedFiles[0];
         $this->assertInstanceOf(UploadedFileInterface::class, $file);
-        $this->assertEquals('foo.html', $file->getClientFilename());
-        $this->assertEquals('text/html', $file->getClientMediaType());
+        $this->assertEquals('foo.txt', $file->getClientFilename());
+        $this->assertEquals('text/plain', $file->getClientMediaType());
         $this->assertEquals(11, $file->getSize());
     }
 
@@ -306,7 +307,7 @@ class RequestTest extends TestCase
     {
         $filename = tempnam(sys_get_temp_dir(), 'test');
         file_put_contents($filename, 'LoremIpsum!');
-        $file = new \Zend\Diactoros\UploadedFile($filename, 11, UPLOAD_ERR_OK, 'test.txt', 'text/plain');
+        $file = new UploadedFile('test.txt', $filename, 'text/plain', 11, UPLOAD_ERR_OK);
 
         $request = new Request();
         $new = $request->withUploadedFiles([$file]);


### PR DESCRIPTION
* Pin Twig to prevent warnings (Needs to be removed after https://github.com/twigphp/Twig-extensions/issues/239 is solved)
* Replace Diactoros with Symfonys `PsrHttpFactory` which uses `symfony/psr-http-message-bridge` to remove warnings that get converted to errors in dev mode
  ```
  /engelsystem/vendor/symfony/psr-http-message-bridge/Factory/DiactorosFactory.php:14:
  int(16384)
  /engelsystem/vendor/symfony/psr-http-message-bridge/Factory/DiactorosFactory.php:14:
  string(151) "The "Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory" class is deprecated since symfony/psr-http-message-bridge 1.2, use PsrHttpFactory instead."
  /engelsystem/vendor/symfony/psr-http-message-bridge/Factory/DiactorosFactory.php:14:
  string(84) "/engelsystem/vendor/symfony/psr-http-message-bridge/Factory/DiactorosFactory.php"
  /engelsystem/vendor/symfony/psr-http-message-bridge/Factory/DiactorosFactory.php:14:
  int(14)
  /engelsystem/vendor/symfony/psr-http-message-bridge/Factory/DiactorosFactory.php:14:
  array(1) {
    'file' =>
    string(96) "/engelsystem/vendor/composer/../symfony/psr-http-message-bridge/Factory/DiactorosFactory.php"
  }
  ```

closes #583 (Fix CI test job failures induced by deprecation errors)
closes #582 (Gitlab CI broken due to failing test job)