### PR TITLE
added symfony/console as dev dependency for var dump server

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,6 +54,27 @@ at least `phpdbg -qrr`(which has problems with switch case statements) as using 
 php -d pcov.enabled=1 vendor/bin/phpunit --testsuite Unit --coverage-text
 ```
 
+### Var Dump server
+Symfony Var Dump server is configured to allow for easier debugging. It is not meant as a replacement for xdebug but can actually be used together with xdebug.
+This Var Dump Server is especially useful for when you want to debug a request without messing up the output e.g API calls ot HTML layout.
+
+To use simply call the method `dump` and pass the arguments in exactly the same way you would when using `var_dump`.
+
+This will send the output to the Var Dump server which can be viewed in the terminal. 
+This does however require that you start the var-dump-server otherwise the output will be printed in your browser
+
+You can also `dump` and `die` if you wish to not let your code continue any further by calling the `dd` method
+
+To view the output of `dump` call the following commands:
+
+```bash
+vendor/bin/var-dump-server
+# or for running in docker
+docker exec -it engelsystem_dev_es_php_fpm_1 vendor/bin/var-dump-server
+```
+
+For more information check out the Var Dump Server documentation: [Symfony VarDumper](https://symfony.com/components/VarDumper)
+
 ## Translation
 We use gettext. You may use POEdit to extract new texts from the sourcecode.
 Please config POEdit to extract also the twig template files using the following settings: https://gist.github.com/jlambe/a868d9b63d70902a12254ce47069d0e6

--- a/config/app.php
+++ b/config/app.php
@@ -33,6 +33,7 @@ return [
         \Engelsystem\Helpers\VersionServiceProvider::class,
         \Engelsystem\Mail\MailerServiceProvider::class,
         \Engelsystem\Http\HttpClientServiceProvider::class,
+        \Engelsystem\Helpers\DumpServerServiceProvider::class
     ],
 
     // Application middleware

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -263,4 +263,11 @@ return [
             . 'you want to to contribute, have found any [bugs](https://github.com/engelsystem/engelsystem/issues) '
             . 'or need help.'
     ],
+
+    // var dump server
+    'var_dump_server' => [
+        'host' => '127.0.0.1',
+        'port' => '9912',
+        'enable' => false,
+    ],
 ];

--- a/src/Helpers/DumpServerServiceProvider.php
+++ b/src/Helpers/DumpServerServiceProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Helpers;
+
+use Engelsystem\Config\Config;
+use Engelsystem\Container\ServiceProvider;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\CliContextProvider;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\Dumper\ServerDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+class DumpServerServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $app = $this->app;
+
+        /** @var Config $config */
+        $config = $app->get('config');
+        // setup var dump server to use for easier debugging
+        $varDumpServerConfig = $config->get('var_dump_server');
+
+        if (
+            !$varDumpServerConfig['enable']
+            || $config->get('environment') !== 'development'
+            || !class_exists(ServerDumper::class)
+        ) {
+            return;
+        }
+
+        $dumper = new ServerDumper(
+            'tcp://' . $varDumpServerConfig['host'] . ':' . $varDumpServerConfig['port'],
+            in_array(PHP_SAPI, ['cli', 'phpdbg']) ? $app->get(CliDumper::class) : $app->get(HtmlDumper::class),
+            [
+                'cli'    => new CliContextProvider(),
+                'source' => new SourceContextProvider(),
+            ]
+        );
+
+        $cloner = $app->get(VarCloner::class);
+
+        VarDumper::setHandler(
+            // @codeCoverageIgnoreStart
+            static function ($var) use ($cloner, $dumper) {
+                $dumper->dump($cloner->cloneVar($var));
+            }
+            // @codeCoverageIgnoreEnd
+        );
+    }
+}

--- a/tests/Unit/Helpers/DumpServerServiceProviderTest.php
+++ b/tests/Unit/Helpers/DumpServerServiceProviderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Engelsystem\Test\Unit\Helpers;
+
+use Engelsystem\Config\Config;
+use Engelsystem\Helpers\DumpServerServiceProvider;
+use Engelsystem\Test\Unit\ServiceProviderTest;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\ServerDumper;
+
+class DumpServerServiceProviderTest extends ServiceProviderTest
+{
+    /**
+     * @covers \Engelsystem\Helpers\DumpServerServiceProvider::register
+     */
+    public function testRegisterIfClassExists(): void
+    {
+        if (class_exists(ServerDumper::class) === false) {
+            self::markTestSkipped('ServerDumper class does not exist. Skipping.');
+        }
+
+        $varDumpServerConfig = [
+            'host' => 'localhost',
+            'port' => 80,
+            'enable' => true
+        ];
+
+        $config = new Config();
+        $config->set('var_dump_server', $varDumpServerConfig);
+        $config->set('environment', 'development');
+
+        // mock to test that the code has passed the enabled checks and started to configure the var dump server
+        $app = $this->getApp(['get']);
+
+        $app->expects(self::exactly(3))
+            ->method('get')
+            ->withConsecutive(
+                ['config'],
+                [CliDumper::class],
+                [VarCloner::class]
+            )->willReturnOnConsecutiveCalls(
+                $config,
+                new CliDumper(),
+                new VarCloner()
+            );
+
+        $dumpServiceProvider = new DumpServerServiceProvider($app);
+        $dumpServiceProvider->register();
+    }
+
+    public function notEnabledDataProvider(): array
+    {
+        return [
+            [false, 'development'],
+            [false, 'production'],
+            [true, 'production'],
+        ];
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\DumpServerServiceProvider::register
+     * @dataProvider notEnabledDataProvider
+     *
+     * @param bool $enable
+     * @param string $environment
+     */
+    public function testRegisterShouldNotEnable(bool $enable, string $environment): void
+    {
+        $varDumpServerConfig = [
+            'host' => 'localhost',
+            'port' => 80,
+            'enable' => $enable
+        ];
+
+        $config = new Config();
+        $config->set('var_dump_server', $varDumpServerConfig);
+        $config->set('environment', $environment);
+
+        // asset get is called once only
+        $app = $this->getApp(['get']);
+        $app->expects(self::once())
+            ->method('get')
+            ->willReturn($config);
+
+        $dumpServiceProvider = new DumpServerServiceProvider($app);
+        $dumpServiceProvider->register();
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
This PR allows the var dump server to be used in cli by adding the required "symfony/console" dev dependency .
Composer does not install dependencies dev-dependencies.

#### Where should the reviewer start?
Install composer packages and then start var dump server in the cli

#### How should this be manually tested?
- [ ] `composer install`
- [ ]  `./vendor/bin/var-dump-server`