### PR TITLE
Docker Compose: Use internal networks between containers

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     ports:
       - 5000:80
     networks:
-      - internal
+      - fpm
+      - internet
     depends_on:
       - es_php_fpm
   es_php_fpm:
@@ -33,8 +34,9 @@ services:
       MAIL_DRIVER: log
       APP_NAME: Engelsystem DEV
     networks:
-      - internal
       - database
+      - fpm
+      - internet
     depends_on:
       - es_database
   es_workspace:
@@ -56,8 +58,9 @@ services:
       MAIL_DRIVER: log
       APP_NAME: Engelsystem DEV
     networks:
-      - internal
       - database
+      - fpm
+      - internet
     depends_on:
       - es_database
   es_database:
@@ -76,5 +79,8 @@ volumes:
   db: {}
 
 networks:
-  internal:
   database:
+    internal: true
+  fpm:
+    internal: true
+  internet:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     ports:
       - 5000:80
     networks:
-      - internal
+      - fpm
+      - internet
     depends_on:
       - es_php_fpm
   es_php_fpm:
@@ -22,8 +23,9 @@ services:
       MYSQL_PASSWORD: engelsystem
       MYSQL_DATABASE: engelsystem
     networks:
-      - internal
       - database
+      - fpm
+      - internet
     depends_on:
       - es_database
   es_database:
@@ -42,5 +44,8 @@ volumes:
   db: {}
 
 networks:
-  internal:
   database:
+    internal: true
+  fpm:
+    internal: true
+  internet:


### PR DESCRIPTION
Random docker improvements

* Added private (not to the internet connected) networks between docker-compose  containers