### PR TITLE
k8s: Use traefik as default ingress, added improved app url handling to support subpath deployments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -311,8 +311,12 @@ deploy:
     # CI_ENVIRONMENT_URL is the URL configured in the GitLab environment
     - export CI_ENVIRONMENT_URL="${CI_ENVIRONMENT_URL:-https://${CI_PROJECT_PATH_SLUG}.${KUBE_INGRESS_BASE_DOMAIN}/}"
     - export CI_IMAGE=$RELEASE_IMAGE
+    - export CI_INGRESS_CLASS=${CI_INGRESS_CLASS:-traefik}
+    - export CI_INGRESS_MATCH=${CI_INGRESS_MATCH:-$( if [[ "$CI_INGRESS_CLASS" == "nginx" ]]; then echo '/?(.*)'; fi )}
+    - export CI_INGRESS_TRAEFIK_ENTRYPOINT=${CI_INGRESS_TRAEFIK_ENTRYPOINT:-websecure}
     - export CI_INGRESS_DOMAIN=$(echo "$CI_ENVIRONMENT_URL" | grep -oP '(?:https?://)?\K([^/]+)' | head -n1)
     - export CI_INGRESS_PATH=$(echo "$CI_ENVIRONMENT_URL" | grep -oP '(?:https?://)?(?:[^/])+\K(.*)')
+    - '[[ "${CI_INGRESS_PATH}" == /* ]] || export CI_INGRESS_PATH="/${CI_INGRESS_PATH}"'
     - export CI_KUBE_NAMESPACE=$KUBE_NAMESPACE
     # Any available storage class like default, local-path (if you know what you are doing ;), longhorn etc.
     - export CI_PVC_SC=${CI_PVC_SC:-"${CI_PVC_SC_LOCAL:-local-path}"}
@@ -328,6 +332,7 @@ deploy:
       done
 
     - echo "Deploying to ${CI_ENVIRONMENT_URL}"
+    - kubectl diff -f deployment.yaml || true
     - kubectl apply -f deployment.yaml
     - >-
       kubectl -n $CI_KUBE_NAMESPACE wait --for=condition=Ready pods --timeout=${CI_WAIT_TIMEOUT:-5}m

--- a/deployment.tpl.yaml
+++ b/deployment.tpl.yaml
@@ -66,7 +66,6 @@ metadata:
   labels:
     app: <CI_PROJECT_PATH_SLUG>
     environment: <CI_ENVIRONMENT_SLUG>
-    commit: '<CI_COMMIT_SHORT_SHA>'
 spec:
   type: ClusterIP
   ports:
@@ -105,6 +104,7 @@ spec:
         environment: <CI_ENVIRONMENT_SLUG>
         tier: application
         commit: '<CI_COMMIT_SHORT_SHA>'
+        pipeline: '<CI_PIPELINE_ID>'
       annotations:
         app.gitlab.com/app: <CI_PROJECT_PATH_SLUG>
         app.gitlab.com/env: <CI_ENVIRONMENT_SLUG>
@@ -159,7 +159,6 @@ metadata:
   labels:
     app: <CI_PROJECT_PATH_SLUG>
     environment: <CI_ENVIRONMENT_SLUG>
-    commit: '<CI_COMMIT_SHORT_SHA>'
   annotations:
     prometheus.io/port: '80'
     prometheus.io/scrape: 'true'
@@ -181,13 +180,14 @@ metadata:
   name: engelsystem-ingress
   annotations:
     kubernetes.io/tls-acme: 'true'
-    kubernetes.io/ingress.class: 'nginx'
+    kubernetes.io/ingress.class: <CI_INGRESS_CLASS>
     cert-manager.io/cluster-issuer: <CI_CLUSTER_ISSUER>
     nginx.ingress.kubernetes.io/rewrite-target: /$1
+    traefik.ingress.kubernetes.io/router.entrypoints: <CI_INGRESS_TRAEFIK_ENTRYPOINT>
+    traefik.ingress.kubernetes.io/router.tls: 'true'
   labels:
     app: <CI_PROJECT_PATH_SLUG>
     environment: <CI_ENVIRONMENT_SLUG>
-    commit: '<CI_COMMIT_SHORT_SHA>'
 spec:
   tls:
     - hosts:
@@ -197,7 +197,7 @@ spec:
     - host: <CI_INGRESS_DOMAIN>
       http:
         paths:
-          - path: '<CI_INGRESS_PATH>/?(.*)'
+          - path: '<CI_INGRESS_PATH><CI_INGRESS_MATCH>'
             pathType: Prefix
             backend:
               service:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,9 +20,9 @@ http {
   }
 
   server {
-    include     mime.types;
-    access_log  off;
-    listen      [::]:80 ipv6only=off;
+    include             mime.types;
+    access_log          /dev/stdout;
+    listen              [::]:80 ipv6only=off;
     proxy_redirect      off;
     proxy_set_header    Host                $host;
     proxy_set_header    X-Real-IP           $remote_addr;
@@ -32,7 +32,7 @@ http {
     root    /var/www/public;
 
     location / {
-      try_files $uri $uri/ /index.php?$args;
+      try_files $uri $uri/ /index.php$is_args$args;
     }
 
     location ~ \.php$ {

--- a/src/Http/RequestServiceProvider.php
+++ b/src/Http/RequestServiceProvider.php
@@ -2,18 +2,29 @@
 
 namespace Engelsystem\Http;
 
+use Engelsystem\Config\Config;
 use Engelsystem\Container\ServiceProvider;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class RequestServiceProvider extends ServiceProvider
 {
+    /** @var array */
+    protected array $appUrl;
+
     public function register()
     {
+        /** @var Config $config */
         $config = $this->app->get('config');
         $trustedProxies = $config->get('trusted_proxies', []);
+        $this->appUrl = parse_url($config->get('url') ?: '');
 
         if (!is_array($trustedProxies)) {
             $trustedProxies = empty($trustedProxies) ? [] : explode(',', preg_replace('~\s+~', '', $trustedProxies));
+        }
+
+        if (!empty($this->appUrl['path'])) {
+            Request::setFactory([$this, 'createRequestWithoutPrefix']);
         }
 
         /** @var Request $request */
@@ -23,6 +34,46 @@ class RequestServiceProvider extends ServiceProvider
         $this->app->instance(Request::class, $request);
         $this->app->instance(SymfonyRequest::class, $request);
         $this->app->instance('request', $request);
+    }
+
+    /**
+     * @param array $query GET parameters
+     * @param array $request POST parameters
+     * @param array $attributes Additional data
+     * @param array $cookies Cookies
+     * @param array $files Uploaded files
+     * @param array $server Server env
+     * @param mixed $content Request content
+     * @return Request
+     */
+    public function createRequestWithoutPrefix(
+        array $query = [],
+        array $request = [],
+        array $attributes = [],
+        array $cookies = [],
+        array $files = [],
+        array $server = [],
+        $content = null
+    ): Request {
+        if (
+            !empty($this->appUrl['path'])
+            && !empty($server['REQUEST_URI'])
+            && Str::startsWith($server['REQUEST_URI'], $this->appUrl['path'])
+        ) {
+            $requestUri = Str::substr(
+                $server['REQUEST_URI'],
+                Str::length(rtrim($this->appUrl['path'], '/'))
+            );
+
+            // Reset paths which only contain the app path
+            if ($requestUri && !Str::startsWith($requestUri, '/')) {
+                $requestUri = $server['REQUEST_URI'];
+            }
+
+            $server['REQUEST_URI'] = $requestUri ?: '/';
+        }
+
+        return new Request($query, $request, $attributes, $cookies, $files, $server, $content);
     }
 
     /**


### PR DESCRIPTION
* Traefik as k8s default ingress (nginx should work as previously)
* Show k8s diff on deployment
* Added location request path rewrite to the nginx config
* Enabled access logging in nginx for easier debugging
* Added magic to request parsing to ensure the app paths work as expected (by removing the url path prefix from the request)