### PR TITLE
Added OAuth2 SSO login group mapping and support for nested info attributes

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -66,5 +66,7 @@ return [
         //      or $function
         // ]
         'news.created' => \Engelsystem\Events\Listener\News::class . '@created',
+
+        'oauth2.login' => \Engelsystem\Events\Listener\OAuth2::class . '@login',
     ],
 ];

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -98,6 +98,9 @@ return [
             'last_name' => 'last-name',
             // User URL to provider, linked on provider settings page (optional)
             'url' => '[provider page]',
+            // Whether info attributes are nested arrays (optional)
+            // For example {"user":{"name":"foo"}} can be accessed using user.name
+            'nested_info' => false,
             // Only show after clicking the page title (optional)
             'hidden' => false,
             // Mark user as arrived when using this provider (optional)

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -96,12 +96,14 @@ return [
             'first_name' => 'first-name',
             // Info last name field (optional)
             'last_name' => 'last-name',
-            // User URL to provider, shown on provider settings page (optional)
+            // User URL to provider, linked on provider settings page (optional)
             'url' => '[provider page]',
             // Only show after clicking the page title (optional)
             'hidden' => false,
             // Mark user as arrived when using this provider (optional)
             'mark_arrived' => false,
+            // Allow registration even if disabled in config (optional)
+            'allow_registration' => null,
             // Auto join teams
             // Info groups field (optional)
             'groups' => 'groups',

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -102,6 +102,14 @@ return [
             'hidden' => false,
             // Mark user as arrived when using this provider (optional)
             'mark_arrived' => false,
+            // Auto join teams
+            // Info groups field (optional)
+            'groups' => 'groups',
+            // Groups to team (angeltype) mapping (optional)
+            'teams' => [
+                '/Lorem' => 4, // 4 being the ID of the angeltype
+                '/Foo Mod' => ['id' => 5, 'supporter' => true], // 5 being the ID of the angeltype
+            ],
         ],
         */
     ],

--- a/includes/helper/oauth_helper.php
+++ b/includes/helper/oauth_helper.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Engelsystem\Events\Listener;
+
+use Engelsystem\Config\Config;
+use Engelsystem\Database\Database;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Psr\Log\LoggerInterface;
+
+class OAuth2
+{
+    /** @var array */
+    protected $config;
+
+    /** @var LoggerInterface */
+    protected $log;
+
+    /**
+     * @param Config          $config
+     * @param LoggerInterface $log
+     */
+    public function __construct(Config $config, LoggerInterface $log)
+    {
+        $this->config = $config->get('oauth');
+        $this->log = $log;
+    }
+
+    /**
+     * @param string     $event
+     * @param string     $provider
+     * @param Collection $data OAuth userdata
+     */
+    public function login(string $event, string $provider, Collection $data)
+    {
+        /** @var Database $db */
+        $db = app(Database::class);
+        $ssoTeams = $this->getSsoTeams($provider);
+        $user = auth()->user();
+        $currentUserAngeltypes = collect($db->select('SELECT * FROM UserAngelTypes WHERE user_id = ?', [$user->id]));
+        $userGroups = $data->get(($this->config[$provider] ?? [])['groups'] ?? 'groups', []);
+
+        foreach ($userGroups as $groupName) {
+            if (!isset($ssoTeams[$groupName])) {
+                continue;
+            }
+
+            $team = $ssoTeams[$groupName];
+            $userAngeltype = $currentUserAngeltypes->where('angeltype_id', $team['id'])->first();
+            $supporter = $team['supporter'];
+            $confirmed = $supporter ? $user->id : null;
+
+            if (!$userAngeltype) {
+                $this->log->info(
+                    'SSO {provider}: Added to angeltype {angeltype}, confirmed: {confirmed}, supporter: {supporter}',
+                    [
+                        'provider'  => $provider,
+                        'angeltype' => AngelType($team['id'])['name'],
+                        'confirmed'   => $confirmed ? 'yes' : 'no',
+                        'supporter' => $supporter ? 'yes' : 'no',
+                    ]
+                );
+                $db->insert(
+                    'INSERT INTO UserAngelTypes (user_id, angeltype_id, confirm_user_id, supporter) VALUES (?, ?, ?, ?)',
+                    [$user->id, $team['id'], $confirmed, $supporter]
+                );
+
+                continue;
+            }
+
+            if (!$supporter) {
+                continue;
+            }
+
+            if ($userAngeltype->supporter != $supporter) {
+                $db->update(
+                    'UPDATE UserAngelTypes SET supporter=? WHERE id = ?',
+                    [$supporter, $userAngeltype->id]
+                );
+                $this->log->info(
+                    'SSO {provider}: Set supporter state for angeltype {angeltype}',
+                    [
+                        'provider'  => $provider,
+                        'angeltype' => AngelType($userAngeltype->angeltype_id)['name'],
+                    ]
+                );
+            }
+
+            if (!$userAngeltype->confirm_user_id) {
+                $db->update(
+                    'UPDATE UserAngelTypes SET confirm_user_id=? WHERE id = ?',
+                    [$user->id, $userAngeltype->id]
+                );
+                $this->log->info(
+                    'SSO {provider}: Set confirmed state for angeltype {angeltype}',
+                    [
+                        'provider'  => $provider,
+                        'angeltype' => AngelType($userAngeltype->angeltype_id)['name'],
+                    ]
+                );
+            }
+        }
+    }
+
+    /**
+     * @param string $provider
+     * @return array
+     */
+    public function getSsoTeams(string $provider): array
+    {
+        $config = $this->config[$provider] ?? [];
+
+        $teams = [];
+        foreach ($config['teams'] ?? [] as $ssoName => $conf) {
+            $conf = Arr::wrap($conf);
+            $teamId = $conf['id'] ?? $conf[0];
+            $isSupporter = $conf['supporter'] ?? false;
+
+            $teams[$ssoName] = ['id' => $teamId, 'supporter' => $isSupporter];
+        }
+
+        return $teams;
+    }
+}

--- a/includes/includes.php
+++ b/includes/includes.php
@@ -60,6 +60,7 @@ $includeFiles = [
     __DIR__ . '/../includes/helper/legacy_helper.php',
     __DIR__ . '/../includes/helper/message_helper.php',
     __DIR__ . '/../includes/helper/email_helper.php',
+    __DIR__ . '/../includes/helper/oauth_helper.php',
 
     __DIR__ . '/../includes/mailer/shifts_mailer.php',
     __DIR__ . '/../includes/mailer/users_mailer.php',

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Engelsystem\Database\DB;
+use Engelsystem\Events\Listener\OAuth2;
 use Engelsystem\Models\OAuth;
 use Engelsystem\Models\User\Contact;
 use Engelsystem\Models\User\PersonalData;
@@ -54,6 +55,16 @@ function guest_register()
 
     $angel_types_source = AngelTypes();
     $angel_types = [];
+    if (!empty($session->get('oauth2_groups'))) {
+        /** @var OAuth2 $oauth */
+        $oauth = app()->get(OAuth2::class);
+        $ssoTeams = $oauth->getSsoTeams($session->get('oauth2_connect_provider'));
+        foreach ($ssoTeams as $name => $team) {
+            if (in_array($name, $session->get('oauth2_groups'))) {
+                $selected_angel_types[] = $team['id'];
+            }
+        }
+    }
     foreach ($angel_types_source as $angel_type) {
         $angel_types[$angel_type['id']] = $angel_type['name']
             . ($angel_type['restricted'] ? ' (' . __('Requires introduction') . ')' : '');

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -73,7 +73,10 @@ function guest_register()
         }
     }
 
-    if (!auth()->can('register') || (!$authUser && !config('registration_enabled'))) {
+    if (
+        !auth()->can('register')
+        || (!$authUser && !config('registration_enabled') && !$session->get('oauth2_allow_registration'))
+    ) {
         error(__('Registration is disabled.'));
 
         return page_with_title(register_title(), [

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -861,6 +861,10 @@ function User_oauth_render(User $user)
         );
     }
 
+    if (!$output) {
+        return '';
+    }
+
     return div('col-md-2', [
         heading(__('OAuth'), 4),
         join('<br>', $output),

--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -223,6 +223,9 @@ $(function () {
     $('#welcome-title').on('click', function () {
         $('.btn-group.btn-group .btn.d-none').removeClass('d-none');
     });
+    $('#settings-title').on('click', function () {
+        $('.user-settings .nav-item').removeClass('d-none');
+    });
     $('#oauth-settings-title').on('click', function () {
         $('table tr.d-none').removeClass('d-none');
     });

--- a/resources/views/pages/settings/settings.twig
+++ b/resources/views/pages/settings/settings.twig
@@ -6,7 +6,7 @@
 {% block content %}
     <div class="container user-settings">
         {% block container_title %}
-            <h1>
+            <h1 id="settings-title">
                 {{ __('settings.settings') }}
                 <small class="text-muted">{{ block('title') }}</small>
             </h1>
@@ -14,10 +14,12 @@
 
         <div class="row">
             <div class="col-md-3 settings-menu">
-                <ul class="nav nav-pills flex-column mt-3">
+                <ul class="nav nav-pills flex-column mt-3 user-settings">
                     {% for url,title in settings_menu %}
-                        <li class="nav-item">
-                            <a class="nav-link {% if url == request.url() %}active{% endif %}" href="{{ url }}">{{ __(title) }}</a>
+                        <li class="nav-item{% if title.hidden ?? false and url != request.url() %} d-none{% endif %}">
+                            <a class="nav-link {% if url == request.url() %}active{% endif %}" href="{{ url }}">
+                                {{ __(title.title ?? title) }}
+                            </a>
                         </li>
                     {% endfor %}
                 </ul>

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -175,10 +175,6 @@ class OAuthController extends BaseController
         $config = $this->config->get('oauth')[$providerName];
         $userdata = new Collection($resourceOwner->toArray());
         if (!$oauth) {
-            if (!$this->config->get('registration_enabled')) {
-                throw new HttpNotFound('oauth.not-found');
-            }
-
             return $this->redirectRegister(
                 $providerName,
                 $resourceOwner->getId(),
@@ -349,9 +345,21 @@ class OAuthController extends BaseController
         Collection $userdata
     ): Response {
         $config = array_merge(
-            ['username' => null, 'email' => null, 'first_name' => null, 'last_name' => null, 'groups' => null],
+            [
+                'username'           => null,
+                'email'              => null,
+                'first_name'         => null,
+                'last_name'          => null,
+                'allow_registration' => null,
+                'groups'             => null,
+            ],
             $config
         );
+
+        if (!$this->config->get('registration_enabled') && !$config['allow_registration']) {
+            throw new HttpNotFound('oauth.not-found');
+        }
+
         $this->session->set(
             'form_data',
             [
@@ -370,6 +378,7 @@ class OAuthController extends BaseController
         $this->session->set('oauth2_access_token', $accessToken->getToken());
         $this->session->set('oauth2_refresh_token', $accessToken->getRefreshToken());
         $this->session->set('oauth2_expires_at', $expirationTime);
+        $this->session->set('oauth2_allow_registration', $config['allow_registration']);
 
         return $this->redirector->to('/register');
     }

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -61,7 +61,7 @@ class SettingsController extends BaseController
             'pages/settings/password',
             [
                 'settings_menu' => $this->settingsMenu(),
-                'min_length' => config('min_password_length')
+                'min_length'    => config('min_password_length')
 
             ] + $this->getNotifications()
         );
@@ -77,8 +77,8 @@ class SettingsController extends BaseController
 
         $minLength = config('min_password_length');
         $data = $this->validate($request, [
-            'password' => 'required',
-            'new_password' => 'required|min:' . $minLength,
+            'password'      => 'required',
+            'new_password'  => 'required|min:' . $minLength,
             'new_password2' => 'required'
         ]);
 
@@ -110,7 +110,7 @@ class SettingsController extends BaseController
             'pages/settings/oauth',
             [
                 'settings_menu' => $this->settingsMenu(),
-                'providers' => $providers,
+                'providers'     => $providers,
             ] + $this->getNotifications(),
         );
     }
@@ -121,13 +121,28 @@ class SettingsController extends BaseController
     public function settingsMenu(): array
     {
         $menu = [
-            url('/user-settings') => 'settings.profile',
+            url('/user-settings')     => 'settings.profile',
             url('/settings/password') => 'settings.password'
         ];
+
         if (!empty(config('oauth'))) {
-            $menu[url('/settings/oauth')] = 'settings.oauth';
+            $menu[url('/settings/oauth')] = ['title' => 'settings.oauth', 'hidden' => $this->checkOauthHidden()];
         }
 
         return $menu;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function checkOauthHidden(): bool
+    {
+        foreach (config('oauth') as $config) {
+            if (empty($config['hidden']) || !$config['hidden']) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Unit/Controllers/OAuthControllerTest.php
+++ b/tests/Unit/Controllers/OAuthControllerTest.php
@@ -428,6 +428,7 @@ class OAuthControllerTest extends TestCase
         $this->assertEquals('test-token', $this->session->get('oauth2_access_token'));
         $this->assertEquals('test-refresh-token', $this->session->get('oauth2_refresh_token'));
         $this->assertEquals(4242424242, $this->session->get('oauth2_expires_at')->unix());
+        $this->assertEquals(null, $this->session->get('oauth2_allow_registration'));
         $this->assertEquals(
             [
                 'name' => 'username',

--- a/tests/Unit/Controllers/SettingsControllerTest.php
+++ b/tests/Unit/Controllers/SettingsControllerTest.php
@@ -250,10 +250,12 @@ class SettingsControllerTest extends TestCase
 
     /**
      * @covers \Engelsystem\Controllers\SettingsController::settingsMenu
+     * @covers \Engelsystem\Controllers\SettingsController::checkOauthHidden
      */
     public function testSettingsMenuWithOAuth()
     {
         $providers = ['foo' => ['lorem' => 'ipsum']];
+        $providersHidden = ['foo' => ['lorem' => 'ipsum', 'hidden' => true]];
         config(['oauth' => $providers]);
 
         /** @var SettingsController $controller */
@@ -262,7 +264,14 @@ class SettingsControllerTest extends TestCase
         $this->assertEquals([
             'http://localhost/user-settings' => 'settings.profile',
             'http://localhost/settings/password' => 'settings.password',
-            'http://localhost/settings/oauth' => 'settings.oauth'
+            'http://localhost/settings/oauth' => ['title' => 'settings.oauth', 'hidden' => false]
+        ], $controller->settingsMenu());
+
+        config(['oauth' => $providersHidden]);
+        $this->assertEquals([
+            'http://localhost/user-settings' => 'settings.profile',
+            'http://localhost/settings/password' => 'settings.password',
+            'http://localhost/settings/oauth' => ['title' => 'settings.oauth', 'hidden' => true]
         ], $controller->settingsMenu());
     }
 

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -27,6 +27,10 @@ abstract class TestCase extends PHPUnitTestCase
             $times = $this->once();
         }
 
+        if (is_int($times)) {
+            $times = $this->exactly($times);
+        }
+
         $invocation = $object->expects($times)
             ->method($method);
 


### PR DESCRIPTION
Resolves #826  (Extend SSO config to be able to add users to Angeltypes & set supporter rights).

* Allows a mapping of SSO groups to angeltypes and optional supporter rights for those
* Hides the SSO settings tab in profile if all are configured as hidden and hides the OAuth section from the profile if no OAuth is configured
* Added the option to allow registration via SSO even if registration by itself is disabled in config
* Allow info attributes to be accessed from nested arrays
  ```php
    # Info data
    [
        'ocs' => [
            'id' => 'foobar'.
            'email' => 'foo@bar.baz'.
        ]
    ]

    # Config
     'nextcloud' => [
            'name' => 'Nextcloud',
            'client_id' => '[client id]',
            'client_secret' => '[client secret',
            'url_auth' => 'https://cloud.example.com/apps/oauth2/authorize',
            'url_token' => 'https://cloud.example.com/apps/oauth2/api/v1/token',
            'url_info' => 'https://cloud.example.com/ocs/v2.php/cloud/user?format=json',
            'nested_info' => true,
            'id' => 'ocs.data.id',
            'username' => 'ocs.data.id',
            'email' => 'ocs.data.email',
        ],
  ``` 