### PR TITLE
markdown: let Parsedown escape content

### DIFF
--- a/db/migrations/2021_12_30_000000_remove_admin_news_html_privilege.php
+++ b/db/migrations/2021_12_30_000000_remove_admin_news_html_privilege.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+
+class RemoveAdminNewsHtmlPrivilege extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up()
+    {
+        if (!$this->schema->hasTable('GroupPrivileges')) {
+            return;
+        }
+
+        $connection = $this->schema->getConnection();
+
+        // Delete unused privileges
+        $connection->delete('
+                DELETE FROM `Privileges`
+                WHERE `name` = \'admin_news_html\'
+            ');
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down()
+    {
+        if (!$this->schema->hasTable('GroupPrivileges')) {
+            return;
+        }
+
+        $connection->insert('
+                INSERT INTO `Privileges` (`name`, `desc`)
+                VALUES (\'admin_news_html\', \'Use HTML in news\')
+            ');
+    }
+}

--- a/db/migrations/2021_12_30_000000_remove_admin_news_html_privilege.php
+++ b/db/migrations/2021_12_30_000000_remove_admin_news_html_privilege.php
@@ -17,11 +17,11 @@ class RemoveAdminNewsHtmlPrivilege extends Migration
 
         $connection = $this->schema->getConnection();
 
-        // Delete unused privileges
-        $connection->delete('
-                DELETE FROM `Privileges`
-                WHERE `name` = \'admin_news_html\'
-            ');
+        // Delete unused privilege
+        $connection->delete(
+            'DELETE FROM `Privileges` WHERE `name` = ?',
+            ['admin_news_html']
+        );
     }
 
     /**
@@ -33,9 +33,19 @@ class RemoveAdminNewsHtmlPrivilege extends Migration
             return;
         }
 
-        $connection->insert('
-                INSERT INTO `Privileges` (`name`, `desc`)
-                VALUES (\'admin_news_html\', \'Use HTML in news\')
-            ');
+        $connection = $this->schema->getConnection();
+        $connection->insert(
+            'INSERT INTO `Privileges` (`name`, `desc`) VALUES (?, ?)',
+            ['admin_news_html', 'Use HTML in news']
+        );
+
+        // Add permissions to news admins to edit html news
+        $connection->insert(
+            '
+                INSERT IGNORE INTO GroupPrivileges (group_id, privilege_id)
+                VALUES ((SELECT UID FROM `Groups` WHERE `name` = ?), (SELECT id FROM `Privileges` WHERE `name` = ?))
+            ',
+            ['News Admin', 'admin_news_html']
+        );
     }
 }

--- a/resources/lang/de_DE/additional.po
+++ b/resources/lang/de_DE/additional.po
@@ -86,11 +86,6 @@ msgstr "News erfolgreich aktualisiert."
 msgid "news.delete.success"
 msgstr "News erfolgreich gelöscht."
 
-msgid "news.edit.contains-html"
-msgstr ""
-"Diese Nachricht beinhaltet HTML. Wenn du sie speicherst gehen diese "
-"Formatierungen verloren!"
-
 msgid "oauth.invalid-state"
 msgstr "Ungültiger OAuth-Status"
 

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -84,9 +84,6 @@ msgstr "News successfully updated."
 msgid "news.delete.success"
 msgstr "News successfully deleted."
 
-msgid "news.edit.contains-html"
-msgstr "This message contains HTML. After saving the post some formatting will be lost!"
-
 msgid "oauth.invalid-state"
 msgstr "Invalid OAuth state"
 

--- a/resources/views/pages/news/edit.twig
+++ b/resources/views/pages/news/edit.twig
@@ -73,7 +73,7 @@
                                 {{ news.title }}
                             </div>
                             <div class="card-body bg-body">
-                                {{ news.text|raw|markdown(false) }}
+                                {{ news.text|markdown }}
                             </div>
                         </div>
                     </div>

--- a/resources/views/pages/news/overview.twig
+++ b/resources/views/pages/news/overview.twig
@@ -60,7 +60,7 @@
         {% endif %}
 
         <div class="card-body bg-body">
-            {{ news.text(not is_overview)|raw|markdown(false) }}
+            {{ news.text(not is_overview)|markdown }}
             {% if is_overview and news.text != news.text(false) %}
                 {{ m.button(__('news.read_more'), url('news/' ~ news.id), null, 'sm', null, null, 'chevron-double-right') }}
             {% endif %}

--- a/src/Controllers/Admin/NewsController.php
+++ b/src/Controllers/Admin/NewsController.php
@@ -80,14 +80,6 @@ class NewsController extends BaseController
      */
     protected function showEdit(?News $news, bool $isMeetingDefault = false): Response
     {
-        if (
-            $news
-            && !$this->auth->can('admin_news_html')
-            && strip_tags($news->text) != $news->text
-        ) {
-            $this->addNotification('news.edit.contains-html', 'warnings');
-        }
-
         if ($news) {
             $this->cleanupModelNullValues($news);
         }
@@ -136,10 +128,6 @@ class NewsController extends BaseController
             $this->addNotification('news.delete.success');
 
             return $this->redirect->to('/news');
-        }
-
-        if (!$this->auth->can('admin_news_html')) {
-            $data['text'] = strip_tags($data['text']);
         }
 
         if (!$news->user) {

--- a/src/Renderer/Twig/Extensions/Markdown.php
+++ b/src/Renderer/Twig/Extensions/Markdown.php
@@ -40,10 +40,6 @@ class Markdown extends TwigExtension
      */
     public function render(string $text, bool $escapeHtml = true): string
     {
-        if ($escapeHtml) {
-            $text = htmlspecialchars($text);
-        }
-
-        return $this->renderer->text($text);
+        return $this->renderer->setSafeMode($escapeHtml)->text($text);
     }
 }

--- a/tests/Unit/Controllers/Admin/NewsControllerTest.php
+++ b/tests/Unit/Controllers/Admin/NewsControllerTest.php
@@ -31,6 +31,7 @@ class NewsControllerTest extends ControllerTest
     /**
      * @covers \Engelsystem\Controllers\Admin\NewsController::__construct
      * @covers \Engelsystem\Controllers\Admin\NewsController::edit
+     * @covers \Engelsystem\Controllers\Admin\NewsController::showEdit
      */
     public function testEdit()
     {

--- a/tests/Unit/Controllers/Admin/NewsControllerTest.php
+++ b/tests/Unit/Controllers/Admin/NewsControllerTest.php
@@ -23,39 +23,10 @@ class NewsControllerTest extends ControllerTest
     protected $data = [
         [
             'title'      => 'Foo',
-            'text'       => '<b>foo</b>',
-            'is_meeting' => false,
+            'text'       => '**foo**',
             'user_id'    => 1,
         ]
     ];
-
-    /**
-     * @covers \Engelsystem\Controllers\Admin\NewsController::edit
-     * @covers \Engelsystem\Controllers\Admin\NewsController::showEdit
-     */
-    public function testEditHtmlWarning()
-    {
-        $this->request->attributes->set('id', 1);
-        $this->response->expects($this->once())
-            ->method('withView')
-            ->willReturnCallback(function ($view, $data) {
-                $this->assertEquals('pages/news/edit.twig', $view);
-
-                /** @var Collection $warnings */
-                $warnings = $data['warnings'];
-                $this->assertNotEmpty($data['news']);
-                $this->assertTrue($warnings->isNotEmpty());
-                $this->assertEquals('news.edit.contains-html', $warnings->first());
-
-                return $this->response;
-            });
-        $this->addUser();
-
-        /** @var NewsController $controller */
-        $controller = $this->app->make(NewsController::class);
-
-        $controller->edit($this->request);
-    }
 
     /**
      * @covers \Engelsystem\Controllers\Admin\NewsController::__construct
@@ -76,10 +47,6 @@ class NewsControllerTest extends ControllerTest
 
                 return $this->response;
             });
-        $this->auth->expects($this->once())
-            ->method('can')
-            ->with('admin_news_html')
-            ->willReturn(true);
 
         /** @var NewsController $controller */
         $controller = $this->app->make(NewsController::class);
@@ -103,10 +70,6 @@ class NewsControllerTest extends ControllerTest
                     return $this->response;
                 }
             );
-        $this->auth->expects($this->once())
-            ->method('can')
-            ->with('admin_news_html')
-            ->willReturn(true);
 
         /** @var NewsController $controller */
         $controller = $this->app->make(NewsController::class);
@@ -142,10 +105,10 @@ class NewsControllerTest extends ControllerTest
     public function saveCreateEditProvider(): array
     {
         return [
-            ['Some <b>test</b>', true, true, 'Some <b>test</b>'],
-            ['Some <b>test</b>', false, false, 'Some test'],
-            ['Some <b>test</b>', false, true, 'Some <b>test</b>', 1],
-            ['Some <b>test</b>', true, false, 'Some test', 1],
+            ['Some test', true],
+            ['Some test', false],
+            ['Some test', false, 1],
+            ['Some test', true, 1],
         ];
     }
 
@@ -155,15 +118,11 @@ class NewsControllerTest extends ControllerTest
      *
      * @param string $text
      * @param bool $isMeeting
-     * @param bool $canEditHtml
-     * @param string $result
      * @param int|null $id
      */
     public function testSaveCreateEdit(
         string $text,
         bool $isMeeting,
-        bool $canEditHtml,
-        string $result,
         int $id = null
     ) {
         $this->request->attributes->set('id', $id);
@@ -178,10 +137,6 @@ class NewsControllerTest extends ControllerTest
 
         $this->request = $this->request->withParsedBody($body);
         $this->addUser();
-        $this->auth->expects($this->once())
-            ->method('can')
-            ->with('admin_news_html')
-            ->willReturn($canEditHtml);
         $this->response->expects($this->once())
             ->method('redirectTo')
             ->with('http://localhost/news')
@@ -201,7 +156,7 @@ class NewsControllerTest extends ControllerTest
         $this->assertEquals('news.edit.success', $messages[0]);
 
         $news = (new News())->find($id);
-        $this->assertEquals($result, $news->text);
+        $this->assertEquals($text, $news->text);
         $this->assertEquals($isMeeting, (bool)$news->is_meeting);
     }
 
@@ -243,7 +198,7 @@ class NewsControllerTest extends ControllerTest
         // Assert no changes
         $news = News::find(1);
         $this->assertEquals('Foo', $news->title);
-        $this->assertEquals('<b>foo</b>', $news->text);
+        $this->assertEquals('**foo**', $news->text);
         $this->assertFalse($news->is_meeting);
         $this->assertFalse($news->is_pinned);
     }
@@ -305,8 +260,7 @@ class NewsControllerTest extends ControllerTest
 
         (new News([
             'title'      => 'Foo',
-            'text'       => '<b>foo</b>',
-            'is_meeting' => false,
+            'text'       => '**foo**',
             'user_id'    => 1,
         ]))->save();
     }

--- a/tests/Unit/HasDatabase.php
+++ b/tests/Unit/HasDatabase.php
@@ -55,6 +55,7 @@ trait HasDatabase
                     ['migration' => '2020_12_28_000000_oauth_set_identifier_binary'],
                     ['migration' => '2021_08_26_000000_add_shirt_edit_permissions'],
                     ['migration' => '2021_10_12_000000_add_shifts_description'],
+                    ['migration' => '2021_12_30_000000_remove_admin_news_html_privilege'],
                 ]
             );
 

--- a/tests/Unit/Renderer/Twig/Extensions/MarkdownTest.php
+++ b/tests/Unit/Renderer/Twig/Extensions/MarkdownTest.php
@@ -13,10 +13,7 @@ class MarkdownTest extends ExtensionTest
      */
     public function testGeFilters()
     {
-        /** @var Parsedown|MockObject $renderer */
-        $renderer = $this->createMock(Parsedown::class);
-
-        $extension = new Markdown($renderer);
+        $extension = new Markdown(new Parsedown());
         $filters = $extension->getFilters();
 
         $this->assertExtensionExists('markdown', [$extension, 'render'], $filters);
@@ -29,17 +26,12 @@ class MarkdownTest extends ExtensionTest
      */
     public function testRender()
     {
-        /** @var Parsedown|MockObject $renderer */
-        $renderer = $this->createMock(Parsedown::class);
+        $extension = new Markdown(new Parsedown());
 
-        $return = '<p>Lorem <em>&quot;Ipsum&quot;</em></p>';
-        $renderer->expects($this->once())
-            ->method('text')
-            ->with('Lorem *&quot;Ipsum&quot;*')
-            ->willReturn($return);
-
-        $extension = new Markdown($renderer);
-        $this->assertEquals($return, $extension->render('Lorem *"Ipsum"*'));
+        $this->assertEquals(
+            '<p>&lt;i&gt;Lorem&lt;/i&gt; <em>&quot;Ipsum&quot;</em></p>',
+            $extension->render('<i>Lorem</i> *"Ipsum"*'),
+        );
     }
 
     /**
@@ -47,17 +39,12 @@ class MarkdownTest extends ExtensionTest
      */
     public function testRenderHtml()
     {
-        /** @var Parsedown|MockObject $renderer */
-        $renderer = $this->createMock(Parsedown::class);
-
-        $input = '<i>**test**</i>';
-        $return = '<p><strong><i>**test**</i></strong></p>';
-        $renderer->expects($this->once())
-            ->method('text')
-            ->with($input)
-            ->willReturn($return);
-
+        $renderer = new Parsedown();
         $extension = new Markdown($renderer);
-        $this->assertEquals($return, $extension->render($input, false));
+
+        $this->assertEquals(
+            '<p><i>Lorem</i> <em>&quot;Ipsum&quot;</em></p>',
+            $extension->render('<i>Lorem</i> *"Ipsum"*', false),
+        );
     }
 }


### PR DESCRIPTION
Letting Parsedown escape the content, instead of calling
htmlspecialchars provides more context to the escape process.
For example the ampersand character can now be used in markdown links as
part of the url without breaking.