### PR TITLE
Shift delete event

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -64,11 +64,16 @@ return [
         //      a list of
         //      'Class@method' or 'Class' (which uses @handle),
         //      ['Class', 'method'],
-        //      callable like [$instance, 'method] or 'function'
+        //      callable like [$instance, 'method'] or 'function'
         //      or $function
         // ]
         'news.created' => \Engelsystem\Events\Listener\News::class . '@created',
 
         'oauth2.login' => \Engelsystem\Events\Listener\OAuth2::class . '@login',
+
+        'shift.entry.deleting' => [
+            \Engelsystem\Events\Listener\Shift::class . '@deletedEntryCreateWorklog',
+            \Engelsystem\Events\Listener\Shift::class . '@deletedEntrySendEmail',
+        ],
     ],
 ];

--- a/includes/helper/shift_helper.php
+++ b/includes/helper/shift_helper.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Engelsystem\Events\Listener;
+
+use Engelsystem\Helpers\Carbon;
+use Engelsystem\Helpers\Shifts;
+use Engelsystem\Mail\EngelsystemMailer;
+use Engelsystem\Models\Room;
+use Engelsystem\Models\User\User;
+use Engelsystem\Models\Worklog;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Exception\TransportException;
+
+class Shift
+{
+    /** @var LoggerInterface */
+    protected LoggerInterface $log;
+
+    /** @var EngelsystemMailer */
+    protected EngelsystemMailer $mailer;
+
+    /**
+     * @param LoggerInterface   $log
+     * @param EngelsystemMailer $mailer
+     */
+    public function __construct(
+        LoggerInterface $log,
+        EngelsystemMailer $mailer
+    ) {
+        $this->log = $log;
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * @param User   $user
+     * @param Carbon $start
+     * @param Carbon $end
+     * @param string $name
+     * @param string $title
+     * @param string $type
+     * @param Room   $room
+     * @return void
+     */
+    public function deletedEntryCreateWorklog(
+        User $user,
+        Carbon $start,
+        Carbon $end,
+        string $name,
+        string $title,
+        string $type,
+        Room $room,
+        bool $freeloaded
+    ): void {
+        if ($freeloaded || $start > Carbon::now()) {
+            return;
+        }
+
+        $workLog = new Worklog();
+        $workLog->user()->associate($user);
+        $workLog->creator()->associate(auth()->user());
+        $workLog->worked_at = $start->copy()->startOfDay();
+        $workLog->hours =
+            (($end->timestamp - $start->timestamp) / 60 / 60)
+            * Shifts::getNightShiftMultiplier($start, $end);
+        $workLog->comment = sprintf(
+            '%s (%s as %s) in %s, %s - %s',
+            $name,
+            $title,
+            $type,
+            $room->name,
+            $start->format('Y-m-d H:i'),
+            $end->format('Y-m-d H:i')
+        );
+        $workLog->save();
+
+        $this->log->info(
+            'Created worklog entry from shift for {user} ({uid}): {worklog})',
+            ['user' => $workLog->user->name, 'uid' => $workLog->user->id, 'worklog' => $workLog->comment]
+        );
+    }
+
+    /**
+     * @param User   $user
+     * @param Carbon $start
+     * @param Carbon $end
+     * @param string $name
+     * @param string $title
+     * @param string $type
+     * @param Room   $room
+     * @return void
+     */
+    public function deletedEntrySendEmail(
+        User $user,
+        Carbon $start,
+        Carbon $end,
+        string $name,
+        string $title,
+        string $type,
+        Room $room,
+        bool $freeloaded
+    ): void {
+        if (!$user->settings->email_shiftinfo) {
+            return;
+        }
+
+        $subject = 'notification.shift.deleted';
+        try {
+            $this->mailer->sendViewTranslated(
+                $user,
+                $subject,
+                'emails/worklog-from-shift',
+                [
+                    'name'       => $name,
+                    'title'      => $title,
+                    'start'      => $start,
+                    'end'        => $end,
+                    'room'       => $room,
+                    'freeloaded' => $freeloaded,
+                    'username'   => $user->name,
+                ]
+            );
+        } catch (TransportException $e) {
+            $this->log->error(
+                'Unable to send email "{title}" to user {user} with {exception}',
+                ['title' => $subject, 'user' => $user->name, 'exception' => $e]
+            );
+        }
+    }
+}

--- a/includes/includes.php
+++ b/includes/includes.php
@@ -59,6 +59,7 @@ $includeFiles = [
     __DIR__ . '/../includes/helper/message_helper.php',
     __DIR__ . '/../includes/helper/email_helper.php',
     __DIR__ . '/../includes/helper/oauth_helper.php',
+    __DIR__ . '/../includes/helper/shift_helper.php',
 
     __DIR__ . '/../includes/mailer/shifts_mailer.php',
     __DIR__ . '/../includes/mailer/users_mailer.php',

--- a/includes/mailer/shifts_mailer.php
+++ b/includes/mailer/shifts_mailer.php
@@ -79,34 +79,6 @@ function mail_shift_change($old_shift, $new_shift)
 }
 
 /**
- * @param array $shift
- */
-function mail_shift_delete($shift)
-{
-    $users = ShiftEntries_by_shift($shift['SID']);
-    $room = Room::find($shift['RID']);
-
-    $message = __('A Shift you are registered on was deleted:') . "\n";
-
-    $message .= $shift['name'] . "\n";
-    $message .= $shift['title'] . "\n";
-    $message .= date('Y-m-d H:i', $shift['start']) . ' - ' . date('H:i', $shift['end']) . "\n";
-    $message .= $room->name . "\n";
-
-    foreach ($users as $user) {
-        $user = (new User())->forceFill($user);
-        if ($user->settings->email_shiftinfo) {
-            $userMessage = $message;
-            if ($shift['start'] < time() && !$user['freeloaded']) {
-                $userMessage .= "\n" . __('Since the deleted shift was already done, we added a worklog entry instead, to keep your work hours correct.') . "\n";
-            }
-
-            engelsystem_email_to_user($user, __('Your Shift was deleted'), $userMessage, true);
-        }
-    }
-}
-
-/**
  * @param User  $user
  * @param array $shift
  */

--- a/includes/model/Shifts_model.php
+++ b/includes/model/Shifts_model.php
@@ -512,7 +512,6 @@ function Shift_signup_allowed(
  */
 function Shift_delete($shift_id)
 {
-    mail_shift_delete(Shift($shift_id));
     Db::delete('DELETE FROM `Shifts` WHERE `SID`=?', [$shift_id]);
 }
 
@@ -657,7 +656,9 @@ function Shift($shift_id)
     }
 
     $shiftsEntry_source = Db::select('
-        SELECT `ShiftEntry`.`id`, `ShiftEntry`.`TID` , `ShiftEntry`.`UID` , `ShiftEntry`.`freeloaded`, `users`.`name` AS `username`
+        SELECT
+            `ShiftEntry`.`id`, `ShiftEntry`.`TID` , `ShiftEntry`.`UID` , `ShiftEntry`.`freeloaded`,
+            `users`.`name` AS `username`, `users`.`id` AS `user_id`
         FROM `ShiftEntry`
         LEFT JOIN `users` ON (`users`.`id` = `ShiftEntry`.`UID`)
         WHERE `SID`=?', [$shift_id]);

--- a/includes/model/UserWorkLog_model.php
+++ b/includes/model/UserWorkLog_model.php
@@ -67,45 +67,6 @@ function UserWorkLog_create(Worklog $worklog)
 }
 
 /**
- * @param array|int $shift
- */
-function UserWorkLog_from_shift($shift)
-{
-    $shift = is_array($shift) ? $shift : Shift($shift);
-    if ($shift['start'] > time()) {
-        return;
-    }
-
-    $room = Room::find($shift['RID']);
-    foreach ($shift['ShiftEntry'] as $entry) {
-        if ($entry['freeloaded']) {
-            continue;
-        }
-
-        $type = AngelType($entry['TID']);
-
-        $shiftStart = Carbon::createFromTimestamp($shift['start']);
-        $shiftEnd = Carbon::createFromTimestamp($shift['end']);
-        $nightShiftMultiplier = Shifts::getNightShiftMultiplier($shiftStart, $shiftEnd);
-
-        $worklog = UserWorkLog_new($entry['UID']);
-        $worklog->hours = (($shift['end'] - $shift['start']) / 60 / 60) * $nightShiftMultiplier;
-        $worklog->comment = sprintf(
-            '%s (%s as %s) in %s, %s-%s',
-            $shift['name'],
-            $shift['title'],
-            $type['name'],
-            $room->name,
-            Carbon::createFromTimestamp($shift['start'])->format(__('m/d/Y h:i a')),
-            Carbon::createFromTimestamp($shift['end'])->format(__('m/d/Y h:i a'))
-        );
-        $worklog->worked_at = Carbon::createFromTimestamp($shift['start']);
-
-        UserWorkLog_create($worklog);
-    }
-}
-
-/**
  * New user work log entry
  *
  * @param int $userId

--- a/includes/pages/admin_shifts.php
+++ b/includes/pages/admin_shifts.php
@@ -536,7 +536,21 @@ function admin_shifts_history(): string
 
         foreach ($shifts as $shift) {
             $shift = Shift($shift['SID']);
-            UserWorkLog_from_shift($shift);
+            $room = Room::find($shift['RID']);
+            foreach ($shift['ShiftEntry'] as $entry) {
+                $type = AngelType($entry['TID']);
+                event('shift.entry.deleting', [
+                    'user'       => User::find($entry['user_id']),
+                    'start'      => Carbon::createFromTimestamp($shift['start']),
+                    'end'        => Carbon::createFromTimestamp($shift['end']),
+                    'name'       => $shift['name'],
+                    'title'      => $shift['title'],
+                    'type'       => $type['name'],
+                    'room'       => $room,
+                    'freeloaded' => (bool)$entry['freeloaded'],
+                ]);
+            }
+
             shift_delete($shift['SID']);
 
             engelsystem_log(

--- a/resources/lang/de_DE/additional.po
+++ b/resources/lang/de_DE/additional.po
@@ -152,6 +152,17 @@ msgstr "Du wurdest von einem Supporter als %1$s hinzugefügt."
 msgid "notification.angeltype.added.text"
 msgstr "Eine Beschreibung findest du unter %2$s"
 
+msgid "notification.shift.deleted"
+msgstr "Deine Schicht wurde gelöscht"
+
+msgid "notification.shift.deleted.introduction"
+msgstr "Eine deiner Schichten wurde gelöscht:"
+
+msgid "notification.shift.deleted.worklog"
+msgstr ""
+"Da die gelöschte Schicht bereits vergangen ist, "
+"haben wir einen entsprechenden Arbeitseinsatz hinzugefügt."
+
 msgid "user.edit.success"
 msgstr "Benutzer erfolgreich bearbeitet."
 

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -150,6 +150,17 @@ msgstr "You have been added as an %1$s by a supporter."
 msgid "notification.angeltype.added.text"
 msgstr "You can find a description at %2$s"
 
+msgid "notification.shift.deleted"
+msgstr "Your Shift was deleted"
+
+msgid "notification.shift.deleted.introduction"
+msgstr "A Shift you are registered on was deleted:"
+
+msgid "notification.shift.deleted.worklog"
+msgstr ""
+"Since the deleted shift was already done, "
+"we added a worklog entry instead, to keep your work hours correct."
+
 msgid "user.edit.success"
 msgstr "User edited successfully."
 

--- a/resources/views/emails/worklog-from-shift.twig
+++ b/resources/views/emails/worklog-from-shift.twig
@@ -1,0 +1,16 @@
+{% extends "emails/mail.twig" %}
+
+{% block introduction %}
+{{ __('notification.shift.deleted.introduction') }}
+{% endblock %}
+
+{% block message %}
+{{ name }}
+{{ title }}
+{{ start.format(__('Y-m-d H:i')) }} - {{ end.format(__('Y-m-d H:i')) }}
+{{ room.name }}
+
+{% if start <= date() and not freeloaded %}
+{{ __('notification.shift.deleted.worklog') }}
+{% endif %}
+{% endblock %}

--- a/src/Helpers/Shifts.php
+++ b/src/Helpers/Shifts.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Engelsystem\Helpers;
+
+use \Carbon\Carbon;
+
+// Should be moved to the shift model if it's available
+class Shifts
+{
+    /**
+     * Check if a time range is a night shift
+     *
+     * @param Carbon $start
+     * @param Carbon $end
+     * @return bool
+     */
+    public static function isNightShift(Carbon $start, Carbon $end): bool
+    {
+        $config = config('night_shifts');
+
+        return $config['enabled'] && (
+                $start->hour >= $config['start'] && $start->hour < $config['end']
+                || $end->hour >= $config['start'] && $end->hour < $config['end']
+            );
+    }
+
+    /**
+     * Calculate a shifts night multiplier
+     *
+     * @param Carbon $start
+     * @param Carbon $end
+     * @return float
+     */
+    public static function getNightShiftMultiplier(Carbon $start, Carbon $end): float
+    {
+        if (!self::isNightShift($start, $end)) {
+            return 1;
+        }
+
+        return config('night_shifts')['multiplier'];
+    }
+}

--- a/src/Helpers/Shifts.php
+++ b/src/Helpers/Shifts.php
@@ -2,7 +2,7 @@
 
 namespace Engelsystem\Helpers;
 
-use \Carbon\Carbon;
+use Carbon\Carbon;
 
 // Should be moved to the shift model if it's available
 class Shifts

--- a/src/Mail/EngelsystemMailer.php
+++ b/src/Mail/EngelsystemMailer.php
@@ -47,7 +47,7 @@ class EngelsystemMailer extends Mailer
     ): void {
         if ($to instanceof User) {
             $locale = $locale ?: $to->settings->language;
-            $to = $to->contact->email ? $to->contact->email : $to->email;
+            $to = $to->contact->email ?: $to->email;
         }
 
         $activeLocale = null;

--- a/tests/Unit/Helpers/ShiftsTest.php
+++ b/tests/Unit/Helpers/ShiftsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Helpers;
+
+use Engelsystem\Config\Config;
+use Engelsystem\Helpers\Carbon;
+use Engelsystem\Helpers\Shifts;
+use Engelsystem\Test\Unit\TestCase;
+
+class ShiftsTest extends TestCase
+{
+    /**
+     * @covers \Engelsystem\Helpers\Shifts::isNightShift
+     */
+    public function testIsNightShift()
+    {
+        $config = new Config(['night_shifts' => [
+            'enabled'    => false,
+            'start'      => 2,
+            'end'        => 6,
+            'multiplier' => 2,
+        ]]);
+        $this->app->instance('config', $config);
+
+        // At night but disabled
+        $this->assertFalse(Shifts::isNightShift(
+            new Carbon('2042-01-01 04:00'),
+            new Carbon('2042-01-01 05:00')
+        ));
+
+        $config->set('night_shifts', array_merge($config->get('night_shifts'), ['enabled' => true]));
+
+        // Is night shift
+        $this->assertTrue(Shifts::isNightShift(
+            new Carbon('2042-01-01 04:00'),
+            new Carbon('2042-01-01 05:00')
+        ));
+
+        // Starts as night shift
+        $this->assertTrue(Shifts::isNightShift(
+            new Carbon('2042-01-01 05:45'),
+            new Carbon('2042-01-01 07:00')
+        ));
+
+        // Ends as night shift
+        $this->assertTrue(Shifts::isNightShift(
+            new Carbon('2042-01-01 00:00'),
+            new Carbon('2042-01-01 02:15')
+        ));
+
+        // Too early
+        $this->assertFalse(Shifts::isNightShift(
+            new Carbon('2042-01-01 00:00'),
+            new Carbon('2042-01-01 01:59')
+        ));
+
+        // Too late
+        $this->assertFalse(Shifts::isNightShift(
+            new Carbon('2042-01-01 06:00'),
+            new Carbon('2042-01-01 09:59')
+        ));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Shifts::getNightShiftMultiplier
+     */
+    public function testGetNightShiftMultiplier()
+    {
+        $config = new Config(['night_shifts' => [
+            'enabled'    => true,
+            'start'      => 2,
+            'end'        => 6,
+            'multiplier' => 2,
+        ]]);
+        $this->app->instance('config', $config);
+
+        $this->assertEquals(2, Shifts::getNightShiftMultiplier(
+            new Carbon('2042-01-01 02:00'),
+            new Carbon('2042-01-01 04:00')
+        ));
+
+        $config->set('night_shifts', array_merge($config->get('night_shifts'), ['enabled' => false]));
+        $this->assertEquals(1, Shifts::getNightShiftMultiplier(
+            new Carbon('2042-01-01 02:00'),
+            new Carbon('2042-01-01 04:00')
+        ));
+    }
+}


### PR DESCRIPTION
Use the `shift.entry.deleted` event to handle the shift deletion tasks of sending emails to users and creating work logs.