### PR TITLE
Changed default SMTP sender address to noreply@example.com

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -53,7 +53,7 @@ return [
         'driver' => env('MAIL_DRIVER', 'mail'),
         'from'   => [
             // From address of all emails
-            'address' => env('MAIL_FROM_ADDRESS', 'noreply@engelsystem.de'),
+            'address' => env('MAIL_FROM_ADDRESS', 'noreply@example.com'),
             'name'    => env('MAIL_FROM_NAME', env('APP_NAME', 'Engelsystem')),
         ],
 


### PR DESCRIPTION
The engelsystem currently uses 'noreply@engelsystem.de' as the default sender address for outbound mail. When people setup the engelsystem themselves, they may forget to update this value, clashing with the delivery settings of engelsystem.de.

Hence, I updated the default sender address to noreply@example.com