### PR TITLE
Cleanup, fixes and features

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,10 @@ image: php
 
 variables:
   DOCKER_DRIVER: overlay2
-  TEST_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}
-  RELEASE_IMAGE: ${CI_REGISTRY_IMAGE}:latest
+  TEST_IMAGE: ${CI_REGISTRY_IMAGE}/engelsystem:${CI_COMMIT_REF_SLUG}
+  TEST_IMAGE_NGINX: ${CI_REGISTRY_IMAGE}/nginx:${CI_COMMIT_REF_SLUG}
+  RELEASE_IMAGE: ${CI_REGISTRY_IMAGE}/engelsystem:latest
+  RELEASE_IMAGE_NGINX: ${CI_REGISTRY_IMAGE}/nginx:latest
   MYSQL_DATABASE: engelsystem
   MYSQL_USER: engel
   MYSQL_PASSWORD: engelsystem
@@ -52,7 +54,7 @@ validate-yarn:
   before_script:
     - docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
 
-build-image.nginx:
+build-image-nginx:
   <<: *docker_definition
   stage: build
   artifacts:
@@ -61,9 +63,9 @@ build-image.nginx:
     paths:
       - ./public/assets
   script:
-    - docker build --pull -t "${TEST_IMAGE}-nginx" -f docker/nginx/Dockerfile .
-    - docker push "${TEST_IMAGE}-nginx"
-    - instance=$(docker create "${TEST_IMAGE}-nginx")
+    - docker build --pull -t "${TEST_IMAGE_NGINX}" -f docker/nginx/Dockerfile .
+    - docker push "${TEST_IMAGE_NGINX}"
+    - instance=$(docker create "${TEST_IMAGE_NGINX}")
     - docker cp "${instance}:/var/www/public/assets" public/
     - docker rm "${instance}"
 
@@ -116,8 +118,12 @@ test:
     - composer --no-ansi install
     - ./bin/migrate
   script:
-    - php -d pcov.enabled=1 vendor/bin/phpunit -vvv --colors=never --coverage-text --coverage-html "${HOMEDIR}/coverage/" --log-junit "${HOMEDIR}/unittests.xml"
-    - ./bin/migrate down
+    - >-
+      php -d pcov.enabled=1 vendor/bin/phpunit -vvv --colors=never
+      --coverage-text --coverage-html "${HOMEDIR}/coverage/"
+      --log-junit "${HOMEDIR}/unittests.xml"
+  after_script:
+    - '"${DOCROOT}/bin/migrate" down'
 
 release-image:
   <<: *docker_definition
@@ -129,13 +135,13 @@ release-image:
   only:
     - master
 
-release-image.nginx:
+release-image-nginx:
   <<: *docker_definition
   stage: release
   script:
-    - docker pull "${TEST_IMAGE}-nginx"
-    - docker tag "${TEST_IMAGE}-nginx" "${RELEASE_IMAGE}-nginx"
-    - docker push "${RELEASE_IMAGE}-nginx"
+    - docker pull "${TEST_IMAGE_NGINX}"
+    - docker tag "${TEST_IMAGE_NGINX}" "${RELEASE_IMAGE_NGINX}"
+    - docker push "${RELEASE_IMAGE_NGINX}"
   only:
     - master
 
@@ -174,7 +180,7 @@ deploy-staging:
     # Check if deployment variables where set
     - |-
       if [ -z "${SSH_PRIVATE_KEY}" ] || [ -z "${STAGING_REMOTE}" ] || [ -z "${STAGING_REMOTE_PATH}" ]; then
-        echo "Skipping deployment";
+        echo "Skipping deployment"
         exit
       fi
     - *deploy_template_script
@@ -192,7 +198,7 @@ deploy-production:
     # Check if deployment variables where set
     - |-
       if [ -z "${SSH_PRIVATE_KEY}" ] || [ -z "${PRODUCTION_REMOTE}" ] || [ -z "${PRODUCTION_REMOTE_PATH}" ]; then
-        echo "Skipping deployment";
+        echo "Skipping deployment"
         exit
       fi
     - *deploy_template_script

--- a/bin/migrate
+++ b/bin/migrate
@@ -5,6 +5,8 @@ use Composer\Autoload\ClassLoader;
 use Engelsystem\Application;
 use Engelsystem\Database\Migration\Migrate;
 use Engelsystem\Database\Migration\MigrationServiceProvider;
+use Engelsystem\Exceptions\Handler;
+use Engelsystem\Exceptions\Handlers\NullHandler;
 
 require_once __DIR__ . '/../includes/application.php';
 
@@ -14,6 +16,10 @@ $baseDir = __DIR__ . '/../db/migrations';
 /** @var Application $app */
 $app = app();
 $app->register(MigrationServiceProvider::class);
+
+/** @var Handler $errorHandler */
+$errorHandler = $app->get(Handler::class);
+$errorHandler->setHandler(Handler::ENV_PRODUCTION, new NullHandler());
 
 /** @var Migrate $migration */
 $migration = $app->get('db.migration');

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -182,13 +182,14 @@ function view_user_shifts()
     $days = load_days();
     $rooms = load_rooms();
     $types = load_types();
+    $ownTypes = [];
+    foreach (UserAngelTypes_by_User($user->id) as $type) {
+        $ownTypes[] = (int)$type['angeltype_id'];
+    }
 
     if (!$session->has('shifts-filter')) {
-        $room_ids = [
-            $rooms[0]['id']
-        ];
-        $type_ids = array_map('get_ids_from_array', $types);
-        $shiftsFilter = new ShiftsFilter(auth()->can('user_shifts_admin'), $room_ids, $type_ids);
+        $room_ids = collect($rooms)->pluck('id')->toArray();
+        $shiftsFilter = new ShiftsFilter(auth()->can('user_shifts_admin'), $room_ids, $ownTypes);
         $session->set('shifts-filter', $shiftsFilter->sessionExport());
     }
 
@@ -220,11 +221,6 @@ function view_user_shifts()
 
     if (config('signup_requires_arrival') && !$user->state->arrived) {
         info(render_user_arrived_hint());
-    }
-
-    $ownTypes = [];
-    foreach (UserAngelTypes_by_User($user->id) as $type) {
-        $ownTypes[] = (int)$type['angeltype_id'];
     }
 
     return page([

--- a/resources/views/pages/news/edit.twig
+++ b/resources/views/pages/news/edit.twig
@@ -41,7 +41,7 @@
                     ) }}
                 </div>
                 <div class="col-md-6">
-                    {{ f.checkbox('is_meeting', __('news.edit.is_meeting'), news ? news.is_meeting : false) }}
+                    {{ f.checkbox('is_meeting', __('news.edit.is_meeting'), is_meeting) }}
                 </div>
             </div>
 

--- a/resources/views/pages/news/news.twig
+++ b/resources/views/pages/news/news.twig
@@ -2,7 +2,7 @@
 {% import 'macros/base.twig' as m %}
 {% import 'macros/form.twig' as f %}
 
-{% block title %}{{ news.title }}{% endblock %}
+{% block title %}{% if news.is_meeting %}{{ __('news.is_meeting') }} {% endif %}{{ news.title }}{% endblock %}
 
 {% block news %}
     {{ _self.news(news) }}

--- a/resources/views/pages/news/overview.twig
+++ b/resources/views/pages/news/overview.twig
@@ -1,14 +1,15 @@
 {% extends 'layouts/app.twig' %}
 {% import 'macros/base.twig' as m %}
 
-{% block title %}{{ not only_meetings|default(false) ? __('news.title') : __('news.title.meetings') }}{% endblock %}
+{% set only_meetings = only_meetings|default(false) %}
+{% block title %}{{ not only_meetings ? __('news.title') : __('news.title.meetings') }}{% endblock %}
 
 {% block content %}
     <div class="container">
         <h1>
             {{ block('title') }}
             {%- if has_permission_to('admin_news') and is_overview|default(false) -%}
-                {{ m.button(__('news.add'), url('admin/news')) }}
+                {{ m.button(__('news.add'), url('admin/news', only_meetings ? {'meeting': 1} : {})) }}
             {%- endif %}
         </h1>
 

--- a/src/Controllers/Admin/NewsController.php
+++ b/src/Controllers/Admin/NewsController.php
@@ -64,6 +64,7 @@ class NewsController extends BaseController
     {
         $id = $request->getAttribute('id');
         $news = $this->news->find($id);
+        $isMeeting = $request->get('meeting', false);
 
         if (
             $news
@@ -75,7 +76,7 @@ class NewsController extends BaseController
 
         return $this->response->withView(
             'pages/news/edit.twig',
-            ['news' => $news] + $this->getNotifications()
+            ['news' => $news, 'is_meeting' => $news ? $news->is_meeting : $isMeeting] + $this->getNotifications(),
         );
     }
 

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -4,35 +4,37 @@ namespace Engelsystem\Controllers;
 
 use Engelsystem\Config\Config;
 use Engelsystem\Helpers\Authenticator;
-use Engelsystem\Http\Exceptions\HttpTemporaryRedirect;
+use Engelsystem\Http\Redirector;
+use Engelsystem\Http\Response;
 
 class HomeController extends BaseController
 {
-    /**
-     * @var Authenticator
-     */
+    /** @var Authenticator */
     protected $auth;
 
-    /**
-     * @var Config
-     */
+    /** @var Config */
     protected $config;
+
+    /** @var Redirector */
+    protected $redirect;
 
     /**
      * @param Authenticator $auth
      * @param Config        $config
+     * @param Redirector    $redirect
      */
-    public function __construct(Authenticator $auth, Config $config)
+    public function __construct(Authenticator $auth, Config $config, Redirector $redirect)
     {
         $this->auth = $auth;
         $this->config = $config;
+        $this->redirect = $redirect;
     }
 
     /**
-     * @throws HttpTemporaryRedirect
+     * @return Response
      */
-    public function index()
+    public function index(): Response
     {
-        throw new HttpTemporaryRedirect($this->auth->user() ? $this->config->get('home_site') : 'login');
+        return $this->redirect->to($this->auth->user() ? $this->config->get('home_site') : 'login');
     }
 }

--- a/src/Exceptions/Handlers/NullHandler.php
+++ b/src/Exceptions/Handlers/NullHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Engelsystem\Exceptions\Handlers;
+
+use Engelsystem\Http\Request;
+use Throwable;
+
+class NullHandler extends Legacy
+{
+    /**
+     * @param Request   $request
+     * @param Throwable $e
+     */
+    public function render($request, Throwable $e)
+    {
+        return;
+    }
+}

--- a/src/Renderer/Renderer.php
+++ b/src/Renderer/Renderer.php
@@ -29,7 +29,7 @@ class Renderer
         }
 
         if ($this->logger) {
-            $this->logger->error('Unable to find a renderer for template file "{file}"', ['file' => $template]);
+            $this->logger->critical('Unable to find a renderer for template file "{file}"', ['file' => $template]);
         }
 
         return '';

--- a/tests/Unit/Controllers/Admin/NewsControllerTest.php
+++ b/tests/Unit/Controllers/Admin/NewsControllerTest.php
@@ -107,6 +107,42 @@ class NewsControllerTest extends TestCase
     }
 
     /**
+     * @covers \Engelsystem\Controllers\Admin\NewsController::edit
+     */
+    public function testEditIsMeeting()
+    {
+        $isMeeting = false;
+        $this->response->expects($this->exactly(3))
+            ->method('withView')
+            ->willReturnCallback(
+                function ($view, $data) use (&$isMeeting) {
+                    $this->assertEquals($isMeeting, $data['is_meeting']);
+                    $isMeeting = !$isMeeting;
+
+                    return $this->response;
+                }
+            );
+        $this->auth->expects($this->once())
+            ->method('can')
+            ->with('admin_news_html')
+            ->willReturn(true);
+
+        /** @var NewsController $controller */
+        $controller = $this->app->make(NewsController::class);
+
+        // Is no meeting
+        $controller->edit($this->request);
+
+        // Is meeting
+        $this->request->query->set('meeting', 1);
+        $controller->edit($this->request);
+
+        // Should stay no meeting
+        $this->request->attributes->set('id', 1);
+        $controller->edit($this->request);
+    }
+
+    /**
      * @covers \Engelsystem\Controllers\Admin\NewsController::save
      */
     public function testSaveCreateInvalid()

--- a/tests/Unit/Controllers/HomeControllerTest.php
+++ b/tests/Unit/Controllers/HomeControllerTest.php
@@ -5,7 +5,8 @@ namespace Engelsystem\Test\Unit\Controllers;
 use Engelsystem\Config\Config;
 use Engelsystem\Controllers\HomeController;
 use Engelsystem\Helpers\Authenticator;
-use Engelsystem\Http\Exceptions\HttpTemporaryRedirect;
+use Engelsystem\Http\Redirector;
+use Engelsystem\Http\Response;
 use Engelsystem\Test\Unit\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,10 +22,11 @@ class HomeControllerTest extends TestCase
         /** @var Authenticator|MockObject $auth */
         $auth = $this->createMock(Authenticator::class);
         $this->setExpects($auth, 'user', null, true);
+        /** @var Redirector|MockObject $redirect */
+        $redirect = $this->createMock(Redirector::class);
+        $this->setExpects($redirect, 'to', ['/foo'], new Response());
 
-        $controller = new HomeController($auth, $config);
-
-        $this->expectException(HttpTemporaryRedirect::class);
+        $controller = new HomeController($auth, $config, $redirect);
         $controller->index();
     }
 }

--- a/tests/Unit/Exceptions/Handlers/NullHandlerTest.php
+++ b/tests/Unit/Exceptions/Handlers/NullHandlerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Engelsystem\Test\Unit\Exceptions\Handlers;
+
+use Engelsystem\Exceptions\Handlers\NullHandler;
+use Engelsystem\Http\Request;
+use ErrorException;
+use PHPUnit\Framework\TestCase;
+
+class NullHandlerTest extends TestCase
+{
+    /**
+     * @covers \Engelsystem\Exceptions\Handlers\NullHandler::render
+     */
+    public function testRender()
+    {
+        $handler = new NullHandler();
+        $request = new Request();
+        $exception = new ErrorException();
+
+        $this->expectOutputString('');
+        $handler->render($request, $exception);
+    }
+}

--- a/tests/Unit/Models/EventConfigTest.php
+++ b/tests/Unit/Models/EventConfigTest.php
@@ -4,13 +4,9 @@ namespace Engelsystem\Test\Unit\Models;
 
 use Carbon\Carbon;
 use Engelsystem\Models\EventConfig;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
 
-class EventConfigTest extends TestCase
+class EventConfigTest extends ModelTest
 {
-    use HasDatabase;
-
     /**
      * @covers \Engelsystem\Models\EventConfig::setValueAttribute
      */
@@ -116,14 +112,5 @@ class EventConfigTest extends TestCase
                 return $this;
             }
         };
-    }
-
-    /**
-     * Prepare test
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->initDatabase();
     }
 }

--- a/tests/Unit/Models/LogEntryTest.php
+++ b/tests/Unit/Models/LogEntryTest.php
@@ -3,14 +3,10 @@
 namespace Engelsystem\Test\Unit\Models;
 
 use Engelsystem\Models\LogEntry;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
 use Psr\Log\LogLevel;
 
-class LogEntryTest extends TestCase
+class LogEntryTest extends ModelTest
 {
-    use HasDatabase;
-
     /**
      * @covers \Engelsystem\Models\LogEntry::filter
      */
@@ -33,14 +29,5 @@ class LogEntryTest extends TestCase
         $this->assertCount(7, LogEntry::filter());
         $this->assertCount(3, LogEntry::filter(LogLevel::INFO));
         $this->assertCount(1, LogEntry::filter('Oops'));
-    }
-
-    /**
-     * Prepare test
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->initDatabase();
     }
 }

--- a/tests/Unit/Models/MessageTest.php
+++ b/tests/Unit/Models/MessageTest.php
@@ -6,16 +6,12 @@ namespace Engelsystem\Test\Unit\Models;
 
 use Engelsystem\Models\Message;
 use Engelsystem\Models\User\User;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
 
 /**
  * This class provides tests covering the Message model and its relations.
  */
-class MessageTest extends TestCase
+class MessageTest extends ModelTest
 {
-    use HasDatabase;
-
     /** @var User */
     private $user1;
 
@@ -37,7 +33,6 @@ class MessageTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->initDatabase();
 
         $this->user1 = User::create([
             'name'     => 'user1',

--- a/tests/Unit/Models/ModelTest.php
+++ b/tests/Unit/Models/ModelTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Engelsystem\Test\Unit\Models;
+
+use Engelsystem\Test\Unit\HasDatabase;
+use Engelsystem\Test\Unit\TestCase;
+
+abstract class ModelTest extends TestCase
+{
+    use HasDatabase;
+
+    /**
+     * Prepare test
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->initDatabase();
+    }
+}

--- a/tests/Unit/Models/NewsCommentsTest.php
+++ b/tests/Unit/Models/NewsCommentsTest.php
@@ -7,16 +7,12 @@ namespace Engelsystem\Test\Unit\Models;
 use Engelsystem\Models\News;
 use Engelsystem\Models\NewsComment;
 use Engelsystem\Models\User\User;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
 
 /**
  * This class provides tests for the NewsComments model.
  */
-class NewsCommentsTest extends TestCase
+class NewsCommentsTest extends ModelTest
 {
-    use HasDatabase;
-
     /** @var User */
     private $user;
 
@@ -32,7 +28,6 @@ class NewsCommentsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->initDatabase();
 
         $this->user = User::create([
             'name'     => 'lorem',

--- a/tests/Unit/Models/NewsTest.php
+++ b/tests/Unit/Models/NewsTest.php
@@ -6,16 +6,12 @@ namespace Engelsystem\Test\Unit\Models;
 
 use Engelsystem\Models\News;
 use Engelsystem\Models\User\User;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
 
 /**
  * This class provides tests for the News model.
  */
-class NewsTest extends TestCase
+class NewsTest extends ModelTest
 {
-    use HasDatabase;
-
     /** @var array */
     private $newsData;
 
@@ -28,7 +24,6 @@ class NewsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->initDatabase();
 
         $this->user = (new User())->create([
             'name'     => 'lorem',

--- a/tests/Unit/Models/QuestionTest.php
+++ b/tests/Unit/Models/QuestionTest.php
@@ -6,14 +6,10 @@ namespace Engelsystem\Test\Unit\Models;
 
 use Engelsystem\Models\Question;
 use Engelsystem\Models\User\User;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
 use Illuminate\Support\Str;
 
-class QuestionTest extends TestCase
+class QuestionTest extends ModelTest
 {
-    use HasDatabase;
-
     /**
      * @var User
      */
@@ -30,7 +26,6 @@ class QuestionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->initDatabase();
 
         $this->user1 = User::create(
             [

--- a/tests/Unit/Models/Shifts/ScheduleShiftTest.php
+++ b/tests/Unit/Models/Shifts/ScheduleShiftTest.php
@@ -4,14 +4,11 @@ namespace Engelsystem\Test\Unit\Models\Shifts;
 
 use Engelsystem\Models\Shifts\Schedule;
 use Engelsystem\Models\Shifts\ScheduleShift;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
+use Engelsystem\Test\Unit\Models\ModelTest;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class ScheduleShiftTest extends TestCase
+class ScheduleShiftTest extends ModelTest
 {
-    use HasDatabase;
-
     /**
      * @covers \Engelsystem\Models\Shifts\ScheduleShift::schedule
      */
@@ -28,14 +25,5 @@ class ScheduleShiftTest extends TestCase
         $scheduleShift = (new ScheduleShift())->find(1);
         $this->assertInstanceOf(BelongsTo::class, $scheduleShift->schedule());
         $this->assertEquals($schedule->id, $scheduleShift->schedule->id);
-    }
-
-    /**
-     * Prepare test
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->initDatabase();
     }
 }

--- a/tests/Unit/Models/Shifts/ScheduleTest.php
+++ b/tests/Unit/Models/Shifts/ScheduleTest.php
@@ -4,13 +4,10 @@ namespace Engelsystem\Test\Unit\Models\Shifts;
 
 use Engelsystem\Models\Shifts\Schedule;
 use Engelsystem\Models\Shifts\ScheduleShift;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
+use Engelsystem\Test\Unit\Models\ModelTest;
 
-class ScheduleTest extends TestCase
+class ScheduleTest extends ModelTest
 {
-    use HasDatabase;
-
     /**
      * @covers \Engelsystem\Models\Shifts\Schedule::scheduleShifts
      */
@@ -24,14 +21,5 @@ class ScheduleTest extends TestCase
         (new ScheduleShift(['shift_id' => 3, 'schedule_id' => $schedule->id, 'guid' => 'c']))->save();
 
         $this->assertCount(3, $schedule->scheduleShifts);
-    }
-
-    /**
-     * Prepare test
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->initDatabase();
     }
 }

--- a/tests/Unit/Models/User/UserTest.php
+++ b/tests/Unit/Models/User/UserTest.php
@@ -13,15 +13,13 @@ use Engelsystem\Models\User\PersonalData;
 use Engelsystem\Models\User\Settings;
 use Engelsystem\Models\User\State;
 use Engelsystem\Models\User\User;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
+use Engelsystem\Test\Unit\Models\ModelTest;
 use Exception;
 use Illuminate\Support\Str;
 
-class UserTest extends TestCase
+class UserTest extends ModelTest
 {
     use ArraySubsetAsserts;
-    use HasDatabase;
 
     /** @var string[] */
     protected $data = [
@@ -206,14 +204,5 @@ class UserTest extends TestCase
         $this->assertCount(2, $answers);
         $this->assertContains($question1->id, $answers);
         $this->assertContains($question2->id, $answers);
-    }
-
-    /**
-     * Prepare test
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->initDatabase();
     }
 }

--- a/tests/Unit/Models/User/UsesUserModelTest.php
+++ b/tests/Unit/Models/User/UsesUserModelTest.php
@@ -4,14 +4,11 @@ namespace Engelsystem\Test\Unit\Models\User;
 
 use Engelsystem\Models\BaseModel;
 use Engelsystem\Models\User\UsesUserModel;
-use Engelsystem\Test\Unit\HasDatabase;
-use Engelsystem\Test\Unit\TestCase;
+use Engelsystem\Test\Unit\Models\ModelTest;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class UsesUserModelTest extends TestCase
+class UsesUserModelTest extends ModelTest
 {
-    use HasDatabase;
-
     /**
      * @covers \Engelsystem\Models\User\UsesUserModel::user
      */
@@ -24,14 +21,5 @@ class UsesUserModelTest extends TestCase
         };
 
         $this->assertInstanceOf(BelongsTo::class, $model->user());
-    }
-
-    /**
-     * Prepare test
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->initDatabase();
     }
 }

--- a/tests/Unit/Renderer/RendererTest.php
+++ b/tests/Unit/Renderer/RendererTest.php
@@ -56,7 +56,7 @@ class RendererTest extends TestCase
         $loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
         $loggerMock
             ->expects($this->once())
-            ->method('error');
+            ->method('critical');
 
         $renderer->setLogger($loggerMock);
 


### PR DESCRIPTION
* Preselect all rooms and only own shifts in shifts overview
* Show `[Meeting]` prefix on meeting detail pages
* Preselect is meeting if adding from meetings overview page
* Hide mokey error message on migration errors as exception gets shown anyways
* Cleaned up the `.gitlab-ci.yml`
* As the GitLab container registry started supporting multiple namespaces per project a while ago its a great idea to use them :tada:
* Fixed the `HomeController` to use the `Redirector` to generate the right URL to redirect to
* The `Renderer` logs now with `critical` severity instead of only `error`
* Refactored model tests to extend the `ModelTest` class
