### PR TITLE
Add models ide helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _vimrc_local.vim
 /docker/dev/.env
 
 # Project files
+/_ide_helper_models.php
 /config/config.php
 /test/coverage
 /public/coverage

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ The `bin/migrate` script can be used to import and update the database of the en
 
 For more information on how to use it call `./bin/migrate help`
 
+##### [bin/gen_ide_helper_models](bin/gen_ide_helper_models)
+
+This script dumps the ide helper model docs to [_ide_helper_models](./_ide_helper_models).
+
 ### Translation
 We use gettext. You may use POEdit to extract new texts from the sourcecode. Please config POEdit to extract also the twig template files using the following settings: https://gist.github.com/jlambe/a868d9b63d70902a12254ce47069d0e6
 

--- a/bin/gen_ide_helper_models
+++ b/bin/gen_ide_helper_models
@@ -1,0 +1,28 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+require_once __DIR__ . '/../includes/application.php';
+
+/**
+ * This script generates the models helper file "_ide_helper_models.php" into the project root.
+ */
+
+$config = $app->get('config');
+$config['ide-helper.model_locations'] = ['src/Models'];
+
+$fileSystem = new Filesystem();
+$command = new ModelsCommand($fileSystem);
+$command->setLaravel($app);
+$command->run(
+    new ArrayInput([
+        '--nowrite' => true,
+    ]),
+    new ConsoleOutput()
+);

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "vlucas/phpdotenv": "^3.3"
     },
     "require-dev": {
+        "barryvdh/laravel-ide-helper": "^2.6",
         "dms/phpunit-arraysubset-asserts": "^0.1.0",
         "filp/whoops": "^2.3",
         "phpunit/phpunit": "^8.1",


### PR DESCRIPTION
I've frickeled the [ide model helper](https://github.com/barryvdh/laravel-ide-helper) into a script. Since it's not 100 % laravel I write a separate file and not into the models directly. It's quite convenient during development.