### PR TITLE
Ignore the timezone configured in php.ini, better cleanup after feature tests

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -286,7 +286,7 @@ return [
     'max_freeloadable_shifts' => env('MAX_FREELOADABLE_SHIFTS', 2),
 
     // Local timezone
-    'timezone'                => env('TIMEZONE', ini_get('date.timezone') ?: 'Europe/Berlin'),
+    'timezone'                => env('TIMEZONE', 'Europe/Berlin'),
 
     // Multiply 'night shifts' and freeloaded shifts (start or end between 2 and 6 exclusive) by 2
     'night_shifts'            => [

--- a/tests/Feature/ApplicationFeatureTest.php
+++ b/tests/Feature/ApplicationFeatureTest.php
@@ -11,4 +11,18 @@ abstract class ApplicationFeatureTest extends TestCase
         $_SERVER['HTTP_HOST'] = 'foo.bar';
         require __DIR__ . '/../../includes/engelsystem.php';
     }
+
+    /**
+     * Undo the changes done by the ConfigureEnvironmentServiceProvider
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        ini_set('display_errors', true);
+        error_reporting(E_ALL);
+
+        ini_set('date.timezone', 'UTC');
+        date_default_timezone_set('UTC');
+    }
 }


### PR DESCRIPTION
* Feature tests currently reset it to the configured one which is unexpected
* Servers can be misconfigured / have default configs which we don't want