### PR TITLE
Secure tokens

### DIFF
--- a/db/factories/User/PasswordResetFactory.php
+++ b/db/factories/User/PasswordResetFactory.php
@@ -16,7 +16,7 @@ class PasswordResetFactory extends Factory
     public function definition()
     {
         return [
-            'token' => md5($this->faker->unique()->password()),
+            'token' => bin2hex(random_bytes(16)),
         ];
     }
 }

--- a/db/factories/User/UserFactory.php
+++ b/db/factories/User/UserFactory.php
@@ -19,7 +19,7 @@ class UserFactory extends Factory
             'name'     => $this->faker->unique()->userName(),
             'password' => password_hash($this->faker->password(), PASSWORD_DEFAULT),
             'email'    => $this->faker->unique()->safeEmail(),
-            'api_key'  => md5($this->faker->unique()->password()),
+            'api_key'  => bin2hex(random_bytes(16)),
         ];
     }
 }

--- a/db/factories/User/UserFactory.php
+++ b/db/factories/User/UserFactory.php
@@ -19,7 +19,7 @@ class UserFactory extends Factory
             'name'     => $this->faker->unique()->userName(),
             'password' => password_hash($this->faker->password(), PASSWORD_DEFAULT),
             'email'    => $this->faker->unique()->safeEmail(),
-            'api_key'  => bin2hex(random_bytes(16)),
+            'api_key'  => bin2hex(random_bytes(32)),
         ];
     }
 }

--- a/db/migrations/2022_12_06_000000_change_api_key_length.php
+++ b/db/migrations/2022_12_06_000000_change_api_key_length.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class ChangeApiKeyLength extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up()
+    {
+        $this->schema->table('users', function (Blueprint $table) {
+            $table->string('api_key', 64)->change();
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down()
+    {
+        $this->schema->table('users', function (Blueprint $table) {
+            $table->string('api_key', 32)->change();
+        });
+    }
+}

--- a/includes/model/User_model.php
+++ b/includes/model/User_model.php
@@ -212,7 +212,7 @@ function User_validate_planned_departure_date($planned_arrival_date, $planned_de
  */
 function User_reset_api_key($user, $log = true)
 {
-    $user->api_key = md5($user->name . time() . rand());
+    $user->api_key = bin2hex(random_bytes(16));
     $user->save();
 
     if ($log) {

--- a/includes/model/User_model.php
+++ b/includes/model/User_model.php
@@ -212,7 +212,7 @@ function User_validate_planned_departure_date($planned_arrival_date, $planned_de
  */
 function User_reset_api_key($user, $log = true)
 {
-    $user->api_key = bin2hex(random_bytes(16));
+    $user->api_key = bin2hex(random_bytes(32));
     $user->save();
 
     if ($log) {

--- a/src/Controllers/PasswordResetController.php
+++ b/src/Controllers/PasswordResetController.php
@@ -76,7 +76,7 @@ class PasswordResetController extends BaseController
         if ($user) {
             $reset = (new PasswordReset())->findOrNew($user->id);
             $reset->user_id = $user->id;
-            $reset->token = md5(random_bytes(64));
+            $reset->token = bin2hex(random_bytes(16));
             $reset->save();
 
             $this->log->info(


### PR DESCRIPTION
`md5()` isn't secure any more. replaced it with `random_bytes()`
32 chars is a bit less for a api key. increased it to 64 chars

`password_resets`->`token` is type `text` in database. should we change that to `varchar(32)`?
when do i have to add a migration in the `HasDatabase.php` migration list?