### PR TITLE
Fix caching issue for '/' route

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,14 +1,11 @@
 <?php
 
-use Engelsystem\Http\Exceptions\HttpTemporaryRedirect;
 use FastRoute\RouteCollector;
 
 /** @var RouteCollector $route */
 
 // Pages
-$route->get('/', function () {
-    throw new HttpTemporaryRedirect(auth()->user() ? config('home_site') : 'login');
-});
+$route->get('/', 'HomeController@index');
 $route->get('/credits', 'CreditsController@index');
 
 // Authentication

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -2,15 +2,37 @@
 
 namespace Engelsystem\Controllers;
 
+use Engelsystem\Config\Config;
+use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Exceptions\HttpTemporaryRedirect;
 
 class HomeController extends BaseController
 {
     /**
+     * @var Authenticator
+     */
+    protected $auth;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @param Authenticator $auth
+     * @param Config        $config
+     */
+    public function __construct(Authenticator $auth, Config $config)
+    {
+        $this->auth = $auth;
+        $this->config = $config;
+    }
+
+    /**
      * @throws HttpTemporaryRedirect
      */
     public function index()
     {
-        throw new HttpTemporaryRedirect(auth()->user() ? config('home_site') : 'login');
+        throw new HttpTemporaryRedirect($this->auth->user() ? $this->config->get('home_site') : 'login');
     }
 }

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Engelsystem\Controllers;
+
+use Engelsystem\Http\Exceptions\HttpTemporaryRedirect;
+
+class HomeController extends BaseController
+{
+    /**
+     * @throws HttpTemporaryRedirect
+     */
+    public function index()
+    {
+        throw new HttpTemporaryRedirect(auth()->user() ? config('home_site') : 'login');
+    }
+}

--- a/tests/Unit/Controllers/HomeControllerTest.php
+++ b/tests/Unit/Controllers/HomeControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Engelsystem\Test\Unit\Controllers;
+
+use Engelsystem\Config\Config;
+use Engelsystem\Controllers\HomeController;
+use Engelsystem\Helpers\Authenticator;
+use Engelsystem\Http\Exceptions\HttpTemporaryRedirect;
+use Engelsystem\Test\Unit\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class HomeControllerTest extends TestCase
+{
+    /**
+     * @covers \Engelsystem\Controllers\HomeController::__construct
+     * @covers \Engelsystem\Controllers\HomeController::index
+     */
+    public function testIndex()
+    {
+        $config = new Config(['home_site' => '/foo']);
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $this->setExpects($auth, 'user', null, true);
+
+        $controller = new HomeController($auth, $config);
+
+        $this->expectException(HttpTemporaryRedirect::class);
+        $controller->index();
+    }
+}


### PR DESCRIPTION
The new route for '/' is utilizing a closure instead of a member function. Since using closures in the `storage/cache/routes.cache.php` file is not supported, running Engelsystem in a production environment (where caching is enabled) leads to the following exception being thrown:
```
2019/06/13 14:41:32 [error] 27493#27493: *222 FastCGI sent in stderr: "PHP message: Exception: Code: 0, Message: Call to undefined method Closure::__set_state(), File: storage/cache/routes.cache.php:7, Trace: [{"file":"\/opt\/engelsystem\/nightly\/vendor\/nikic\/fast-route\/src\/functions.php","line":51,"function":"require"},{"file":"\/opt\/engelsystem\/nightly\/src\/Middleware\/RouteDispatcherServiceProvider.php","line":60,"function":"FastRoute\\cachedDispatcher","args":[{},{"cacheFile":"\/opt\/engelsystem\/nightly\/storage\/cache\/routes.cache.php","routeParser":"FastRoute\\RouteParser\\Std","dataGenerator":"FastRoute\\DataGenerator\\GroupCountBased","dispatcher":"FastRoute\\Dispatcher\\GroupCountBased","routeCollector":"FastRoute\\RouteCollector","cacheDisabled":false}]},{"file":"\/opt\/engelsystem\/nightly\/src\/Middleware\/RouteDispatcherServiceProvider.php","line":32,"function":"generateRouting","class":"Engelsystem\\Middleware\\RouteDispatcherServiceProvider","type":"->","args":[{"cacheFile":"\/opt\/engelsystem\/nightly\/storage\/cache\/routes.cache.php"}]},{"" while reading response header from upstream, client: [...], server: [...], request: "GET /login HTTP/2.0", upstream: "fastcgi://unix:/var/run/php/php7.3-fpm.sock:", host: "[...]"
```
This can be fixed by creating a Controller class with a member function throwing the HttpTemporaryRedirect accordingly.