### PR TITLE
Add option for minutes after shift start where signup is allowed

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -103,6 +103,9 @@ return [
     // Setting this to 0 disables the feature
     'signup_advance_hours'    => 0,
 
+    // Allow signup this many minutes after the start of the shift
+    'signup_post_minutes'     => 0,
+
     // Number of hours that an angel has to sign out own shifts
     'last_unsubscribe'        => 3,
 

--- a/includes/model/Shifts_model.php
+++ b/includes/model/Shifts_model.php
@@ -353,7 +353,7 @@ function Shift_signup_allowed_angel(
         return new ShiftSignupState(ShiftSignupState::SIGNED_UP, $free_entries);
     }
 
-    if (time() > $shift['start']) {
+    if (time() > $shift['start'] + config('signup_post_minutes') * 60) {
         // you can only join if the shift is in future
         return new ShiftSignupState(ShiftSignupState::SHIFT_ENDED, $free_entries);
     }


### PR DESCRIPTION
For example it might be reasonable to allow signup up to 5 minutes after the shift has started.