### PR TITLE
Settings Languages rewrite

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -24,6 +24,8 @@ $route->get('/settings/password', 'SettingsController@password');
 $route->post('/settings/password', 'SettingsController@savePassword');
 $route->get('/settings/theme', 'SettingsController@theme');
 $route->post('/settings/theme', 'SettingsController@saveTheme');
+$route->get('/settings/language', 'SettingsController@language');
+$route->post('/settings/language', 'SettingsController@saveLanguage');
 $route->get('/settings/oauth', 'SettingsController@oauth');
 
 // Password recovery

--- a/includes/pages/user_settings.php
+++ b/includes/pages/user_settings.php
@@ -106,36 +106,6 @@ function user_settings_main($user_source, $enable_tshirt_size, $tshirt_sizes)
 }
 
 /**
- * Change use locale
- *
- * @param User  $user_source The user
- * @param array $locales     List of available locales
- * @return User
- */
-function user_settings_locale($user_source, $locales)
-{
-    $valid = true;
-    $request = request();
-    $session = session();
-
-    if ($request->has('language') && isset($locales[$request->input('language')])) {
-        $user_source->settings->language = $request->input('language');
-    } else {
-        $valid = false;
-    }
-
-    if ($valid) {
-        $user_source->settings->save();
-        $session->set('locale', $user_source->settings->language);
-
-        success('Language changed.');
-        throw_redirect(page_link_to('user_settings'));
-    }
-
-    return $user_source;
-}
-
-/**
  * Main user settings page/controller
  *
  * @return string
@@ -147,7 +117,6 @@ function user_settings()
 
     $enable_tshirt_size = config('enable_tshirt_size');
     $tshirt_sizes = config('tshirt_sizes');
-    $locales = config('locales');
 
     $buildup_start_date = null;
     $teardown_end_date = null;
@@ -165,13 +134,10 @@ function user_settings()
     $user_source = auth()->user();
     if ($request->hasPostData('submit')) {
         $user_source = user_settings_main($user_source, $enable_tshirt_size, $tshirt_sizes);
-    } elseif ($request->hasPostData('submit_language')) {
-        $user_source = user_settings_locale($user_source, $locales);
     }
 
     return User_settings_view(
         $user_source,
-        $locales,
         $buildup_start_date,
         $teardown_end_date,
         $enable_tshirt_size,

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -13,7 +13,6 @@ use Engelsystem\Controllers\SettingsController;
  * Renders user settings page
  *
  * @param User  $user_source        The user
- * @param array $locales            Available languages
  * @param int   $buildup_start_date Unix timestamp
  * @param int   $teardown_end_date  Unix timestamp
  * @param bool  $enable_tshirt_size
@@ -23,7 +22,6 @@ use Engelsystem\Controllers\SettingsController;
  */
 function User_settings_view(
     $user_source,
-    $locales,
     $buildup_start_date,
     $teardown_end_date,
     $enable_tshirt_size,
@@ -115,11 +113,6 @@ function User_settings_view(
                             ) : '',
                             form_info('', __('Please visit the angeltypes page to manage your angeltypes.')),
                             form_submit('submit', __('Save'))
-                        ]),
-                        form([
-                            form_info(__('Here you can choose your language:')),
-                            form_select('language', __('Language:'), $locales, $user_source->settings->language),
-                            form_submit('submit_language', __('Save'))
                         ]),
                     ])
                 ])

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -2521,14 +2521,6 @@ msgstr "Geplanter Abreisetag"
 msgid "Please visit the angeltypes page to manage your angeltypes."
 msgstr "Bitte benutze die Engeltypen-Seite um deine Engeltypen zu verwalten."
 
-#: includes/view/User_view.php:101
-msgid "Here you can choose your language:"
-msgstr "Hier kannst Du Deine Sprache auswählen:"
-
-#: includes/view/User_view.php:102
-msgid "Language:"
-msgstr "Sprache:"
-
 #: includes/view/User_view.php:124
 msgid ""
 "Do you really want to delete the user including all his shifts and every "
@@ -2964,6 +2956,15 @@ msgstr "Hier kannst Du Dein Theme ändern."
 
 msgid "settings.theme.success"
 msgstr "Theme wurde erfolgreich geändert."
+
+msgid "settings.language"
+msgstr "Sprache"
+
+msgid "settings.language.info"
+msgstr "Hier kannst Du Deine Sprache ändern."
+
+msgid "settings.language.success"
+msgstr "Sprache wurde erfolgreich geändert."
 
 msgid "settings.oauth"
 msgstr "Single Sign-On"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -235,6 +235,15 @@ msgstr "Here you can change your theme."
 msgid "settings.theme.success"
 msgstr "Theme was changed successfully."
 
+msgid "settings.language"
+msgstr "Language"
+
+msgid "settings.language.info"
+msgstr "Here you can change your language."
+
+msgid "settings.language.success"
+msgstr "Language was changed successfully."
+
 msgid "settings.oauth"
 msgstr "Single Sign-On"
 

--- a/resources/lang/pt_BR/default.po
+++ b/resources/lang/pt_BR/default.po
@@ -2207,14 +2207,6 @@ msgstr "Nova senha:"
 msgid "Password confirmation:"
 msgstr "Confirmação de senha:"
 
-#: includes/view/User_view.php:73
-msgid "Here you can choose your language:"
-msgstr "Aqui você pode selecionar seu idioma:"
-
-#: includes/view/User_view.php:74
-msgid "Language:"
-msgstr "Idioma:"
-
 #: includes/view/User_view.php:88
 msgid "Registration successful"
 msgstr "Registrado com sucesso"

--- a/resources/views/pages/settings/language.twig
+++ b/resources/views/pages/settings/language.twig
@@ -1,0 +1,19 @@
+{% extends 'pages/settings/settings.twig' %}
+{% import 'macros/form.twig' as f %}
+{% import 'macros/base.twig' as m %}
+
+{% block title %}{{ __('settings.language') }}{% endblock %}
+
+{% block row_content %}
+    <form action="" enctype="multipart/form-data" method="post">
+        {{ csrf() }}
+
+        <div class="row">
+            <div class="col-md-12">
+                {{ m.info(__('settings.language.info')) }}
+                {{ f.select('select_language', languages, __('settings.language'), current_language) }}
+                {{ f.submit() }}
+            </div>
+        </div>
+    </form>
+{% endblock %}


### PR DESCRIPTION
- The language settings are no longer handled in includes/pages/user_settings.php and includes/view/User_view.php but in the SettingsController.php.
- The language settings do now have a separate section, just as passwords.

![language](https://user-images.githubusercontent.com/95189570/175115400-97595442-6988-4ce6-98f0-6978284f9a84.png)

