### PR TITLE
babelrc: Specify iOS target in lower case

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
         "safari": 9,
         "opera": 32,
         "edge": 12,
-        "iOS": 9
+        "ios": 9
       },
       "loose": false,
       "useBuiltIns": "entry"


### PR DESCRIPTION
Since version 7.4.0 of babel/preset-env (where https://github.com/babel/babel/pull/7646 is included), the lower case name of the target `ios` is being enforced.

Without this change, the yarn build failed for me with this error:
```
ERROR in ./resources/assets/js/vendor.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: [BABEL] /opt/engelsystem/resources/assets/js/vendor.js: Invalid Option: 'iOS' is not a valid target
        Maybe you meant to use 'ie'? (While processing: "/opt/engelsystem/node_modules/@babel/preset-env/lib/index.js")
    at validateTargetNames (/opt/engelsystem/node_modules/@babel/preset-env/lib/targets-parser.js:66:13)
    at getTargets (/opt/engelsystem/node_modules/@babel/preset-env/lib/targets-parser.js:184:3)
    at _default (/opt/engelsystem/node_modules/@babel/preset-env/lib/index.js:128:46)
    at /opt/engelsystem/node_modules/@babel/helper-plugin-utils/lib/index.js:19:12
    at loadDescriptor (/opt/engelsystem/node_modules/@babel/core/lib/config/full.js:165:14)
    at cachedFunction (/opt/engelsystem/node_modules/@babel/core/lib/config/caching.js:33:19)
    at loadPresetDescriptor (/opt/engelsystem/node_modules/@babel/core/lib/config/full.js:235:63)
    at config.presets.reduce (/opt/engelsystem/node_modules/@babel/core/lib/config/full.js:77:21)
    at Array.reduce (<anonymous>)
    at recurseDescriptors (/opt/engelsystem/node_modules/@babel/core/lib/config/full.js:74:38)
    at loadFullConfig (/opt/engelsystem/node_modules/@babel/core/lib/config/full.js:108:6)
    at process.nextTick (/opt/engelsystem/node_modules/@babel/core/lib/transform.js:28:33)
    at processTicksAndRejections (internal/process/task_queues.js:79:9)
```

I tested this change with the following versions of babel/preset-env and was able to build it:
- 7.2.0 (the oldest possible version as specified in package.json)
- 7.4.3 (the latest version)