### PR TITLE
invert input time icon color for chrome based browsers in dark themes

### DIFF
--- a/resources/assets/themes/dark.scss
+++ b/resources/assets/themes/dark.scss
@@ -6,3 +6,10 @@ $secondary: #222;
 $table-striped-bg: rgba(#fff, 0.05);
 
 $es-choices-highlight-color: #000;
+
+$invert-color-value: 1 !default;
+
+/* Invert the clock icon color for Chrome */
+input[type='time']::-webkit-calendar-picker-indicator {
+  filter: invert($invert-color-value);
+}

--- a/resources/views/pages/user-shifts.html
+++ b/resources/views/pages/user-shifts.html
@@ -13,7 +13,7 @@
                                 pattern="^\d{1,2}:\d{2}$" placeholder="HH:MM" maxlength="5" value="%start_time%"
                             >
                             <button class="btn btn-secondary" title="Now" type="button">
-                                <span class="bi bi-clock"></span>
+                                <span class="bi bi-arrow-counterclockwise"></span>
                             </button>
                         </div>
                     </div>
@@ -28,7 +28,7 @@
                                 pattern="^\d{1,2}:\d{2}$" placeholder="HH:MM" maxlength="5" value="%end_time%"
                             >
                             <button class="btn btn-secondary" title="Now" type="button">
-                                <span class="bi bi-clock"></span>
+                                <span class="bi bi-arrow-counterclockwise"></span>
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1078640/209973379-fe6ce439-c93c-4918-b3da-66aca3f6c71d.png)
after:
![image](https://user-images.githubusercontent.com/1078640/209973294-130782aa-4e07-427b-9a06-213fae101458.png)


should we also hide the date-picker icon?
```css
input[type='time']::-webkit-calendar-picker-indicator,
input[type='datetime-local']::-webkit-calendar-picker-indicator {
  display: none;
  -webkit-appearance: none;
}
```