### PR TITLE
Enable select2

### DIFF
--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+require('select2')
 
 /**
  * Sets all checkboxes to the wanted state
@@ -169,6 +170,15 @@ $(function () {
             });
         });
     });
+});
+
+/**
+ * Enable select2
+ */
+$(function () {
+    $.fn.select2.defaults.set('theme', 'bootstrap');
+
+    $('select').select2();
 });
 
 /**

--- a/resources/assets/themes/base.less
+++ b/resources/assets/themes/base.less
@@ -1,5 +1,7 @@
 @import "../../../node_modules/bootstrap/less/bootstrap";
 @import "../../../node_modules/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css";
+@import "../../../node_modules/select2/dist/css/select2.min.css";
+@import "../../../node_modules/select2-bootstrap-theme/src/select2-bootstrap.less";
 @import "error";
 
 body {
@@ -139,6 +141,10 @@ table a > .icon-icon_angel {
 .panel-danger .panel-heading a {
   color: @panel-danger-text;
   background-color: @panel-danger-heading-bg;
+}
+
+.select2-dropdown {
+  background-color: @brand-primary;
 }
 
 .selection .checkbox {


### PR DESCRIPTION
We could also only use select2 on selects with more than ~5 elements but that would be more confusing

```js
$('select').each(function (_, select) {
    if (select.length > 5) {
        $(select).select2();
    }
})
```

resolves #235 (selection users should be possible by some fancy javascript search)
fixes #554 (Messages: User search function or alphabetical order?)