### PR TITLE
Support disabling the planned arrival

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -99,6 +99,9 @@ return [
     // The minimum length for passwords
     'min_password_length'     => 8,
 
+    // Enables the planned arrival/leave date
+    'enable_planned_arrival'  => true,
+
     // Enables the T-Shirt configuration on signup and profile
     'enable_tshirt_size'      => true,
 

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -42,6 +42,7 @@ function guest_register()
     $authUser = auth()->user();
     $tshirt_sizes = config('tshirt_sizes');
     $enable_tshirt_size = config('enable_tshirt_size');
+    $enable_planned_arrival = config('enable_planned_arrival');
     $min_password_length = config('min_password_length');
     $config = config();
     $request = request();
@@ -140,7 +141,7 @@ function guest_register()
             ), true);
         }
 
-        if ($request->has('planned_arrival_date')) {
+        if ($request->has('planned_arrival_date') && $enable_planned_arrival) {
             $tmp = parse_date('Y-m-d H:i', $request->input('planned_arrival_date') . ' 00:00');
             $result = User_validate_planned_arrival_date($tmp);
             $planned_arrival_date = $result->getValue();
@@ -148,7 +149,7 @@ function guest_register()
                 $valid = false;
                 error(__('Please enter your planned date of arrival. It should be after the buildup start date and before teardown end date.'));
             }
-        } else {
+        } else if ($enable_planned_arrival) {
             $valid = false;
             error(__('Please enter your planned date of arrival. It should be after the buildup start date and before teardown end date.'));
         }
@@ -302,11 +303,11 @@ function guest_register()
                     ]),
                     div('row', [
                         div('col-sm-6', [
-                            form_date(
+                            $enable_planned_arrival ? form_date(
                                 'planned_arrival_date',
                                 __('Planned date of arrival') . ' ' . entry_required(),
                                 $planned_arrival_date, $buildup_start_date, $teardown_end_date
-                            )
+                            ) : ''
                         ]),
                         div('col-sm-6', [
                             $enable_tshirt_size ? form_select('tshirt_size',

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -25,6 +25,7 @@ function User_settings_view(
     $tshirt_sizes
 ) {
     $personalData = $user_source->personalData;
+    $enable_planned_arrival = config('enable_planned_arrival');
     return page_with_title(settings_title(), [
         msg(),
         div('row', [
@@ -35,20 +36,20 @@ function User_settings_view(
                     form_text('nick', __('Nick'), $user_source->name, true),
                     form_text('lastname', __('Last name'), $personalData->last_name),
                     form_text('prename', __('First name'), $personalData->first_name),
-                    form_date(
+                    $enable_planned_arrival ? form_date(
                         'planned_arrival_date',
                         __('Planned date of arrival') . ' ' . entry_required(),
                         $personalData->planned_arrival_date ? $personalData->planned_arrival_date->getTimestamp() : '',
                         $buildup_start_date,
                         $teardown_end_date
-                    ),
-                    form_date(
+                    ) : '',
+                    $enable_planned_arrival ? form_date(
                         'planned_departure_date',
                         __('Planned date of departure'),
                         $personalData->planned_departure_date ? $personalData->planned_departure_date->getTimestamp() : '',
                         $buildup_start_date,
                         $teardown_end_date
-                    ),
+                    ) : '',
                     form_text('dect', __('DECT'), $user_source->contact->dect),
                     form_text('mobile', __('Mobile'), $user_source->contact->mobile),
                     form_text('mail', __('E-Mail') . ' ' . entry_required(), $user_source->email),
@@ -893,7 +894,7 @@ function render_profile_link($text, $user_id = null, $class = '')
  */
 function render_user_departure_date_hint()
 {
-    if (!auth()->user()->personalData->planned_departure_date) {
+    if (config('enable_planned_arrival') && !auth()->user()->personalData->planned_departure_date) {
         $text = __('Please enter your planned date of departure on your settings page to give us a feeling for teardown capacities.');
         return render_profile_link($text, null, 'alert-link');
     }


### PR DESCRIPTION
We also use Engelsystem for single-day events, and the planned
arrival/departure feature doesn't make sense for us.