### PR TITLE
Allow specifying the deadline for signup in terms of shift length

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -146,8 +146,15 @@ return [
     // Setting this to 0 disables the feature
     'signup_advance_hours'    => env('SIGNUP_ADVANCE_HOURS', 0),
 
-    // Allow signup this many minutes after the start of the shift
+    // Allow signup this many minutes after the start of the shift.
+    // If signup_post_fraction is set, first applies that before adding the number of minutes specified by this.
     'signup_post_minutes'     => env('SIGNUP_POST_MINUTES', 0),
+
+    // Allow signup this fraction of the shift length after the start of the shift.
+    // Example: If this is set to 1, signup is allowed until the end of a shift
+    //          If this is set to 0.5, signup is allowd for the first half of a shift
+    // If signup_post_minutes is set, first applies this and then adds the signup_post_minutes on top.
+    'signup_post_fraction'    => env('SIGNUP_POST_FRACTION', 0),
 
     // Number of hours that an angel has to sign out own shifts
     'last_unsubscribe'        => env('LAST_UNSUBSCRIBE', 3),

--- a/includes/model/Shifts_model.php
+++ b/includes/model/Shifts_model.php
@@ -358,7 +358,9 @@ function Shift_signup_allowed_angel(
         return new ShiftSignupState(ShiftSignupState::SIGNED_UP, $free_entries);
     }
 
-    if (time() > $shift['start'] + config('signup_post_minutes') * 60) {
+    $shift_post_signup_total_allowed_seconds = (config('signup_post_fraction') * ($shift['end'] - $shift['start'])) + (config('signup_post_minutes') * 60);
+
+    if (time() > $shift['start'] + $shift_post_signup_total_allowed_seconds) {
         // you can only join if the shift is in future
         return new ShiftSignupState(ShiftSignupState::SHIFT_ENDED, $free_entries);
     }


### PR DESCRIPTION
Allow finer control over the specification of the
time after shift start where signup is still allowed.

The new config field is multiplied by the shift duration,
and the result added to the start time to determine the
time when signup is closed.

The existing signup_post_minutes is just added to the time
calculated by this new feature.

The feature is useful when the signup should be allowed
not just a few minutes after shift start but for a larger part
of the shift (like for half of the shift).
With the previous option it would not make sense to allow a late signup
longer than the shortest shift of the event.

This is a follow-up to a50dd9cae09f0167c6ece831d99b975ac5b4af4a (which is part of #752)