### PR TITLE
Improve 36c3 theme readability

### DIFF
--- a/resources/assets/themes/theme12.less
+++ b/resources/assets/themes/theme12.less
@@ -37,6 +37,7 @@ THE SOFTWARE.
 @gray:                   #555; // #555
 @gray-light:             #888;   // #999
 @gray-lighter:           #D0D0CE; // #eee
+@black:                  #000;
 
 @brand-primary:         #fe5000;
 @brand-success:         #00bb31;
@@ -52,7 +53,7 @@ THE SOFTWARE.
 //** Background color for `<body>`.
 @body-bg:               #000;
 //** Global text color on `<body>`.
-@text-color:            @gray-light;
+@text-color:            @gray-lighter;
 
 //** Global textual link color.
 @link-color:            @brand-primary;
@@ -163,24 +164,23 @@ THE SOFTWARE.
 
 @btn-font-weight:                normal;
 
-@btn-default-color:              #000;
+@btn-default-color:              @gray-lighter;
 @btn-default-bg:                 lighten(@gray-dark, 10%);
-
 @btn-default-border:             darken(@btn-default-bg, 10%);
 
-@btn-primary-color:              @btn-default-color;
+@btn-primary-color:              @black;
 @btn-primary-bg:                 @brand-primary;
 @btn-primary-border:             darken(@btn-default-bg, 10%);
 
-@btn-success-color:              @btn-default-color;
+@btn-success-color:              @black;
 @btn-success-bg:                 @brand-success;
 @btn-success-border:             darken(@btn-default-bg, 10%);
 
-@btn-info-color:                 @btn-default-color;
+@btn-info-color:                 @black;
 @btn-info-bg:                    @brand-info;
 @btn-info-border:                darken(@btn-default-bg, 10%);
 
-@btn-warning-color:              @btn-default-color;
+@btn-warning-color:              @black;
 @btn-warning-bg:                 @brand-warning;
 @btn-warning-border:             darken(@btn-default-bg, 10%);
 
@@ -450,15 +450,15 @@ THE SOFTWARE.
 //
 //##
 
-@pagination-color:                     #fff;
+@pagination-color:                     @black;
 @pagination-bg:                        @gray-darker;
 @pagination-border:                    @gray-dark;
 
-@pagination-hover-color:               #fff;
+@pagination-hover-color:               @black;
 @pagination-hover-bg:                  @component-active-bg;
 @pagination-hover-border:              transparent;
 
-@pagination-active-color:              #fff;
+@pagination-active-color:              @black;
 @pagination-active-bg:                 @brand-primary;
 @pagination-active-border:             transparent;
 
@@ -769,9 +769,9 @@ THE SOFTWARE.
 //
 //##
 
-@badge-color:                 #fff;
+@badge-color:                 @black;
 //** Linked badge text color on hover
-@badge-link-hover-color:      #fff;
+@badge-link-hover-color:      @black;
 @badge-bg:                    @brand-primary;
 
 //** Badge text color in active nav link
@@ -1037,5 +1037,25 @@ a.thumbnail.active {
 
   h1, h2, h3, h4, h5, h6 {
     color: #fff;
+  }
+}
+
+// datetimepicker
+
+.bootstrap-datetimepicker-widget {
+
+  .timepicker-hour,
+  .timepicker-minute,
+  [data-action='selectHour'],
+  [data-action='selectMinute'],
+  [data-action='incrementHours'],
+  [data-action='decrementHours'],
+  [data-action='incrementMinutes'],
+  [data-action='decrementMinutes'] {
+
+    &:hover {
+
+      color: @gray;
+    }
   }
 }


### PR DESCRIPTION
- more contract for the default text color
- black instead of white text in badges and pagination
- more contrast within the datepicker

example

before
![es_before](https://user-images.githubusercontent.com/6216686/71036254-98d3b180-211d-11ea-81da-7ce15ac5c187.png)

after
![es_after](https://user-images.githubusercontent.com/6216686/71036252-98d3b180-211d-11ea-9e81-042b0a3f9bf5.png)

Maybe just check the branch out and have a look