### PR TITLE
PHP 7.4 compatibility, PHP min version 7.2, Twig 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To report bugs use [engelsystem/issues](https://github.com/engelsystem/engelsyst
 ## Installation
 
 ### Requirements
- * PHP >= 7.1
+ * PHP >= 7.2
    * Required modules:
      * dom
      * json
@@ -150,7 +150,7 @@ docker-compose up
 
 Run these commands once initially and then as required after changes
 
-```
+```bash
 # Install composer dependencies
 docker exec -it engelsystem_dev_es_workspace_1 composer i
 
@@ -169,7 +169,7 @@ docker exec -it engelsystem_dev_es_workspace_1 bin/migrate
 
 While developing you may use the watch mode to rebuild the system on changes
 
-```
+```bash
 # Run a front-end build
 docker exec -it engelsystem_dev_es_workspace_1 yarn build:watch
 ```
@@ -199,10 +199,10 @@ We use gettext. You may use POEdit to extract new texts from the sourcecode. Ple
 ### Code style
 Please ensure that your pull requests follow the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style guide.
 You can check that by running
-```php
+```bash
 composer run phpcs
 ```
 You may auto fix reported issues by running
-```php
+```bash
 composer run phpcbf
 ```

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "swiftmailer/swiftmailer": "^6.2",
         "symfony/http-foundation": "^4.3",
         "symfony/psr-http-message-bridge": "^1.2",
-        "twig/twig": "~2.6.0",
+        "twig/twig": "^2.11",
         "vlucas/phpdotenv": "^3.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "swiftmailer/swiftmailer": "^6.2",
         "symfony/http-foundation": "^4.3",
         "symfony/psr-http-message-bridge": "^1.2",
-        "twig/twig": "^2.11",
+        "twig/twig": "^3.0",
         "vlucas/phpdotenv": "^3.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpcbf": "phpcbf -p"
     },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "swiftmailer/swiftmailer": "^6.2",
         "symfony/http-foundation": "^4.3",
         "symfony/psr-http-message-bridge": "^1.2",
-        "twig/extensions": "^1.5",
         "twig/twig": "~2.6.0",
         "vlucas/phpdotenv": "^3.3"
     },

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -1,5 +1,3 @@
-{% import _self as elements %}
-
 {% macro toolbar_item(label, link, active_page, icon) %}
     <li{% if page() == active_page %} class="active"{% endif %}>
         <a href="{{ link }}">
@@ -36,23 +34,23 @@
                         <ul class="nav navbar-nav navbar-right">
 
                             {% if is_user() %}
-                                {{ elements.toolbar_item(menuUserShiftState(user), url('shifts', {'action': 'next'}), '', 'glyphicon-time') }}
+                                {{ _self.toolbar_item(menuUserShiftState(user), url('shifts', {'action': 'next'}), '', 'glyphicon-time') }}
                             {% elseif has_permission_to('register') and config('registration_enabled') %}
-                                {{ elements.toolbar_item(__('Register'), url('register'), 'register', 'glyphicon-plus') }}
+                                {{ _self.toolbar_item(__('Register'), url('register'), 'register', 'glyphicon-plus') }}
                             {% endif %}
 
                             {% if has_permission_to('login') %}
-                                {{ elements.toolbar_item(__('Login'), url('login'), 'login', 'glyphicon-log-in') }}
+                                {{ _self.toolbar_item(__('Login'), url('login'), 'login', 'glyphicon-log-in') }}
                             {% endif %}
 
                             {% if is_user() and has_permission_to('user_messages') %}
-                                {{ elements.toolbar_item(menuUserMessages(), url('user-messages'), 'user-messages', 'glyphicon-envelope') }}
+                                {{ _self.toolbar_item(menuUserMessages(), url('user-messages'), 'user-messages', 'glyphicon-envelope') }}
                             {% endif %}
 
                             {{ menuUserHints() }}
 
                             {% if has_permission_to('user_myshifts') %}
-                                {{ elements.toolbar_item(user.name, url('users', {'action': 'view'}), 'users', 'icon icon-icon_angel') }}
+                                {{ _self.toolbar_item(user.name, url('users', {'action': 'view'}), 'users', 'icon icon-icon_angel') }}
                             {% endif %}
 
                             <li class="dropdown">

--- a/resources/views/pages/login.twig
+++ b/resources/views/pages/login.twig
@@ -17,7 +17,7 @@
                 (__('Event starts')): config('event_start'),
                 (__('Event ends')): config('event_end'),
                 (__('Teardown ends')): config('teardown_end')
-            } if date %}
+            } | filter(date => date) %}
                 {% if date > date() %}
                     <div class="col-sm-3 text-center hidden-xs">
                         <h4>{{ name }}</h4>

--- a/src/Config/ConfigServiceProvider.php
+++ b/src/Config/ConfigServiceProvider.php
@@ -40,10 +40,11 @@ class ConfigServiceProvider extends ServiceProvider
                 continue;
             }
 
-            $config->set(array_replace_recursive(
+            $configuration = array_replace_recursive(
                 $config->get(null),
                 require $file
-            ));
+            );
+            $config->set($configuration);
         }
 
         if (empty($config->get(null))) {

--- a/src/Controllers/Metrics/MetricsEngine.php
+++ b/src/Controllers/Metrics/MetricsEngine.php
@@ -142,7 +142,7 @@ class MetricsEngine implements EngineInterface
      * @param string|mixed[] $key
      * @param mixed          $value
      */
-    public function share($key, $value = null)
+    public function share($key, $value = null): void
     {
     }
 }

--- a/src/Helpers/Authenticator.php
+++ b/src/Helpers/Authenticator.php
@@ -25,7 +25,7 @@ class Authenticator
     /** @var string[] */
     protected $permissions;
 
-    /** @var int */
+    /** @var int|string|null */
     protected $passwordAlgorithm = PASSWORD_DEFAULT;
 
     /**
@@ -163,13 +163,11 @@ class Authenticator
      */
     public function verifyPassword(User $user, string $password)
     {
-        $algorithm = $this->passwordAlgorithm;
-
         if (!password_verify($password, $user->password)) {
             return false;
         }
 
-        if (password_needs_rehash($user->password, $algorithm)) {
+        if (password_needs_rehash($user->password, $this->passwordAlgorithm)) {
             $this->setPassword($user, $password);
         }
 
@@ -182,14 +180,12 @@ class Authenticator
      */
     public function setPassword(User $user, string $password)
     {
-        $algorithm = $this->passwordAlgorithm;
-
-        $user->password = password_hash($password, $algorithm);
+        $user->password = password_hash($password, $this->passwordAlgorithm);
         $user->save();
     }
 
     /**
-     * @return int
+     * @return int|string|null
      */
     public function getPasswordAlgorithm()
     {
@@ -197,9 +193,9 @@ class Authenticator
     }
 
     /**
-     * @param int $passwordAlgorithm
+     * @param int|string|null $passwordAlgorithm
      */
-    public function setPasswordAlgorithm(int $passwordAlgorithm)
+    public function setPasswordAlgorithm($passwordAlgorithm)
     {
         $this->passwordAlgorithm = $passwordAlgorithm;
     }

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Twig_LoaderInterface as TwigLoader;
+use Twig\Loader\LoaderInterface as TwigLoader;
 
 class ErrorHandler implements MiddlewareInterface
 {

--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -67,13 +67,11 @@ class ErrorHandler implements MiddlewareInterface
 
             if ($request instanceof Request) {
                 $session = $request->getSession();
-                $session->set(
-                    'errors',
-                    array_merge_recursive(
-                        $session->get('errors', []),
-                        ['validation' => $e->getValidator()->getErrors()]
-                    )
+                $errors = array_merge_recursive(
+                    $session->get('errors', []),
+                    ['validation' => $e->getValidator()->getErrors()]
                 );
+                $session->set('errors', $errors);
 
                 $session->set('form-data', Arr::except($request->request->all(), $this->formIgnore));
             }

--- a/src/Renderer/Engine.php
+++ b/src/Renderer/Engine.php
@@ -11,7 +11,7 @@ abstract class Engine implements EngineInterface
      * @param mixed[]|string $key
      * @param null           $value
      */
-    public function share($key, $value = null)
+    public function share($key, $value = null): void
     {
         if (!is_array($key)) {
             $key = [$key => $value];

--- a/src/Renderer/EngineInterface.php
+++ b/src/Renderer/EngineInterface.php
@@ -23,5 +23,5 @@ interface EngineInterface
      * @param string|mixed[] $key
      * @param mixed          $value
      */
-    public function share($key, $value = null);
+    public function share($key, $value = null): void;
 }

--- a/src/Renderer/Renderer.php
+++ b/src/Renderer/Renderer.php
@@ -18,7 +18,7 @@ class Renderer
      * @param mixed[] $data
      * @return string
      */
-    public function render($template, $data = [])
+    public function render(string $template, array $data = []): string
     {
         foreach ($this->renderer as $renderer) {
             if (!$renderer->canRender($template)) {
@@ -40,7 +40,7 @@ class Renderer
      *
      * @param EngineInterface $renderer
      */
-    public function addRenderer(EngineInterface $renderer)
+    public function addRenderer(EngineInterface $renderer): void
     {
         $this->renderer[] = $renderer;
     }

--- a/src/Renderer/Twig/Extensions/Assets.php
+++ b/src/Renderer/Twig/Extensions/Assets.php
@@ -22,7 +22,7 @@ class Assets extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('asset', [$this, 'getAsset']),
@@ -31,9 +31,9 @@ class Assets extends TwigExtension
 
     /**
      * @param string $path
-     * @return UrlGenerator|string
+     * @return string
      */
-    public function getAsset($path)
+    public function getAsset(string $path): string
     {
         $path = ltrim($path, '/');
 

--- a/src/Renderer/Twig/Extensions/Assets.php
+++ b/src/Renderer/Twig/Extensions/Assets.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Http\UrlGenerator;
-use Twig_Extension as TwigExtension;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFunction;
 
 class Assets extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Authentication.php
+++ b/src/Renderer/Twig/Extensions/Authentication.php
@@ -22,7 +22,7 @@ class Authentication extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('is_user', [$this, 'isAuthenticated']),
@@ -34,7 +34,7 @@ class Authentication extends TwigExtension
     /**
      * @return bool
      */
-    public function isAuthenticated()
+    public function isAuthenticated(): bool
     {
         return (bool)$this->auth->user();
     }
@@ -42,7 +42,7 @@ class Authentication extends TwigExtension
     /**
      * @return bool
      */
-    public function isGuest()
+    public function isGuest(): bool
     {
         return !$this->isAuthenticated();
     }

--- a/src/Renderer/Twig/Extensions/Authentication.php
+++ b/src/Renderer/Twig/Extensions/Authentication.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Helpers\Authenticator;
-use Twig_Extension as TwigExtension;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFunction;
 
 class Authentication extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Config.php
+++ b/src/Renderer/Twig/Extensions/Config.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Config\Config as EngelsystemConfig;
-use Twig_Extension as TwigExtension;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFunction;
 
 class Config extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Config.php
+++ b/src/Renderer/Twig/Extensions/Config.php
@@ -22,7 +22,7 @@ class Config extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('config', [$this->config, 'get']),

--- a/src/Renderer/Twig/Extensions/Csrf.php
+++ b/src/Renderer/Twig/Extensions/Csrf.php
@@ -22,7 +22,7 @@ class Csrf extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('csrf', [$this, 'getCsrfField'], ['is_safe' => ['html']]),
@@ -33,7 +33,7 @@ class Csrf extends TwigExtension
     /**
      * @return string
      */
-    public function getCsrfField()
+    public function getCsrfField(): string
     {
         return sprintf('<input type="hidden" name="_token" value="%s">', $this->getCsrfToken());
     }
@@ -41,7 +41,7 @@ class Csrf extends TwigExtension
     /**
      * @return string
      */
-    public function getCsrfToken()
+    public function getCsrfToken(): string
     {
         return $this->session->get('_token');
     }

--- a/src/Renderer/Twig/Extensions/Csrf.php
+++ b/src/Renderer/Twig/Extensions/Csrf.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Twig_Extension as TwigExtension;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFunction;
 
 class Csrf extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Globals.php
+++ b/src/Renderer/Twig/Extensions/Globals.php
@@ -24,7 +24,7 @@ class Globals extends TwigExtension implements GlobalsInterface
      *
      * @return array An array of global variables
      */
-    public function getGlobals()
+    public function getGlobals(): array
     {
         $user = $this->auth->user();
 

--- a/src/Renderer/Twig/Extensions/Globals.php
+++ b/src/Renderer/Twig/Extensions/Globals.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Helpers\Authenticator;
-use Twig_Extension as TwigExtension;
-use Twig_Extension_GlobalsInterface as GlobalsInterface;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\Extension\GlobalsInterface as GlobalsInterface;
 
 class Globals extends TwigExtension implements GlobalsInterface
 {

--- a/src/Renderer/Twig/Extensions/Legacy.php
+++ b/src/Renderer/Twig/Extensions/Legacy.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Http\Request;
-use Twig_Extension as TwigExtension;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFunction;
 
 class Legacy extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Legacy.php
+++ b/src/Renderer/Twig/Extensions/Legacy.php
@@ -22,7 +22,7 @@ class Legacy extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         $isSafeHtml = ['is_safe' => ['html']];
         return [
@@ -39,7 +39,7 @@ class Legacy extends TwigExtension
     /**
      * @return string
      */
-    public function getPage()
+    public function getPage(): string
     {
         if ($this->request->has('p')) {
             return $this->request->get('p');

--- a/src/Renderer/Twig/Extensions/Markdown.php
+++ b/src/Renderer/Twig/Extensions/Markdown.php
@@ -36,7 +36,7 @@ class Markdown extends TwigExtension
      * @param string $text
      * @return string
      */
-    public function render($text): string
+    public function render(string $text): string
     {
         return $this->renderer->text(htmlspecialchars($text));
     }

--- a/src/Renderer/Twig/Extensions/Markdown.php
+++ b/src/Renderer/Twig/Extensions/Markdown.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Parsedown;
-use Twig_Extension as TwigExtension;
-use Twig_Filter as TwigFilter;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFilter;
 
 class Markdown extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Session.php
+++ b/src/Renderer/Twig/Extensions/Session.php
@@ -22,7 +22,7 @@ class Session extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('session_get', [$this->session, 'get']),

--- a/src/Renderer/Twig/Extensions/Session.php
+++ b/src/Renderer/Twig/Extensions/Session.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
-use Twig_Extension as TwigExtension;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFunction;
 
 class Session extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Translation.php
+++ b/src/Renderer/Twig/Extensions/Translation.php
@@ -3,9 +3,9 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Helpers\Translation\Translator;
-use Twig_Extension as TwigExtension;
-use Twig_Filter as TwigFilter;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class Translation extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Translation.php
+++ b/src/Renderer/Twig/Extensions/Translation.php
@@ -23,7 +23,7 @@ class Translation extends TwigExtension
     /**
      * @return array
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('trans', [$this->translator, 'translate']),
@@ -33,7 +33,7 @@ class Translation extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('__', [$this->translator, 'translate']),

--- a/src/Renderer/Twig/Extensions/Translation.php
+++ b/src/Renderer/Twig/Extensions/Translation.php
@@ -4,27 +4,20 @@ namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Helpers\Translation\Translator;
 use Twig_Extension as TwigExtension;
-use Twig_Extensions_TokenParser_Trans as TranslationTokenParser;
 use Twig_Filter as TwigFilter;
 use Twig_Function as TwigFunction;
-use Twig_TokenParserInterface as TwigTokenParser;
 
 class Translation extends TwigExtension
 {
     /** @var Translator */
     protected $translator;
 
-    /** @var TranslationTokenParser */
-    protected $tokenParser;
-
     /**
-     * @param Translator             $translator
-     * @param TranslationTokenParser $tokenParser
+     * @param Translator $translator
      */
-    public function __construct(Translator $translator, TranslationTokenParser $tokenParser)
+    public function __construct(Translator $translator)
     {
         $this->translator = $translator;
-        $this->tokenParser = $tokenParser;
     }
 
     /**
@@ -46,13 +39,5 @@ class Translation extends TwigExtension
             new TwigFunction('__', [$this->translator, 'translate']),
             new TwigFunction('_e', [$this->translator, 'translatePlural']),
         ];
-    }
-
-    /**
-     * @return TwigTokenParser[]
-     */
-    public function getTokenParsers()
-    {
-        return [$this->tokenParser];
     }
 }

--- a/src/Renderer/Twig/Extensions/Url.php
+++ b/src/Renderer/Twig/Extensions/Url.php
@@ -3,8 +3,8 @@
 namespace Engelsystem\Renderer\Twig\Extensions;
 
 use Engelsystem\Http\UrlGenerator;
-use Twig_Extension as TwigExtension;
-use Twig_Function as TwigFunction;
+use Twig\Extension\AbstractExtension as TwigExtension;
+use Twig\TwigFunction;
 
 class Url extends TwigExtension
 {

--- a/src/Renderer/Twig/Extensions/Url.php
+++ b/src/Renderer/Twig/Extensions/Url.php
@@ -22,7 +22,7 @@ class Url extends TwigExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('url', [$this, 'getUrl']),
@@ -32,9 +32,9 @@ class Url extends TwigExtension
     /**
      * @param string $path
      * @param array  $parameters
-     * @return UrlGenerator|string
+     * @return string
      */
-    public function getUrl($path, $parameters = [])
+    public function getUrl(string $path, array $parameters = []): string
     {
         $path = str_replace('_', '-', $path);
 

--- a/src/Renderer/TwigEngine.php
+++ b/src/Renderer/TwigEngine.php
@@ -2,10 +2,10 @@
 
 namespace Engelsystem\Renderer;
 
-use Twig_Environment as Twig;
-use Twig_Error_Loader as LoaderError;
-use Twig_Error_Runtime as RuntimeError;
-use Twig_Error_Syntax as SyntaxError;
+use Twig\Environment as Twig;
+use Twig\Error\LoaderError as LoaderError;
+use Twig\Error\RuntimeError as RuntimeError;
+use Twig\Error\SyntaxError as SyntaxError;
 
 class TwigEngine extends Engine
 {

--- a/src/Renderer/TwigLoader.php
+++ b/src/Renderer/TwigLoader.php
@@ -2,16 +2,16 @@
 
 namespace Engelsystem\Renderer;
 
-use Twig_Error_Loader;
-use Twig_Loader_Filesystem as FilesystemLoader;
+use Twig\Error\LoaderError as ErrorLoader;
+use Twig\Loader\FilesystemLoader as FilesystemLoader;
 
 class TwigLoader extends FilesystemLoader
 {
     /**
      * @param string $name
      * @param bool   $throw
-     * @return false|string
-     * @throws Twig_Error_Loader
+     * @return string|false|null
+     * @throws ErrorLoader
      */
     public function findTemplate($name, $throw = true)
     {

--- a/src/Renderer/TwigLoader.php
+++ b/src/Renderer/TwigLoader.php
@@ -10,10 +10,10 @@ class TwigLoader extends FilesystemLoader
     /**
      * @param string $name
      * @param bool   $throw
-     * @return string|false|null
+     * @return string|null
      * @throws ErrorLoader
      */
-    public function findTemplate($name, $throw = true)
+    public function findTemplate(string $name, bool $throw = true): ?string
     {
         $extension = '.twig';
         $extensionLength = mb_strlen($extension);

--- a/src/Renderer/TwigServiceProvider.php
+++ b/src/Renderer/TwigServiceProvider.php
@@ -95,7 +95,7 @@ class TwigServiceProvider extends ServiceProvider
      * @param string $class
      * @param string $alias
      */
-    protected function registerTwigExtensions($class, $alias)
+    protected function registerTwigExtensions(string $class, string $alias)
     {
         $alias = 'twig.extension.' . $alias;
 

--- a/src/Renderer/TwigServiceProvider.php
+++ b/src/Renderer/TwigServiceProvider.php
@@ -14,9 +14,9 @@ use Engelsystem\Renderer\Twig\Extensions\Markdown;
 use Engelsystem\Renderer\Twig\Extensions\Session;
 use Engelsystem\Renderer\Twig\Extensions\Translation;
 use Engelsystem\Renderer\Twig\Extensions\Url;
-use Twig_Environment as Twig;
-use Twig_Extension_Core as TwigCore;
-use Twig_LoaderInterface as TwigLoaderInterface;
+use Twig\Environment as Twig;
+use Twig\Extension\CoreExtension as TwigCore;
+use Twig\Loader\LoaderInterface as TwigLoaderInterface;
 
 class TwigServiceProvider extends ServiceProvider
 {

--- a/tests/Unit/Middleware/ErrorHandlerTest.php
+++ b/tests/Unit/Middleware/ErrorHandlerTest.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Twig_LoaderInterface as TwigLoader;
+use Twig\Loader\LoaderInterface as TwigLoader;
 
 class ErrorHandlerTest extends TestCase
 {

--- a/tests/Unit/Renderer/Twig/Extensions/ExtensionTest.php
+++ b/tests/Unit/Renderer/Twig/Extensions/ExtensionTest.php
@@ -6,8 +6,8 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Twig_Function as TwigFunction;
-use Twig_Node as TwigNode;
+use Twig\TwigFunction;
+use Twig\Node\Node as TwigNode;
 
 abstract class ExtensionTest extends TestCase
 {

--- a/tests/Unit/Renderer/Twig/Extensions/TranslationTest.php
+++ b/tests/Unit/Renderer/Twig/Extensions/TranslationTest.php
@@ -5,7 +5,6 @@ namespace Engelsystem\Test\Unit\Renderer\Twig\Extensions;
 use Engelsystem\Helpers\Translation\Translator;
 use Engelsystem\Renderer\Twig\Extensions\Translation;
 use PHPUnit\Framework\MockObject\MockObject;
-use Twig_Extensions_TokenParser_Trans as TranslationTokenParser;
 
 class TranslationTest extends ExtensionTest
 {
@@ -17,10 +16,8 @@ class TranslationTest extends ExtensionTest
     {
         /** @var Translator|MockObject $translator */
         $translator = $this->createMock(Translator::class);
-        /** @var TranslationTokenParser|MockObject $parser */
-        $parser = $this->createMock(TranslationTokenParser::class);
 
-        $extension = new Translation($translator, $parser);
+        $extension = new Translation($translator);
         $filters = $extension->getFilters();
 
         $this->assertExtensionExists('trans', [$translator, 'translate'], $filters);
@@ -33,29 +30,11 @@ class TranslationTest extends ExtensionTest
     {
         /** @var Translator|MockObject $translator */
         $translator = $this->createMock(Translator::class);
-        /** @var TranslationTokenParser|MockObject $parser */
-        $parser = $this->createMock(TranslationTokenParser::class);
 
-        $extension = new Translation($translator, $parser);
+        $extension = new Translation($translator);
         $functions = $extension->getFunctions();
 
         $this->assertExtensionExists('__', [$translator, 'translate'], $functions);
         $this->assertExtensionExists('_e', [$translator, 'translatePlural'], $functions);
-    }
-
-    /**
-     * @covers \Engelsystem\Renderer\Twig\Extensions\Translation::getTokenParsers
-     */
-    public function testGetTokenParsers()
-    {
-        /** @var Translator|MockObject $translator */
-        $translator = $this->createMock(Translator::class);
-        /** @var TranslationTokenParser|MockObject $parser */
-        $parser = $this->createMock(TranslationTokenParser::class);
-
-        $extension = new Translation($translator, $parser);
-        $tokenParsers = $extension->getTokenParsers();
-
-        $this->assertTokenParserExists($parser, $tokenParsers);
     }
 }

--- a/tests/Unit/Renderer/TwigEngineTest.php
+++ b/tests/Unit/Renderer/TwigEngineTest.php
@@ -5,8 +5,8 @@ namespace Engelsystem\Test\Unit\Renderer;
 use Engelsystem\Renderer\TwigEngine;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Twig_Environment as Twig;
-use Twig_LoaderInterface as LoaderInterface;
+use Twig\Environment as Twig;
+use Twig\Loader\LoaderInterface as LoaderInterface;
 
 class TwigEngineTest extends TestCase
 {

--- a/tests/Unit/Renderer/TwigServiceProviderTest.php
+++ b/tests/Unit/Renderer/TwigServiceProviderTest.php
@@ -11,10 +11,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass as Reflection;
 use ReflectionException;
 use stdClass;
-use Twig_Environment as Twig;
-use Twig_Extension_Core as TwigCore;
-use Twig_ExtensionInterface as ExtensionInterface;
-use Twig_LoaderInterface as TwigLoaderInterface;
+use Twig\Environment as Twig;
+use Twig\Extension\CoreExtension as TwigCore;
+use Twig\Extension\ExtensionInterface as ExtensionInterface;
+use Twig\Loader\LoaderInterface as TwigLoaderInterface;
 
 class TwigServiceProviderTest extends ServiceProviderTest
 {

--- a/tests/Unit/Renderer/TwigServiceProviderTest.php
+++ b/tests/Unit/Renderer/TwigServiceProviderTest.php
@@ -12,6 +12,7 @@ use ReflectionClass as Reflection;
 use ReflectionException;
 use stdClass;
 use Twig\Environment as Twig;
+use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension as TwigCore;
 use Twig\Extension\ExtensionInterface as ExtensionInterface;
 use Twig\Loader\LoaderInterface as TwigLoaderInterface;
@@ -103,9 +104,15 @@ class TwigServiceProviderTest extends ServiceProviderTest
         /** @var Config|MockObject $config */
         $config = $this->createMock(Config::class);
         /** @var TwigCore|MockObject $twigCore */
-        $twigCore = $this->getMockBuilder(stdClass::class)
-            ->addMethods(['setTimezone'])
-            ->getMock();
+        $twigCore = $this->getMockForAbstractClass(
+            AbstractExtension::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['setTimezone']
+        );
 
         $app = $this->getApp(['make', 'instance', 'tag', 'get']);
 


### PR DESCRIPTION
The goal is to support to also run on PHP 7.4 as thats the newest (and thus best) PHP version out there :heart:

* Changed type of `PASSWORD_DEFAULT` from `int` to `?string`
* Older xdebug code coverage
* Twig - can now be updated: The extension package can be removed as it's not used anymore (and deprecated anyway)