### PR TITLE
Timestamp for questions

### DIFF
--- a/db/migrations/2020_09_27_000000_add_timestamps_to_questions.php
+++ b/db/migrations/2020_09_27_000000_add_timestamps_to_questions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddTimestampsToQuestions extends Migration
+{
+    use ChangesReferences;
+
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        $this->schema->table('questions', function (Blueprint $table) {
+            $table->timestamp('answered_at')->after('answerer_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        $this->schema->table('questions', function (Blueprint $table) {
+            $table->dropColumn('answered_at');
+            $table->dropTimestamps();
+        });
+    }
+}

--- a/includes/view/Questions_view.php
+++ b/includes/view/Questions_view.php
@@ -13,13 +13,14 @@ function Questions_view(array $open_questions, array $answered_questions, $ask_a
     $open_questions = array_map(
         static function (Question $question): array {
             return [
-                'actions'  => form(
+                'actions'    => form(
                     [
                         form_submit('submit', __('delete'), 'btn-default btn-xs')
                     ],
                     page_link_to('user_questions', ['action' => 'delete', 'id' => $question->id])
                 ),
-                'Question' => nl2br(htmlspecialchars($question->text)),
+                'Question'   => nl2br(htmlspecialchars($question->text)),
+                'created_at' => $question->created_at,
             ];
         },
         $open_questions
@@ -28,10 +29,12 @@ function Questions_view(array $open_questions, array $answered_questions, $ask_a
     $answered_questions = array_map(
         static function (Question $question): array {
             return [
-                'Question' => nl2br(htmlspecialchars($question->text)),
-                'Answer'   => nl2br(htmlspecialchars($question->answer)),
+                'Question'    => nl2br(htmlspecialchars($question->text)),
+                'created_at'  => $question->created_at,
+                'Answer'      => nl2br(htmlspecialchars($question->answer)),
                 'answer_user' => User_Nick_render($question->answerer),
-                'actions'  => form(
+                'answered_at' => $question->answered_at,
+                'actions'     => form(
                     [
                         form_submit('submit', __('delete'), 'btn-default btn-xs')
                     ],
@@ -46,14 +49,17 @@ function Questions_view(array $open_questions, array $answered_questions, $ask_a
         msg(),
         heading(__('Open questions'), 2),
         table([
-            'Question' => __('Question'),
-            'actions'  => ''
+            'Question'   => __('Question'),
+            'created_at' => __('Asked at'),
+            'actions'    => ''
         ], $open_questions),
         heading(__('Answered questions'), 2),
         table([
             'Question'    => __('Question'),
+            'created_at'  => __('Asked at'),
             'answer_user' => __('Answered by'),
             'Answer'      => __('Answer'),
+            'answered_at' => __('Answered at'),
             'actions'     => ''
         ], $answered_questions),
         heading(__('Ask the Heaven'), 2),

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1336,6 +1336,14 @@ msgstr "Beantwortete Fragen"
 msgid "Answered by"
 msgstr "Antwort von"
 
+#: includes/pages/admin_questions.php:102 includes/view/Questions_view.php:40
+msgid "Answered at"
+msgstr "Beantwortet am"
+
+#: includes/pages/admin_questions.php:91 includes/view/Questions_view.php:37
+msgid "Asked at"
+msgstr "Gefragt am"
+
 #: includes/pages/admin_rooms.php:7 includes/pages/user_shifts.php:230
 #: includes/sys_menu.php:118 includes/sys_menu.php:172
 msgid "Rooms"

--- a/src/Models/Question.php
+++ b/src/Models/Question.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Engelsystem\Models;
 
+use Carbon\Carbon;
 use Engelsystem\Models\User\User;
 use Engelsystem\Models\User\UsesUserModel;
 use Illuminate\Database\Eloquent\Builder;
@@ -11,11 +12,16 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
- * @property int       $id
- * @property string    $text
- * @property string    $answer
- * @property int       $answerer_id
- * @property-read User $answerer
+ * @property int         $id
+ * @property string      $text
+ * @property string      $answer
+ * @property int         $answerer_id
+ * @property Carbon|null $answered_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ *
+ * @property-read User   $answerer
+ *
  * @method static Builder|Question whereAnswer($value)
  * @method static Builder|Question whereAnswererId($value)
  * @method static Builder|Question whereId($value)
@@ -25,12 +31,21 @@ class Question extends BaseModel
 {
     use UsesUserModel;
 
+    /** @var bool Enable timestamps */
+    public $timestamps = true;
+
+    /** @var string[] */
+    protected $dates = [
+        'answered_at'
+    ];
+
     /** @var string[] */
     protected $fillable = [
         'user_id',
         'text',
         'answerer_id',
         'answer',
+        'answered_at',
     ];
 
     /** @var string[] */

--- a/tests/Unit/Models/QuestionTest.php
+++ b/tests/Unit/Models/QuestionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Engelsystem\Test\Unit\Models;
 
+use Carbon\Carbon;
 use Engelsystem\Models\Question;
 use Engelsystem\Models\User\User;
 use Illuminate\Support\Str;
@@ -77,6 +78,8 @@ class QuestionTest extends ModelTest
         $this->assertCount(2, $unAnsweredQuestionIds);
         $this->assertContains($question1->id, $unAnsweredQuestionIds);
         $this->assertContains($question2->id, $unAnsweredQuestionIds);
+
+        $this->assertNull(Question::find($question1->id)->answered_at);
     }
 
     /**
@@ -94,6 +97,8 @@ class QuestionTest extends ModelTest
         $this->assertCount(2, $answeredQuestionIds);
         $this->assertContains($question1->id, $answeredQuestionIds);
         $this->assertContains($question2->id, $answeredQuestionIds);
+
+        $this->assertInstanceOf(Carbon::class, Question::find($question1->id)->answered_at);
     }
 
     /**
@@ -112,6 +117,7 @@ class QuestionTest extends ModelTest
             $data += [
                 'answerer_id' => $answerer->id,
                 'answer'      => Str::random(),
+                'answered_at' => Carbon::now(),
             ];
         }
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds timestamps to the question e.g created_at for when a new question is asked, answered_at for when the question is answered and an updated_at every time the question is updated.
This is intended to solve the issues #225

Some checks have been made simpler but in general I have kept everything the same only now it uses a model instead of static queries.

#### Where should the reviewer start?
The reviewer has to go to the `Frag den Himmel` page and create a question.
The reviewer should also go to the `admin -> Fragen beantworten` page to see the list of questions ready to be answered.

#### How should this be manually tested?
- [x] run DB migrations
- [x]  go to the `Frag den Himmel` page and create a question
- [x] Is the created_at date added?
- [x] go to the `admin -> Fragen beantworten` page
- [x] Is the created_at date visible under the section `Unbeantwortete Fragen`?
- [x] Answer one of the newly created questions.
- [x] Is the question now answered and shows a created_at and answered_at column visible under the section `Beantwortete Fragen`?

#### Documents

#### What should happen on deployment? (check all that apply)
- [x] The migrations should be run