### PR TITLE
Improve voucher texts

### DIFF
--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -159,8 +159,8 @@ function User_edit_vouchers_view($user)
         ]),
         info(sprintf(
             $user->state->force_active
-                ? __('Angel should receive at least %d vouchers and is FA.')
-                : __('Angel should receive at least %d vouchers.'),
+                ? __('Angel can receive another %d vouchers and is FA.')
+                : __('Angel can receive another %d vouchers.'),
             User_get_eligable_voucher_count($user)
         ), true),
         form(
@@ -635,7 +635,7 @@ function User_view(
                                     'users',
                                     ['action' => 'edit_vouchers', 'user_id' => $user_source->id]
                                 ),
-                                icon('file-binary-fill') . __('Edit vouchers')
+                                icon('file-binary-fill') . __('Vouchers')
                             )
                         : '',
                         $admin_user_worklog_privilege ? button(

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -2535,13 +2535,13 @@ msgstr "Dein Passwort"
 
 #: includes/view/User_view.php:148
 #, php-format
-msgid "Angel should receive at least %d vouchers."
-msgstr "Engel sollte mindestens %d Gutscheine bekommen."
+msgid "Angel can receive another %d vouchers."
+msgstr "Engel kann noch %d Gutscheine bekommen."
 
 #: includes/view/User_view.php:148
 #, php-format
-msgid "Angel should receive at least %d vouchers and is FA."
-msgstr "Engel sollte mindestens %d Gutscheine bekommen und ist FA."
+msgid "Angel can receive another %d vouchers and is FA."
+msgstr "Engel kann noch %d Gutscheine bekommen und ist FA."
 
 #: includes/view/User_view.php:153
 msgid "Number of vouchers given out"
@@ -2649,8 +2649,8 @@ msgid "driving license"
 msgstr "Führerschein"
 
 #: includes/view/User_view.php:608
-msgid "Edit vouchers"
-msgstr "Gutschein bearbeiten"
+msgid "Vouchers"
+msgstr "Gutscheine"
 
 #: includes/view/User_view.php:612
 msgid "Add work log"


### PR DESCRIPTION
Also removed the second „edit“ and just call it „Vouchers“ as it doesn't say „edit driving licence“ etc.

![grafik](https://user-images.githubusercontent.com/6216686/180620531-2f39f12a-f456-45a2-b981-cdb98b631dd3.png)

:ping_pong: @MyIgel 