### PR TITLE
Declare summary of atom feed items as HTML

### DIFF
--- a/includes/pages/user_atom.php
+++ b/includes/pages/user_atom.php
@@ -77,6 +77,6 @@ function make_atom_entry_from_news($news_entry)
             page_link_to('news_comments', ['nid' => $news_entry['ID']])
         ) . '</id>
     <updated>' . date('Y-m-d\TH:i:sP', $news_entry['Datum']) . '</updated>
-    <summary>' . htmlspecialchars($news_entry['Text']) . '</summary>
+    <summary type="html">' . htmlspecialchars($news_entry['Text']) . '</summary>
   </entry>' . "\n";
 }


### PR DESCRIPTION
[RFC4287 Section 3.1.1](https://tools.ietf.org/html/rfc4287#section-3.1.1) requires HTML content to be declared
as such with the "type" attribute, this commit adds that attribute
to the generated atom feeds.