### PR TITLE
Frontend: Show language selects on every page

### DIFF
--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -55,16 +55,14 @@
                                 {{ elements.toolbar_item(user.name, url('users', {'action': 'view'}), 'users', 'icon icon-icon_angel') }}
                             {% endif %}
 
-                            {% if has_permission_to('user_settings') or has_permission_to('logout') %}
-                                <li class="dropdown">
-                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                                        <span class="caret"></span>
-                                    </a>
-                                    <ul class="dropdown-menu" role="menu">
-                                        {{ menuUserSubmenu()|join(" ")|raw }}
-                                    </ul>
-                                </li>
-                            {% endif %}
+                            <li class="dropdown">
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                    <span class="caret"></span>
+                                </a>
+                                <ul class="dropdown-menu" role="menu">
+                                    {{ menuUserSubmenu()|join(" ")|raw }}
+                                </ul>
+                            </li>
 
                         </ul>
                     {% endblock %}


### PR DESCRIPTION
As `make_user_submenu()` has all required permission checks this is fine and allows anyone to change the language for the login/register/whatever pages where no login is required.