### PR TITLE
Bugfix: Default value for planned_arrival_date and don't overwrite dect

### DIFF
--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -203,7 +203,7 @@ function guest_register()
                 'first_name'           => $preName,
                 'last_name'            => $lastName,
                 'shirt_size'           => $tshirt_size,
-                'planned_arrival_date' => Carbon::createFromTimestamp($planned_arrival_date),
+                'planned_arrival_date' => $enable_planned_arrival ? Carbon::createFromTimestamp($planned_arrival_date) : null,
             ]);
             $personalData->user()
                 ->associate($user)
@@ -303,13 +303,13 @@ function guest_register()
                         ])
                     ]),
                     div('row', [
-                        div('col-sm-6', [
-                            $enable_planned_arrival ? form_date(
+                        $enable_planned_arrival ? div('col-sm-6', [
+                            form_date(
                                 'planned_arrival_date',
                                 __('Planned date of arrival') . ' ' . entry_required(),
                                 $planned_arrival_date, $buildup_start_date, $teardown_end_date
-                            ) : ''
-                        ]),
+                            )
+                        ]) : '',
                         div('col-sm-6', [
                             $enable_tshirt_size ? form_select('tshirt_size',
                                 __('Shirt size') . ' ' . entry_required(),

--- a/includes/pages/user_settings.php
+++ b/includes/pages/user_settings.php
@@ -70,15 +70,15 @@ function user_settings_main($user_source, $enable_tshirt_size, $tshirt_sizes)
     }
 
     // Trivia
-    $user_source->personalData->last_name = strip_request_item('lastname', $user_source['Name']);
-    $user_source->personalData->first_name = strip_request_item('prename', $user_source['Vorname']);
+    $user_source->personalData->last_name = strip_request_item('lastname', $user_source->personalData->last_name);
+    $user_source->personalData->first_name = strip_request_item('prename', $user_source->personalData->first_name);
     if (strlen(strip_request_item('dect')) <= 40) {
-        $user_source->contact->dect = strip_request_item('dect', $user_source['DECT']);
+        $user_source->contact->dect = strip_request_item('dect', $user_source->contact->dect);
     } else {
         $valid = false;
         error(__('For dect numbers are only 40 digits allowed.'));
     }
-    $user_source->contact->mobile = strip_request_item('mobile', $user_source['Handy']);
+    $user_source->contact->mobile = strip_request_item('mobile', $user_source->contact->mobile);
 
     if ($valid) {
         $user_source->save();


### PR DESCRIPTION
* Fixes that planned_arrival_date is set to `1970-01-01` on registration, introduced in #596
* Fixed profile request attributes fallback values, otherwise the dect field will be overwritten if the dect feature is only temporary disabled
* Fixed registration form formatting