### PR TITLE
Improve mobile navigation (esp. on iPhone SE)

### DIFF
--- a/resources/assets/themes/base.less
+++ b/resources/assets/themes/base.less
@@ -442,4 +442,19 @@ span.ref-id[id] {
       margin-top: 7px;
     }
   }
+
+  .navbar-toggle {
+    align-items: center;
+    font-size: 18px;
+    display: flex;
+    height: 38px;
+    justify-content: center;
+    padding: 0;
+    transform: none;
+    width: 38px;
+
+    .icon-close {
+      padding: 0;
+    }
+  }
 }

--- a/resources/assets/themes/base.less
+++ b/resources/assets/themes/base.less
@@ -411,6 +411,8 @@ span.ref-id[id] {
     max-height: unset;
     left: 101%;
     top: @navbar-height + 1;
+    // extra padding because mobile Safari displays a bottom bar hiding parts of the menu
+    padding-bottom: 75px;
 
     transition: left .3s ease-in-out;
     -webkit-transition: left .3s ease-in-out;
@@ -434,6 +436,7 @@ span.ref-id[id] {
     .nav > li.active {
       display: none;
     }
+
     .caret {
       float: right;
       margin-top: 7px;

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -11,13 +11,13 @@
     <div class="container-fluid">
         {% block navbar %}
             <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed"
-                        data-toggle="offcanvas" data-target="#navbar-offcanvas">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon icon-open">☰</span>
-                    <span class="icon icon-close">×</span>
-
-
+                <button type="button"
+                        class="navbar-toggle collapsed"
+                        data-toggle="offcanvas"
+                        data-target="#navbar-offcanvas"
+                        aria-label="Toggle navigation">
+                    <span class="text-primary glyphicon glyphicon-menu-hamburger icon-open"></span>
+                    <span class="text-primary glyphicon glyphicon-remove icon-close"></span>
                 </button>
                 <a class="navbar-brand" href="{{ url('/') }}">
                     <span class="icon-icon_angel"></span>


### PR DESCRIPTION
- Adds an additional bottom padding to the mobile navigation.
Safari adds a bottom bar hiding parts of the menu.  
With the padding the logout menu item is fully displayed and clickable.
- Improves the menu toggle button layout.

Fixes #792 