### PR TITLE
select2 width should be 100% to scale if the browser width changes

### DIFF
--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -122,6 +122,7 @@ $(function () {
 $(function () {
   $('select').select2({
     theme: 'bootstrap-5',
+    width: '100%',
   });
 })
 


### PR DESCRIPTION
prevent something like this:
![grafik](https://user-images.githubusercontent.com/1078640/205040768-3d2587f4-9d54-40a8-bd71-fd40da77aa5c.png)
