### PR TITLE
Groups: Fix naming and update IDs

### DIFF
--- a/db/migrations/2022_07_21_000000_fix_old_groups_table_id_and_name.php
+++ b/db/migrations/2022_07_21_000000_fix_old_groups_table_id_and_name.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+
+class FixOldGroupsTableIdAndName extends Migration
+{
+    /** @var string[] */
+    protected array $naming = [
+        '1-Gast'              => 'Guest',
+        '2-Engel'             => 'Angel',
+        'Shirt-Manager'       => 'Shirt Manager',
+        '3-Shift Coordinator' => 'Shift Coordinator',
+        '4-Team Coordinator'  => 'Team Coordinator',
+        '5-Bürokrat'          => 'Bureaucrat',
+        '6-Developer'         => 'Developer',
+    ];
+
+    /** @var int[] */
+    protected array $ids = [
+        -25 => -30,
+        -26 => -35,
+        -30 => -50,
+        -40 => -60,
+        -50 => -65,
+        -60 => -80,
+        -65 => -85,
+        -70 => -90,
+    ];
+
+    /**
+     * Run the migration
+     */
+    public function up()
+    {
+        $this->migrate($this->naming, $this->ids);
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down()
+    {
+        $this->migrate(array_flip($this->naming), array_flip($this->ids));
+    }
+
+    /**
+     * @param string[] $naming
+     * @param int[] $ids
+     */
+    protected function migrate(array $naming, array $ids)
+    {
+        if (!$this->schema->hasTable('Groups')) {
+            return;
+        }
+
+        $connection = $this->schema->getConnection();
+        foreach ($connection->table('Groups')->orderByDesc('UID')->get() as $data) {
+            if (isset($naming[$data->Name])) {
+                $data->Name = $naming[$data->Name];
+            }
+
+            $data->oldId = $data->UID;
+            if (isset($ids[$data->oldId])) {
+                $data->UID = $ids[$data->oldId];
+            } elseif (isset($ids[$data->oldId * -1])) {
+                $data->UID = $ids[$data->oldId * -1] * -1;
+            }
+
+            $connection
+                ->table('Groups')
+                ->where('UID', $data->oldId)
+                ->update([
+                    'UID'  => $data->UID * -1,
+                    'Name' => $data->Name,
+                ]);
+        }
+    }
+}

--- a/includes/pages/admin_groups.php
+++ b/includes/pages/admin_groups.php
@@ -59,8 +59,8 @@ function admin_groups()
     } else {
         switch ($request->input('action')) {
             case 'edit':
-                if ($request->has('id') && preg_match('/^-\d{1,11}$/', $request->input('id'))) {
-                    $group_id = $request->input('id');
+                if ($request->has('id')) {
+                    $group_id = (int)$request->input('id');
                 } else {
                     return error('Incomplete call, missing Groups ID.', true);
                 }
@@ -103,10 +103,9 @@ function admin_groups()
             case 'save':
                 if (
                     $request->has('id')
-                    && preg_match('/^-\d{1,11}$/', $request->input('id'))
                     && $request->hasPostData('submit')
                 ) {
-                    $group_id = $request->input('id');
+                    $group_id = (int)$request->input('id');
                 } else {
                     return error('Incomplete call, missing Groups ID.', true);
                 }
@@ -117,7 +116,8 @@ function admin_groups()
                     Db::delete('DELETE FROM `GroupPrivileges` WHERE `group_id`=?', [$group_id]);
                     $privilege_names = [];
                     foreach ($privileges as $privilege) {
-                        if (preg_match('/^\d+$/', $privilege)) {
+                        $privilege = (int)$privilege;
+                        if ($privilege) {
                             $group_privileges_source = Db::selectOne(
                                 'SELECT `name` FROM `Privileges` WHERE `id`=? LIMIT 1',
                                 [$privilege]

--- a/includes/pages/admin_user.php
+++ b/includes/pages/admin_user.php
@@ -127,24 +127,24 @@ function admin_user()
         $html .= '<hr />';
 
         $my_highest_group = DB::selectOne(
-            'SELECT group_id FROM `UserGroups` WHERE `uid`=? ORDER BY `group_id` LIMIT 1',
+            'SELECT group_id FROM `UserGroups` WHERE `uid`=? ORDER BY `group_id` DESC LIMIT 1',
             [$user->id]
         );
         if (!empty($my_highest_group)) {
             $my_highest_group = $my_highest_group['group_id'];
         }
 
-        $his_highest_group = DB::selectOne(
+        $angel_highest_group = DB::selectOne(
             'SELECT `group_id` FROM `UserGroups` WHERE `uid`=? ORDER BY `group_id` LIMIT 1',
             [$user_id]
         );
-        if (!empty($his_highest_group)) {
-            $his_highest_group = $his_highest_group['group_id'];
+        if (!empty($angel_highest_group)) {
+            $angel_highest_group = $angel_highest_group['group_id'];
         }
 
         if (
             ($user_id != $user->id || auth()->can('admin_groups'))
-            && ($my_highest_group <= $his_highest_group || is_null($his_highest_group))
+            && ($my_highest_group >= $angel_highest_group || is_null($angel_highest_group))
         ) {
             $html .= 'Hier kannst Du die Benutzergruppen des Engels festlegen:<form action="'
                 . page_link_to('admin_user', ['action' => 'save_groups', 'id' => $user_id])
@@ -160,7 +160,7 @@ function admin_user()
                         `UserGroups`.`group_id` = `Groups`.`UID`
                         AND `UserGroups`.`uid` = ?
                     )
-                    WHERE `Groups`.`UID` >= ?
+                    WHERE `Groups`.`UID` <= ?
                     ORDER BY `Groups`.`Name`
                 ',
                 [
@@ -192,19 +192,19 @@ function admin_user()
             case 'save_groups':
                 if ($user_id != $user->id || auth()->can('admin_groups')) {
                     $my_highest_group = DB::selectOne(
-                        'SELECT * FROM `UserGroups` WHERE `uid`=? ORDER BY `group_id`',
+                        'SELECT * FROM `UserGroups` WHERE `uid`=? ORDER BY `group_id` DESC LIMIT 1',
                         [$user->id]
                     );
-                    $his_highest_group = DB::selectOne(
-                        'SELECT * FROM `UserGroups` WHERE `uid`=? ORDER BY `group_id`',
+                    $angel_highest_group = DB::selectOne(
+                        'SELECT * FROM `UserGroups` WHERE `uid`=? ORDER BY `group_id` DESC LIMIT 1',
                         [$user_id]
                     );
 
                     if (
-                        count($my_highest_group) > 0
+                        $my_highest_group
                         && (
-                            empty($his_highest_group)
-                            || ($my_highest_group['group_id'] <= $his_highest_group['group_id'])
+                            empty($angel_highest_group)
+                            || ($my_highest_group['group_id'] >= $angel_highest_group['group_id'])
                         )
                     ) {
                         $groups_source = DB::select(
@@ -215,7 +215,7 @@ function admin_user()
                                     `UserGroups`.`group_id` = `Groups`.`UID`
                                     AND `UserGroups`.`uid` = ?
                                 )
-                                WHERE `Groups`.`UID` >= ?
+                                WHERE `Groups`.`UID` <= ?
                                 ORDER BY `Groups`.`Name`
                             ',
                             [

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -869,8 +869,7 @@ function User_groups_render($user_groups)
 {
     $output = [];
     foreach ($user_groups as $group) {
-        $groupName = preg_replace('/(^\d+-)/', '', $group['Name']);
-        $output[] = __($groupName);
+        $output[] = __($group['Name']);
     }
 
     return div('col-md-2', [

--- a/src/Helpers/Authenticator.php
+++ b/src/Helpers/Authenticator.php
@@ -28,6 +28,9 @@ class Authenticator
     /** @var int|string|null */
     protected $passwordAlgorithm = PASSWORD_DEFAULT;
 
+    /** @var int */
+    protected $guestRole = 10;
+
     /**
      * @param ServerRequestInterface $request
      * @param Session                $session
@@ -119,7 +122,7 @@ class Authenticator
             }
 
             if (empty($this->permissions)) {
-                $this->permissions = $this->getPermissionsByGroup(-10);
+                $this->permissions = $this->getPermissionsByGroup($this->guestRole);
             }
         }
 
@@ -198,6 +201,22 @@ class Authenticator
     public function setPasswordAlgorithm($passwordAlgorithm)
     {
         $this->passwordAlgorithm = $passwordAlgorithm;
+    }
+
+    /**
+     * @return int
+     */
+    public function getGuestRole()
+    {
+        return $this->guestRole;
+    }
+
+    /**
+     * @param int $guestRole
+     */
+    public function setGuestRole(int $guestRole)
+    {
+        $this->guestRole = $guestRole;
     }
 
     /**

--- a/src/Helpers/AuthenticatorServiceProvider.php
+++ b/src/Helpers/AuthenticatorServiceProvider.php
@@ -14,6 +14,7 @@ class AuthenticatorServiceProvider extends ServiceProvider
         /** @var Authenticator $authenticator */
         $authenticator = $this->app->make(Authenticator::class);
         $authenticator->setPasswordAlgorithm($config->get('password_algorithm'));
+        $authenticator->setGuestRole($config->get('auth_guest_role', $authenticator->getGuestRole()));
 
         $this->app->instance(Authenticator::class, $authenticator);
         $this->app->instance('authenticator', $authenticator);

--- a/tests/Unit/HasDatabase.php
+++ b/tests/Unit/HasDatabase.php
@@ -58,6 +58,7 @@ trait HasDatabase
                     ['migration' => '2021_12_30_000000_remove_admin_news_html_privilege'],
                     ['migration' => '2022_06_02_000000_create_voucher_edit_permission'],
                     ['migration' => '2022_06_03_000000_shifts_add_transaction_id'],
+                    ['migration' => '2022_07_21_000000_fix_old_groups_table_id_and_name'],
                     ['migration' => '2022_10_21_000000_add_hide_register_to_angeltypes'],
                 ]
             );

--- a/tests/Unit/Helpers/AuthenticatorServiceProviderTest.php
+++ b/tests/Unit/Helpers/AuthenticatorServiceProviderTest.php
@@ -22,6 +22,7 @@ class AuthenticatorServiceProviderTest extends ServiceProviderTest
 
         $config = new Config();
         $config->set('password_algorithm', PASSWORD_DEFAULT);
+        $config->set('auth_guest_role', 42);
         $app->instance('config', $config);
 
         $serviceProvider = new AuthenticatorServiceProvider($app);
@@ -34,5 +35,6 @@ class AuthenticatorServiceProviderTest extends ServiceProviderTest
         /** @var Authenticator $auth */
         $auth = $app->get(Authenticator::class);
         $this->assertEquals(PASSWORD_DEFAULT, $auth->getPasswordAlgorithm());
+        $this->assertEquals(42, $auth->getGuestRole());
     }
 }

--- a/tests/Unit/Helpers/AuthenticatorTest.php
+++ b/tests/Unit/Helpers/AuthenticatorTest.php
@@ -132,7 +132,7 @@ class AuthenticatorTest extends ServiceProviderTest
             ->getMock();
         $auth->expects($this->exactly(1))
             ->method('getPermissionsByGroup')
-            ->with(-10)
+            ->with(10)
             ->willReturn([]);
         $auth->expects($this->exactly(1))
             ->method('getPermissionsByUser')
@@ -243,6 +243,18 @@ class AuthenticatorTest extends ServiceProviderTest
 
         $auth->setPasswordAlgorithm(PASSWORD_ARGON2I);
         $this->assertEquals(PASSWORD_ARGON2I, $auth->getPasswordAlgorithm());
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Authenticator::setGuestRole
+     * @covers \Engelsystem\Helpers\Authenticator::getGuestRole
+     */
+    public function testGuestRole()
+    {
+        $auth = $this->getAuthenticator();
+
+        $auth->setGuestRole(42);
+        $this->assertEquals(42, $auth->getGuestRole());
     }
 
     /**


### PR DESCRIPTION
Use positive IDs for groups, re-shuffle IDs and fix naming.