### PR TITLE
Fix CI

### DIFF
--- a/contrib/nginx/Dockerfile
+++ b/contrib/nginx/Dockerfile
@@ -1,7 +1,6 @@
-FROM node:8-alpine as themes
+FROM node:10-alpine as themes
 WORKDIR /app
-RUN apk add --no-cache yarn
-COPY .babelrc .browserslistrc package.json webpack.config.js /app/
+COPY .babelrc .browserslistrc package.json webpack.config.js yarn.lock /app/
 RUN yarn install
 COPY resources/assets/ /app/resources/assets
 RUN yarn build

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "file-loader": "^2.0.0",
     "imports-loader": "^0.8.0",
     "less": "^3.9.0",
-    "less-loader": "^4.0.5",
+    "less-loader": "^5",
     "mini-css-extract-plugin": "^0.4.5",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.3",


### PR DESCRIPTION
Less broke itself with a new version. (https://github.com/less/less.js/issues/3414)
I've also removed redundant yarn install in the dockerfile and changed the node version to 10.
(Installing yarn with apk also installed node 10 so nothing changed)

Also added yarn.lock to the dockerfile => wont happen again.