### PR TITLE
Database: Increase shift_size column size

### DIFF
--- a/db/migrations/2022_05_23_000000_increase_tshirt_field_width.php
+++ b/db/migrations/2022_05_23_000000_increase_tshirt_field_width.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * To allow for larger key names such as "2XL-G"
+ */
+class IncreaseTshirtFieldWidth extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up()
+    {
+        $this->schema->table('users_personal_data', function (Blueprint $table) {
+            $table->string('shirt_size', 10)->change();
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down()
+    {
+        $this->schema->table('users_personal_data', function (Blueprint $table) {
+            $table->string('shirt_size', 4)->change();
+        });
+    }
+}


### PR DESCRIPTION
This resolves the following error message we're seeing:

```
 Exception: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'shirt_size' at row 1 (SQL: insert into `users_personal_data` (`first_name`, `last_name`, `pronoun`, `shirt_size`, `planned_arrival_date`, `user_id`) values (, , , 3XL-G, 2022-07-21 00:00:00, 101))
```

Users are running into this on signup, and since the user_personal_data is being saved before their `Angel` role has been assigned, these users are not able to do anything due to lack of rights.