### PR TITLE
WIP: Basic (temporary) API implementation

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -30,5 +30,6 @@ $route->addGroup('/api/v2019-alpha', function (RouteCollector $route) {
     $route->get('/shifts/my', 'ApiController@getMyShifts');
     $route->get('/shifts/free/{start:.+}/until/{stop:.+}', 'ApiController@getShiftsFree');
     $route->get('/shifts/by/angeltype/{angeltypeid:\d+}', 'ApiController@getShiftsByAngelType');
+    $route->get('/shift/{shiftid:\d+}', 'ApiController@getShiftById');
     $route->get('[/{resource:.+}]', 'ApiController@index');
 });

--- a/config/routes.php
+++ b/config/routes.php
@@ -24,9 +24,11 @@ $route->get('/metrics', 'Metrics\\Controller@metrics');
 $route->get('/stats', 'Metrics\\Controller@stats');
 
 // API
-$route->get('/api/angeltypes/my', 'ApiController@getMyAngelTypes');
-$route->get('/api/angeltypes', 'ApiController@getAngelTypes');
-$route->get('/api/shifts/my', 'ApiController@getMyShifts');
-$route->get('/api/shifts/free/{start:.+}/until/{stop:.+}', 'ApiController@getShiftsFree');
-$route->get('/api/shifts/by/angeltype/{angeltypeid:.+}', 'ApiController@getShiftsByAngelType');
-$route->get('/api[/{resource:.+}]', 'ApiController@index');
+$route->addGroup('/api/v2019-alpha', function (RouteCollector $route) {
+    $route->get('/angeltypes/my', 'ApiController@getMyAngelTypes');
+    $route->get('/angeltypes', 'ApiController@getAngelTypes');
+    $route->get('/shifts/my', 'ApiController@getMyShifts');
+    $route->get('/shifts/free/{start:.+}/until/{stop:.+}', 'ApiController@getShiftsFree');
+    $route->get('/shifts/by/angeltype/{angeltypeid:.+}', 'ApiController@getShiftsByAngelType');
+    $route->get('[/{resource:.+}]', 'ApiController@index');
+});

--- a/config/routes.php
+++ b/config/routes.php
@@ -24,4 +24,9 @@ $route->get('/metrics', 'Metrics\\Controller@metrics');
 $route->get('/stats', 'Metrics\\Controller@stats');
 
 // API
+$route->get('/api/angeltypes/my', 'ApiController@getMyAngelTypes');
+$route->get('/api/angeltypes', 'ApiController@getAngelTypes');
+$route->get('/api/shifts/my', 'ApiController@getMyShifts');
+$route->get('/api/shifts/free/{start:.+}/until/{stop:.+}', 'ApiController@getShiftsFree');
+$route->get('/api/shifts/by/angeltype/{angeltypeid:.+}', 'ApiController@getShiftsByAngelType');
 $route->get('/api[/{resource:.+}]', 'ApiController@index');

--- a/config/routes.php
+++ b/config/routes.php
@@ -29,6 +29,6 @@ $route->addGroup('/api/v2019-alpha', function (RouteCollector $route) {
     $route->get('/angeltypes', 'ApiController@getAngelTypes');
     $route->get('/shifts/my', 'ApiController@getMyShifts');
     $route->get('/shifts/free/{start:.+}/until/{stop:.+}', 'ApiController@getShiftsFree');
-    $route->get('/shifts/by/angeltype/{angeltypeid:.+}', 'ApiController@getShiftsByAngelType');
+    $route->get('/shifts/by/angeltype/{angeltypeid:\d+}', 'ApiController@getShiftsByAngelType');
     $route->get('[/{resource:.+}]', 'ApiController@index');
 });

--- a/db/migrations/2019_11_19_000000_add_api_privilege.php
+++ b/db/migrations/2019_11_19_000000_add_api_privilege.php
@@ -12,15 +12,11 @@ class AddApiPrivilege extends Migration
     public function up()
     {
         $connection = $this->schema->getConnection();
-
         // Add api permissions
-        $connection->insert(
-            '
-                INSERT INTO `Privileges` (`id`, `name`, `desc`) VALUES (NULL, \'view_api\', \'API accessible.\');
-            ',
+        $connection->table('Privileges')->insert(
             [
-                -40, // Shift Coordinator
-                43,  // admin_user_worklog
+                'name' => 'view_api',
+                'desc' => 'API accessible.'
             ]
         );
     }
@@ -30,11 +26,8 @@ class AddApiPrivilege extends Migration
      */
     public function down()
     {
+        $connection = $this->schema->getConnection();
         // Remove view_api permission
-        $this->schema->getConnection()->delete(
-            'DELETE FROM `Privileges`
-                WHERE `name` = \'view_api\'
-                )'
-        );
+        $connection->table('Privileges')->where('name', '=', 'view_api')->delete();
     }
 }

--- a/db/migrations/2019_11_19_000000_add_api_privilege.php
+++ b/db/migrations/2019_11_19_000000_add_api_privilege.php
@@ -11,6 +11,9 @@ class AddApiPrivilege extends Migration
      */
     public function up()
     {
+        if (!$this->schema->hasTable('Privileges')) {
+            return;
+        }
         $connection = $this->schema->getConnection();
         // Add api permissions
         $connection->table('Privileges')->insert(
@@ -26,6 +29,9 @@ class AddApiPrivilege extends Migration
      */
     public function down()
     {
+        if (!$this->schema->hasTable('Privileges')) {
+            return;
+        }
         $connection = $this->schema->getConnection();
         // Remove view_api permission
         $connection->table('Privileges')->where('name', '=', 'view_api')->delete();

--- a/db/migrations/2019_11_19_000000_add_api_privilege.php
+++ b/db/migrations/2019_11_19_000000_add_api_privilege.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+
+class AddApiPrivilege extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up()
+    {
+        $connection = $this->schema->getConnection();
+
+        // Add api permissions
+        $connection->insert(
+            '
+                INSERT INTO `Privileges` (`id`, `name`, `desc`) VALUES (NULL, \'view_api\', \'API accessible.\');
+            ',
+            [
+                -40, // Shift Coordinator
+                43,  // admin_user_worklog
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down()
+    {
+        // Remove view_api permission
+        $this->schema->getConnection()->delete(
+            'DELETE FROM `Privileges`
+                WHERE `name` = \'view_api\'
+                )'
+        );
+    }
+}

--- a/includes/model/Shifts_model.php
+++ b/includes/model/Shifts_model.php
@@ -668,8 +668,9 @@ function Shift($shift_id)
     }
 
     $shiftsEntry_source = DB::select('
-        SELECT `id`, `TID` , `UID` , `freeloaded`
+        SELECT `ShiftEntry`.`id`, `ShiftEntry`.`TID` , `ShiftEntry`.`UID` , `ShiftEntry`.`freeloaded`, `users`.`name`
         FROM `ShiftEntry`
+        LEFT JOIN `users` ON (`users`.`id` = `ShiftEntry`.`UID`)
         WHERE `SID`=?', [$shift_id]);
 
     $result['ShiftEntry'] = $shiftsEntry_source;

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -290,14 +290,32 @@ function ical_hint()
 {
     $user = auth()->user();
 
-    return heading(__('iCal export') . ' ' . button_help('user/ical'), 2)
+    return heading(__('iCal export and API') . ' ' . button_help('user/ical'), 2)
         . '<p>' . sprintf(
             __('Export your own shifts. <a href="%s">iCal format</a> or <a href="%s">JSON format</a> available (please keep secret, otherwise <a href="%s">reset the api key</a>).'),
             page_link_to('ical', ['key' => $user->api_key]),
             page_link_to('shifts_json_export', ['key' => $user->api_key]),
             page_link_to('user_myshifts', ['reset' => 1])
-        ) . '</p>';
+        ) .
+        sprintf(__('<div class="card border-danger mb-3">
+                <div class="card-header" id="apiHeader">
+                    <h2 class="mb-0">
+                        <button class="btn btn-danger btn-smbtn-danger " data-toggle="collapse" data-target="#collapseApi" aria-expanded="false" aria-controls="collapseApi">
+                        ' . __('Show API Key') .'
+                    </button>
+                    </h2>
+                </div>
+        
+                <div id="collapseApi" class="collapse" aria-labelledby="apiHeader">
+                    <div class="card-body"><code>%s</code> <a href="%s">' . __('Reset API key') . '</a></div>
+                </div>
+            </div>'),
+            $user->api_key,
+            page_link_to('user_myshifts', ['reset' => 1])
+        ) .
+        '</p>';
 }
+
 
 /**
  * @param array $array

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1618,6 +1618,7 @@ msgid "Key changed."
 msgstr "Key geändert."
 
 #: includes/pages/user_myshifts.php:42 includes/view/User_view.php:646
+#: includes/pages/user_myshifts.php:42 includes/pages/user_shifts.php:310
 msgid "Reset API key"
 msgstr "API-Key zurücksetzen"
 
@@ -1792,8 +1793,8 @@ msgid "next 8h"
 msgstr "nächste 8h"
 
 #: includes/pages/user_shifts.php:292
-msgid "iCal export"
-msgstr "iCal Export"
+msgid "iCal export and API"
+msgstr "iCal Export und API"
 
 #: includes/pages/user_shifts.php:294
 #, php-format
@@ -1805,6 +1806,10 @@ msgstr ""
 "Exportiere Deine Schichten. <a href=\"%s\">iCal Format</a> oder <a href=\"%s"
 "\">JSON Format</a> verfügbar (Link bitte geheimhalten, sonst <a href=\"%s"
 "\">API-Key zurücksetzen</a>)."
+
+#: includes/pages/user_shifts.php:304
+msgid "Show API Key"
+msgstr "API Key anzeigen"
 
 #: includes/pages/user_shifts.php:327 includes/view/ShiftTypes_view.php:48
 msgid "All"

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -75,7 +75,7 @@ class ApiController extends BaseController
     }
 
     /**
-     * @Route("/api/v2019-alpha/shifts/by/angeltype/{angeltypeid:.+}")
+     * @Route("/api/v2019-alpha/shifts/by/angeltype/{angeltypeid:\d+}")
      */
     public function getShiftsByAngelType(Request $request)
     {

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -20,13 +20,15 @@ class ApiController extends BaseController
 {
     /** @var Response */
     protected $response;
-
+    protected $user;
     /**
      * @param Response $response
      */
     public function __construct(Response $response)
     {
-        $this->response = $response;
+        $this->response = $response->withHeader('content-type', 'application/json');
+        $this->user = auth()->apiUser('key');
+        $this->permissions = ['view_api'];
     }
 
     /**
@@ -46,8 +48,11 @@ class ApiController extends BaseController
      *
      * Warning: I am still no php coder. This quickly implemented api may be abandoned at any time.
      * Code is mostly harvested from /includes/controller/shifts_controller.php/shifts_json_export_controller()
+     * may or may not be unnecessary
+     * currently used by both getMy[Shifts|AngelTypes] because $this->user is NULL if no api_key provided
+     * (while session based auth is working fine) .
      */
-    protected function doApiAuth($key)
+    protected function doApiAuth()
     {
         $user = auth()->apiUser('key');
 
@@ -63,14 +68,11 @@ class ApiController extends BaseController
      */
     public function getMyShifts(Request $request)
     {
-        $key = $request->input('key');
-        $user = $this->doApiAuth($key);
-
+        $user = $this->doApiAuth();
         $shifts = Shifts_by_user($user->id);
 
         return $this->response
             ->setStatusCode(200)
-            ->withHeader('content-type', 'application/json')
             ->withContent(json_encode($shifts));
     }
 
@@ -79,9 +81,6 @@ class ApiController extends BaseController
      */
     public function getShiftsByAngelType(Request $request)
     {
-        $key = $request->input('key');
-        $user = $this->doApiAuth($key);
-
         // Shifts_by_angeltype uses only the id, required a AngelType though.
         $angelTypeId = (int)$request->getAttribute('angeltypeid');
         $angelType = AngelType($angelTypeId);
@@ -89,7 +88,6 @@ class ApiController extends BaseController
 
         return $this->response
             ->setStatusCode(200)
-            ->withHeader('content-type', 'application/json')
             ->withContent(json_encode($shifts));
     }
 
@@ -98,8 +96,6 @@ class ApiController extends BaseController
      */
     public function getShiftsFree(Request $request)
     {
-        $key = $request->input('key');
-        $user = $this->doApiAuth($key);
         // Shifts_by_angeltype uses only the id, required a AngelType though.
         $start = (int)$request->getAttribute('start');
         $stop = (int)$request->getAttribute('stop');
@@ -107,7 +103,6 @@ class ApiController extends BaseController
 
         return $this->response
             ->setStatusCode(200)
-            ->withHeader('content-type', 'application/json')
             ->withContent(json_encode($shifts));
     }
 
@@ -116,14 +111,11 @@ class ApiController extends BaseController
      */
     public function getMyAngelTypes(Request $request)
     {
-        $key = $request->input('key');
-        $user = $this->doApiAuth($key);
-
+        $user = $this->doApiAuth();
         $angelTypes = User_angeltypes($user->id);
 
         return $this->response
             ->setStatusCode(200)
-            ->withHeader('content-type', 'application/json')
             ->withContent(json_encode($angelTypes));
     }
 
@@ -132,14 +124,10 @@ class ApiController extends BaseController
      */
     public function getAngelTypes(Request $request)
     {
-        $key = $request->input('key');
-        $user = $this->doApiAuth($key);
-
         $angelTypes = AngelTypes();
 
         return $this->response
             ->setStatusCode(200)
-            ->withHeader('content-type', 'application/json')
             ->withContent(json_encode($angelTypes));
     }
 }

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -3,6 +3,18 @@
 namespace Engelsystem\Controllers;
 
 use Engelsystem\Http\Response;
+use Engelsystem\Http\Exceptions\HttpForbidden;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+# Legacy functions
+/* Doing their job, but adding a proper namespaces breaks legacy code :( */
+use function Shifts_by_user;
+use function Shifts_by_angeltype;
+use function Shifts_free;
+use function AngelType;
+use function AngelTypes;
+use function User_angeltypes;
 
 class ApiController extends BaseController
 {
@@ -26,5 +38,115 @@ class ApiController extends BaseController
             ->setStatusCode(501)
             ->withHeader('content-type', 'application/json')
             ->withContent(json_encode(['error' => 'Not implemented']));
+    }
+
+
+    /**
+     * @return User
+     *
+     * Warning: I am no php coder. This code isnt intended for eternity but making our lives @36c3 a bit easier.
+     * Code is mostly harvested from /includes/controller/shifts_controller.php/shifts_json_export_controller()
+     */
+    protected function doApiAuth($key)
+    {
+        $user = auth()->apiUser('key');
+        if (
+            !preg_match('/^[\da-f]{32}$/', $key)
+            || !$user
+        ) {
+            throw new HttpForbidden('{"error":"Missing or invalid key"}', ['content-type' => 'application/json']);
+        }
+
+        if (!auth()->can('view_api')) {
+            throw new HttpForbidden('{"error":"Not allowed"}', ['content-type' => 'application/json']);
+        }
+
+        return $user;
+    }
+
+    /**
+     * @Route(“/api/shifts/my”)
+     */
+    public function getMyShifts(Request $request)
+    {
+        $key = $request->input('key');
+        $user = $this->doApiAuth($key);
+
+        $shifts = Shifts_by_user($user->id);
+
+        return $this->response
+            ->setStatusCode(200)
+            ->withHeader('content-type', 'application/json')
+            ->withContent(json_encode($shifts));
+    }
+
+    /**
+     * @Route(“/api/shifts/my”)
+     * doesnt work? dunno why result is empty.
+     */
+    public function getShiftsByAngelType(Request $request)
+    {
+        $key = $request->input('key');
+        $user = $this->doApiAuth($key);
+
+        // Shifts_by_angeltype uses only the id, required a AngelType though.
+        $angelTypeId = (int)$request->getAttribute('angeltypeid');
+        $angelType = AngelType($angelTypeId);
+        $shifts = Shifts_by_angeltype($angelType);
+
+        return $this->response
+            ->setStatusCode(200)
+            ->withHeader('content-type', 'application/json')
+            ->withContent(json_encode($shifts));
+    }
+
+    /**
+     * @Route(“/api/shifts/free”)
+     */
+    public function getShiftsFree(Request $request)
+    {
+        $key = $request->input('key');
+        $user = $this->doApiAuth($key);
+        // Shifts_by_angeltype uses only the id, required a AngelType though.
+        $start = (int)$request->getAttribute('start');
+        $stop = (int)$request->getAttribute('stop');
+        $shifts = Shifts_free($start, $stop);
+
+        return $this->response
+            ->setStatusCode(200)
+            ->withHeader('content-type', 'application/json')
+            ->withContent(json_encode($shifts));
+    }
+
+    /**
+     * @Route(“/api/angeltypes/my”)
+     */
+    public function getMyAngelTypes(Request $request)
+    {
+        $key = $request->input('key');
+        $user = $this->doApiAuth($key);
+
+        $angelTypes = User_angeltypes($user->id);
+
+        return $this->response
+            ->setStatusCode(200)
+            ->withHeader('content-type', 'application/json')
+            ->withContent(json_encode($angelTypes));
+    }
+
+    /**
+     * @Route(“/api/angeltypes”)
+     */
+    public function getAngelTypes(Request $request)
+    {
+        $key = $request->input('key');
+        $user = $this->doApiAuth($key);
+
+        $angelTypes = AngelTypes();
+
+        return $this->response
+            ->setStatusCode(200)
+            ->withHeader('content-type', 'application/json')
+            ->withContent(json_encode($angelTypes));
     }
 }

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -71,9 +71,7 @@ class ApiController extends BaseController
         $user = $this->doApiAuth();
         $shifts = Shifts_by_user($user->id);
 
-        return $this->response
-            ->setStatusCode(200)
-            ->withContent(json_encode($shifts));
+        return $this->response->withContent(json_encode($shifts));
     }
 
     /**
@@ -86,9 +84,7 @@ class ApiController extends BaseController
         $angelType = AngelType($angelTypeId);
         $shifts = Shifts_by_angeltype($angelType);
 
-        return $this->response
-            ->setStatusCode(200)
-            ->withContent(json_encode($shifts));
+        return $this->response->withContent(json_encode($shifts));
     }
 
     /**
@@ -101,9 +97,7 @@ class ApiController extends BaseController
         $stop = (int)$request->getAttribute('stop');
         $shifts = Shifts_free($start, $stop);
 
-        return $this->response
-            ->setStatusCode(200)
-            ->withContent(json_encode($shifts));
+        return $this->response->withContent(json_encode($shifts));
     }
 
     /**
@@ -114,9 +108,7 @@ class ApiController extends BaseController
         $user = $this->doApiAuth();
         $angelTypes = User_angeltypes($user->id);
 
-        return $this->response
-            ->setStatusCode(200)
-            ->withContent(json_encode($angelTypes));
+        return $this->response->withContent(json_encode($angelTypes));
     }
 
     /**
@@ -126,8 +118,6 @@ class ApiController extends BaseController
     {
         $angelTypes = AngelTypes();
 
-        return $this->response
-            ->setStatusCode(200)
-            ->withContent(json_encode($angelTypes));
+        return $this->response->withContent(json_encode($angelTypes));
     }
 }

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -9,8 +9,10 @@ use Engelsystem\Http\Exceptions\HttpException;
 use Engelsystem\Models\User\User;
 use Symfony\Component\HttpFoundation\Request;
 
-# Legacy functions
-/* Doing their job, but adding a proper namespaces breaks legacy code :( */
+/* Legacy functions
+ * Doing their job, but adding a proper namespaces breaks legacy code :(
+ */
+use function Shift;
 use function Shifts_by_user;
 use function Shifts_by_angeltype;
 use function Shifts_free;
@@ -92,6 +94,19 @@ class ApiController extends BaseController
         $shifts = Shifts_by_angeltype($angelType);
 
         return $this->response->withContent(json_encode($shifts));
+    }
+
+    /**
+     * @Route("/api/v2019-alpha/shift/{shiftid:\d+}")
+     */
+    public function getShiftById(Request $request)
+    {
+        // Shifts_by_angeltype uses only the id, required a AngelType though.
+        $shiftId = (int)$request->getAttribute('shiftid');
+
+        $shift = Shift($shiftId);
+
+        return $this->response->withContent(json_encode($shift));
     }
 
     /**

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -4,7 +4,7 @@ namespace Engelsystem\Controllers;
 
 use Engelsystem\Http\Response;
 use Engelsystem\Http\Exceptions\HttpForbidden;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Engelsystem\Models\User\User;
 use Symfony\Component\HttpFoundation\Request;
 
 # Legacy functions
@@ -16,6 +16,14 @@ use function AngelType;
 use function AngelTypes;
 use function User_angeltypes;
 
+/**
+ * Class ApiController
+ * @package Engelsystem\Controllers
+ *
+ * Warning: I am still no php coder. This quickly implemented api may be abandoned at any time.
+ * Code is mostly harvested from /includes/controller/shifts_controller.php/shifts_json_export_controller()
+ * may or may not be unnecessary
+ */
 class ApiController extends BaseController
 {
     /** @var Response */
@@ -44,11 +52,8 @@ class ApiController extends BaseController
 
 
     /**
-     * @return User
+     * @return User|null
      *
-     * Warning: I am still no php coder. This quickly implemented api may be abandoned at any time.
-     * Code is mostly harvested from /includes/controller/shifts_controller.php/shifts_json_export_controller()
-     * may or may not be unnecessary
      * currently used by both getMy[Shifts|AngelTypes] because $this->user is NULL if no api_key provided
      * (while session based auth is working fine) .
      */

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -3,6 +3,7 @@
 namespace Engelsystem\Controllers;
 
 use DateTime;
+use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Response;
 use Engelsystem\Http\Exceptions\HttpForbidden;
 use Engelsystem\Http\Exceptions\HttpException;
@@ -32,13 +33,18 @@ class ApiController extends BaseController
     /** @var Response */
     protected $response;
     protected $user;
+
+    /** @var Authenticator */
+    protected $auth;
     /**
-     * @param Response $response
+     * @param Response              $response
+     * @param Authenticator         $auth
      */
-    public function __construct(Response $response)
+    public function __construct(Response $response, Authenticator $auth)
     {
         $this->response = $response->withHeader('content-type', 'application/json');
-        $this->user = auth()->apiUser('key');
+        $this->auth = $auth;
+        $this->user = $this->auth->apiUser('key');
         $this->permissions = ['view_api'];
     }
 
@@ -63,9 +69,9 @@ class ApiController extends BaseController
      */
     protected function doApiAuth()
     {
-        $user = auth()->apiUser('key');
+        $user = $this->auth->apiUser('key');
 
-        if (!auth()->can('view_api')) {
+        if (!$this->auth > can('view_api')) {
             throw new HttpForbidden('{"error":"Not allowed"}', ['content-type' => 'application/json']);
         }
 

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -22,7 +22,6 @@ use function User_angeltypes;
  *
  * Warning: I am still no php coder. This quickly implemented api may be abandoned at any time.
  * Code is mostly harvested from /includes/controller/shifts_controller.php/shifts_json_export_controller()
- * may or may not be unnecessary
  */
 class ApiController extends BaseController
 {
@@ -55,7 +54,8 @@ class ApiController extends BaseController
      * @return User|null
      *
      * currently used by both getMy[Shifts|AngelTypes] because $this->user is NULL if no api_key provided
-     * (while session based auth is working fine) .
+     * (while session based auth is still working fine) .
+     * may or may not be unnecessary and removed.
      */
     protected function doApiAuth()
     {

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -44,18 +44,12 @@ class ApiController extends BaseController
     /**
      * @return User
      *
-     * Warning: I am no php coder. This code isnt intended for eternity but making our lives @36c3 a bit easier.
+     * Warning: I am still no php coder. This quickly implemented api may be abandoned at any time.
      * Code is mostly harvested from /includes/controller/shifts_controller.php/shifts_json_export_controller()
      */
     protected function doApiAuth($key)
     {
         $user = auth()->apiUser('key');
-        if (
-            !preg_match('/^[\da-f]{32}$/', $key)
-            || !$user
-        ) {
-            throw new HttpForbidden('{"error":"Missing or invalid key"}', ['content-type' => 'application/json']);
-        }
 
         if (!auth()->can('view_api')) {
             throw new HttpForbidden('{"error":"Not allowed"}', ['content-type' => 'application/json']);
@@ -65,7 +59,7 @@ class ApiController extends BaseController
     }
 
     /**
-     * @Route(“/api/shifts/my”)
+     * @Route("/api/v2019-alpha/shifts/my")
      */
     public function getMyShifts(Request $request)
     {
@@ -81,8 +75,7 @@ class ApiController extends BaseController
     }
 
     /**
-     * @Route(“/api/shifts/my”)
-     * doesnt work? dunno why result is empty.
+     * @Route("/api/v2019-alpha/shifts/by/angeltype/{angeltypeid:.+}")
      */
     public function getShiftsByAngelType(Request $request)
     {
@@ -101,7 +94,7 @@ class ApiController extends BaseController
     }
 
     /**
-     * @Route(“/api/shifts/free”)
+     * @Route("/api/v2019-alpha/shifts/free")
      */
     public function getShiftsFree(Request $request)
     {
@@ -119,7 +112,7 @@ class ApiController extends BaseController
     }
 
     /**
-     * @Route(“/api/angeltypes/my”)
+     * @Route("/api/v2019-alpha/angeltypes/my")
      */
     public function getMyAngelTypes(Request $request)
     {
@@ -135,7 +128,7 @@ class ApiController extends BaseController
     }
 
     /**
-     * @Route(“/api/angeltypes”)
+     * @Route("/api/v2019-alpha/angeltypes")
      */
     public function getAngelTypes(Request $request)
     {

--- a/tests/Unit/Controllers/ApiControllerTest.php
+++ b/tests/Unit/Controllers/ApiControllerTest.php
@@ -3,6 +3,7 @@
 namespace Engelsystem\Test\Unit\Controllers;
 
 use Engelsystem\Controllers\ApiController;
+use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,9 @@ class ApiControllerTest extends TestCase
      */
     public function testIndex()
     {
-        $controller = new ApiController(new Response());
+        $auth = $this->createMock(Authenticator::class);
+        $response = new Response();
+        $controller = new ApiController($response, $auth);
 
         $response = $controller->index();
 


### PR DESCRIPTION
# Content
This implements some basic api features around shift data.
To be more precise the following endpoints are implemented by now:
* /api/angeltypes/my
* /api/angeltypes
* /api/shifts/my
* /api/shifts/free/{start:.+}/until/{stop:.+}
* /api/shifts/by/angeltype/{angeltypeid:.+}

All endpoints are protected by the already implemented api_key and the new privilege 'view_api' which is not a default privilege for any user or group (yet).

## Motivation
We at c3cert spending quite some time on all large events (where we _have to_ provide service 24/7) to fill up all our shifts across different rooms and angel types.
The web view (on smaller devices) isn't optimal in this regard  and won't offer a proper way to poke our team automagically.
I'm sure this feature is useful for other OCs as well.