### PR TITLE
translation: less misleading admin_arrive translation

### DIFF
--- a/includes/pages/admin_arrive.php
+++ b/includes/pages/admin_arrive.php
@@ -7,7 +7,7 @@ use Engelsystem\Models\User\User;
  */
 function admin_arrive_title()
 {
-    return __('Arrived angels');
+    return __('Arrive angels');
 }
 
 /**

--- a/includes/sys_menu.php
+++ b/includes/sys_menu.php
@@ -110,7 +110,7 @@ function make_navigation()
     $admin_pages = [
         // path              => name
         // path              => [name, permission]
-        'admin_arrive'       => 'Arrived angels',
+        'admin_arrive'       => 'Arrive angels',
         'admin_active'       => 'Active angels',
         'admin_user'         => 'All Angels',
         'admin_free'         => 'Free angels',

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1045,8 +1045,8 @@ msgid "Given shirts"
 msgstr "Ausgegebene T-Shirts"
 
 #: includes/pages/admin_arrive.php:10 includes/sys_menu.php:111
-msgid "Arrived angels"
-msgstr "Angekommene Engel"
+msgid "Arrive angels"
+msgstr "Ankommende Engel"
 
 #: includes/pages/admin_arrive.php:41
 msgid "Reset done. Angel has not arrived."

--- a/resources/lang/pt_BR/default.po
+++ b/resources/lang/pt_BR/default.po
@@ -785,7 +785,7 @@ msgid "Given shirts"
 msgstr "Camisetas entregues"
 
 #: includes/pages/admin_arrive.php:4
-msgid "Arrived angels"
+msgid "Arrive angels"
 msgstr "Anjos que chegaram"
 
 #: includes/pages/admin_arrive.php:20


### PR DESCRIPTION
I am not sure how the translation system works. I just searched for 'Arrived angels' and 'Angekommene Engel' and replaced every occurence to something less misleading.

see #704