### PR TITLE
Sets Monday as first day of the week

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eonasdan-bootstrap-datetimepicker": "^4.17.47",
     "jquery": "^3.3.1",
     "jquery-ui": "^1.11.2",
-    "moment": "^2.8.2",
+    "moment": "^2.12.0",
     "moment-timezone": "^0.4.0",
     "select2": "^4.0.6-rc.1",
     "select2-bootstrap-theme": "0.1.0-beta.10"

--- a/resources/assets/js/vendor.js
+++ b/resources/assets/js/vendor.js
@@ -10,6 +10,13 @@ require('./forms');
 require('./sticky-headers');
 require('./moment-countdown');
 
+moment.updateLocale('en', {
+    week : {
+        dow : 1, // Monday is the first day of the week.
+        doy : 4  // The week that contains Jan 4th is the first week of the year.
+    }
+});
+
 $.ajaxSetup({
     headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')}
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,7 +3328,7 @@ moment-timezone@^0.4.0:
   dependencies:
     moment ">= 2.6.0"
 
-"moment@>= 2.6.0", moment@^2.10, moment@^2.10.2, moment@^2.8.2:
+"moment@>= 2.6.0", moment@^2.10, moment@^2.10.2, moment@^2.12.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
Moment.js introduced a locale update function in 2.12. So I've updated Moment to this version.

Monday is now first day of the week - even if English has been selected.

Closes #630