### PR TITLE
Allow password-less registration

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -108,6 +108,8 @@ return [
             'hidden' => false,
             // Mark user as arrived when using this provider (optional)
             'mark_arrived' => false,
+            // If the password field should be enabled on registration (optional)
+            'enable_password' => false,
             // Allow registration even if disabled in config (optional)
             'allow_registration' => null,
             // Auto join teams

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -245,8 +245,8 @@ return [
     'min_password_length'     => env('PASSWORD_MINIMUM_LENGTH', 8),
 
     // Whether the Password field should be enabled on registration.
-    // If this is disabled, it means that no password can be set on registration so the user will
-    // not be able to log in unless linked to an oauth provider.
+    // This is useful when using oauth, disabling it also disables normal
+    // registration without oauth.
     'enable_password'         => (bool)env('ENABLE_PASSWORD', true),
 
     // Whether the DECT field should be enabled

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -244,6 +244,11 @@ return [
     // The minimum length for passwords
     'min_password_length'     => env('PASSWORD_MINIMUM_LENGTH', 8),
 
+    // Whether the Password field should be enabled.
+    // If this is disabled, it means that no password can be set and the user will
+    // not be able to log in unless linked to an oauth provider.
+    'enable_password'         => (bool)env('ENABLE_PASSWORD', true),
+
     // Whether the DECT field should be enabled
     'enable_dect'             => (bool)env('ENABLE_DECT', true),
 

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -244,8 +244,8 @@ return [
     // The minimum length for passwords
     'min_password_length'     => env('PASSWORD_MINIMUM_LENGTH', 8),
 
-    // Whether the Password field should be enabled.
-    // If this is disabled, it means that no password can be set and the user will
+    // Whether the Password field should be enabled on registration.
+    // If this is disabled, it means that no password can be set on registration so the user will
     // not be able to log in unless linked to an oauth provider.
     'enable_password'         => (bool)env('ENABLE_PASSWORD', true),
 

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -37,6 +37,7 @@ function guest_register()
     $config = config();
     $request = request();
     $session = session();
+    $is_oauth = $session->has('oauth2_connect_provider');
 
     $msg = '';
     $nick = '';
@@ -76,8 +77,10 @@ function guest_register()
     }
 
     if (
-        !auth()->can('register')
-        || (!$authUser && !config('registration_enabled') && !$session->get('oauth2_allow_registration'))
+        !auth()->can('register') // No registration permission
+        // Not authenticated and
+        || (!$authUser && !config('registration_enabled') && !$session->get('oauth2_allow_registration')) // Registration disabled
+        || (!$authUser && !$enable_password && !$is_oauth) // Password disabled and not oauth
     ) {
         error(__('Registration is disabled.'));
 

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -76,6 +76,11 @@ function guest_register()
         }
     }
 
+    $oauth_enable_password = $session->get('oauth2_enable_password');
+    if (!is_null($oauth_enable_password)) {
+        $enable_password = $oauth_enable_password;
+    }
+
     if (
         !auth()->can('register') // No registration permission
         // Not authenticated and

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -32,6 +32,7 @@ function guest_register()
     $enable_dect = config('enable_dect');
     $enable_planned_arrival = config('enable_planned_arrival');
     $min_password_length = config('min_password_length');
+    $enable_password = config('enable_password');
     $enable_pronoun = config('enable_pronoun');
     $config = config();
     $request = request();
@@ -146,12 +147,12 @@ function guest_register()
             }
         }
 
-        if ($request->has('password') && strlen($request->postData('password')) >= $min_password_length) {
+        if ($enable_password && $request->has('password') && strlen($request->postData('password')) >= $min_password_length) {
             if ($request->postData('password') != $request->postData('password2')) {
                 $valid = false;
                 $msg .= error(__('Your passwords don\'t match.'), true);
             }
-        } else {
+        } else if ($enable_password) {
             $valid = false;
             $msg .= error(sprintf(
                 __('Your password is too short (please use at least %s characters).'),
@@ -272,7 +273,9 @@ function guest_register()
 
             // Assign user-group and set password
             DB::insert('INSERT INTO `UserGroups` (`uid`, `group_id`) VALUES (?, -20)', [$user->id]);
-            auth()->setPassword($user, $request->postData('password'));
+            if ($enable_password) {
+                auth()->setPassword($user, $request->postData('password'));
+            }
 
             // Assign angel-types
             $user_angel_types_info = [];
@@ -397,14 +400,14 @@ function guest_register()
                                 ) : '',
                         ])
                     ]),
-                    div('row', [
+                    $enable_password ? div('row', [
                         div('col-sm-6', [
                             form_password('password', __('Password') . ' ' . entry_required())
                         ]),
                         div('col-sm-6', [
                             form_password('password2', __('Confirm password') . ' ' . entry_required())
                         ])
-                    ]),
+                    ]) : '',
                     div('row', [
                         $enable_planned_arrival ? div('col-sm-6', [
                             form_date(

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -188,6 +188,9 @@ msgstr "Passwort vergessen"
 msgid "Please sign up, if you want to help us!"
 msgstr "Bitte registriere Dich, wenn Du helfen möchtest!"
 
+msgid "Registration is only available via external login."
+msgstr "Die Registrierung ist nur über einen externen Login möglich."
+
 #: resources/views/pages/login.twig:90 includes/pages/guest_login.php:61
 msgid "Registration is disabled."
 msgstr "Registrierung ist abgeschaltet."

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -21,6 +21,7 @@ msgstr ""
 
 #~ msgid "auth.no-password"
 #~ msgstr "Please enter a password."
+
 msgid "auth.password.error"
 msgstr "Your password is incorrect. Please try it again."
 

--- a/resources/views/pages/login.twig
+++ b/resources/views/pages/login.twig
@@ -100,8 +100,12 @@
             <div class="col-sm-6 text-center">
                 <h2>{{ __('Register') }}</h2>
                 {% if has_permission_to('register') and config('registration_enabled') %}
-                    <p>{{ __('Please sign up, if you want to help us!') }}</p>
-                    <a href="{{ url('register') }}" class="btn btn-primary">{{ __('Register') }} &raquo;</a>
+                    {% if config('enable_password') %}
+                        <p>{{ __('Please sign up, if you want to help us!') }}</p>
+                        <a href="{{ url('register') }}" class="btn btn-primary">{{ __('Register') }} &raquo;</a>
+                    {% else %}
+                        <p>{{ __('Registration is only available via external login.') }}</p>
+                    {% endif %}
                 {% else %}
                     {{ m.alert(__('Registration is disabled.'), 'danger') }}
                 {% endif %}

--- a/resources/views/pages/settings/password.twig
+++ b/resources/views/pages/settings/password.twig
@@ -11,12 +11,15 @@
             <div class="row">
                 <div class="col-md-12">
                     {{ m.info(__('settings.password.info')) }}
-                    {{ f.input(
-                        'password',
-                        __('settings.password.password'),
-                        'password',
-                        {'required': true}
-                    ) }}
+
+                    {% if user.password %}
+                        {{ f.input(
+                            'password',
+                            __('settings.password.password'),
+                            'password',
+                            {'required': true}
+                        ) }}
+                    {% endif %}
                     {{ f.input(
                         'new_password',
                         __('settings.password.new_password'),

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -372,6 +372,7 @@ class OAuthController extends BaseController
                 'email'              => null,
                 'first_name'         => null,
                 'last_name'          => null,
+                'enable_password'    => false,
                 'allow_registration' => null,
                 'groups'             => null,
             ],
@@ -400,6 +401,7 @@ class OAuthController extends BaseController
         $this->session->set('oauth2_access_token', $accessToken->getToken());
         $this->session->set('oauth2_refresh_token', $accessToken->getRefreshToken());
         $this->session->set('oauth2_expires_at', $expirationTime);
+        $this->session->set('oauth2_enable_password', $config['enable_password']);
         $this->session->set('oauth2_allow_registration', $config['allow_registration']);
 
         return $this->redirector->to('/register');

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -77,12 +77,12 @@ class SettingsController extends BaseController
 
         $minLength = config('min_password_length');
         $data = $this->validate($request, [
-            'password'      => 'required',
+            'password'      => 'required' . (empty($user->password) ? '|optional' : ''),
             'new_password'  => 'required|min:' . $minLength,
-            'new_password2' => 'required'
+            'new_password2' => 'required',
         ]);
 
-        if (!$this->auth->verifyPassword($user, $data['password'])) {
+        if (!empty($user->password) && !$this->auth->verifyPassword($user, $data['password'])) {
             $this->addNotification('auth.password.error', 'errors');
         } elseif ($data['new_password'] != $data['new_password2']) {
             $this->addNotification('validation.password.confirmed', 'errors');

--- a/tests/Unit/Controllers/OAuthControllerTest.php
+++ b/tests/Unit/Controllers/OAuthControllerTest.php
@@ -427,6 +427,7 @@ class OAuthControllerTest extends TestCase
         $this->assertEquals('test-token', $this->session->get('oauth2_access_token'));
         $this->assertEquals('test-refresh-token', $this->session->get('oauth2_refresh_token'));
         $this->assertEquals(4242424242, $this->session->get('oauth2_expires_at')->unix());
+        $this->assertFalse($this->session->get('oauth2_enable_password'));
         $this->assertEquals(null, $this->session->get('oauth2_allow_registration'));
         $this->assertEquals(
             [

--- a/tests/Unit/Controllers/SettingsControllerTest.php
+++ b/tests/Unit/Controllers/SettingsControllerTest.php
@@ -102,6 +102,36 @@ class SettingsControllerTest extends TestCase
     /**
      * @covers \Engelsystem\Controllers\SettingsController::savePassword
      */
+    public function testSavePasswordWhenEmpty()
+    {
+        $this->user->password = '';
+        $this->user->save();
+
+        $body = [
+            'new_password'  => 'anotherpassword',
+            'new_password2' => 'anotherpassword'
+        ];
+        $this->request = $this->request->withParsedBody($body);
+
+        $this->setExpects($this->auth, 'user', null, $this->user, $this->once());
+        $this->setExpects($this->auth, 'setPassword', [$this->user, 'anotherpassword'], null, $this->once());
+        $this->setExpects(
+            $this->response,
+            'redirectTo',
+            ['http://localhost/settings/password'],
+            $this->response,
+            $this->once()
+        );
+
+        /** @var SettingsController $controller */
+        $controller = $this->app->make(SettingsController::class);
+        $controller->setValidator(new Validator());
+        $controller->savePassword($this->request);
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\SettingsController::savePassword
+     */
     public function testSavePasswordWrongOldPassword()
     {
         $body = [


### PR DESCRIPTION
Introduce a configuration option that, when unset, causes registration to not require setting a password. Users registered without a password will not be able to login unless through SSO.

A possible follow-up would be to only enforce this in the oauth2 registration flow, but still require a password to be set when registering without SSO.

closes #844 