### PR TITLE
Improve javascript

### DIFF
--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -212,7 +212,7 @@ function view_user_shifts()
     $days = load_days();
     $rooms = load_rooms();
     $types = load_types();
-    $ownTypes = [];
+    $ownAngelTypes = [];
 
     /** @var EloquentCollection|UserAngelType[] $userAngelTypes */
     $userAngelTypes = UserAngelType::whereUserId($user->id)
@@ -223,12 +223,12 @@ function view_user_shifts()
         })
         ->get();
     foreach ($userAngelTypes as $type) {
-        $ownTypes[] = $type->angel_type_id;
+        $ownAngelTypes[] = $type->angel_type_id;
     }
 
     if (!$session->has('shifts-filter')) {
         $room_ids = $rooms->pluck('id')->toArray();
-        $shiftsFilter = new ShiftsFilter(auth()->can('user_shifts_admin'), $room_ids, $ownTypes);
+        $shiftsFilter = new ShiftsFilter(auth()->can('user_shifts_admin'), $room_ids, $ownAngelTypes);
         $session->set('shifts-filter', $shiftsFilter->sessionExport());
     }
 
@@ -296,13 +296,7 @@ function view_user_shifts()
                     $shiftsFilter->getTypes(),
                     'types',
                     icon('person-lines-fill') . __('Angeltypes') . '<sup>1</sup>',
-                    [
-                        button(
-                            'javascript:checkOwnTypes(\'selection_types\', ' . json_encode($ownTypes) . ')',
-                            __('Own'),
-                            'd-print-none'
-                        ),
-                    ]
+                    $ownAngelTypes
                 ),
                 'filled_select' => make_select(
                     $filled,
@@ -378,20 +372,23 @@ function get_ids_from_array($array)
  * @param array  $selected
  * @param string $name
  * @param string $title
- * @param array  $additionalButtons
+ * @param int[]  $ownSelect
  * @return string
  */
-function make_select($items, $selected, $name, $title = null, $additionalButtons = [])
+function make_select($items, $selected, $name, $title = null, $ownSelect = [])
 {
     $html = '';
     if (isset($title)) {
         $html .= '<h4>' . $title . '</h4>' . "\n";
     }
 
-    $buttons = [];
-    $buttons[] = button('javascript:checkAll(\'selection_' . $name . '\', true)', __('All'), 'd-print-none');
-    $buttons[] = button('javascript:checkAll(\'selection_' . $name . '\', false)', __('None'), 'd-print-none');
-    $buttons = array_merge($buttons, $additionalButtons);
+    $buttons = [
+        button_checkbox_selection($name, __('All'), 'true'),
+        button_checkbox_selection($name, __('None'), 'false')
+    ];
+    if (count($ownSelect) > 0) {
+        $buttons[] = button_checkbox_selection($name, __('Own'), json_encode($ownSelect));
+    }
 
     $html .= buttons($buttons);
     $html .= '<div id="selection_' . $name . '" class="mb-3 selection ' . $name . '">' . "\n";

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -384,7 +384,7 @@ function make_select($items, $selected, $name, $title = null, $ownSelect = [])
 
     $buttons = [
         button_checkbox_selection($name, __('All'), 'true'),
-        button_checkbox_selection($name, __('None'), 'false')
+        button_checkbox_selection($name, __('None'), 'false'),
     ];
     if (count($ownSelect) > 0) {
         $buttons[] = button_checkbox_selection($name, __('Own'), json_encode($ownSelect));

--- a/includes/sys_template.php
+++ b/includes/sys_template.php
@@ -374,16 +374,17 @@ function button($href, $label, $class = '', $id = '')
 }
 
 /**
- * Rendert einen Knopf mit JavaScript onclick Handler
+ * Renders a button to select corresponding checkboxes
  *
- * @param string $javascript
+ * @param string $name
  * @param string $label
- * @param string $class
+ * @param string $value
  * @return string
  */
-function button_js($javascript, $label, $class = '')
+function button_checkbox_selection($name, $label, $value)
 {
-    return '<a onclick="' . $javascript . '" href="#" class="btn btn-secondary ' . $class . '">' . $label . '</a>';
+    return '<button type="button" class="btn btn-secondary d-print-none checkbox-selection" '
+        . 'data-id="selection_' . $name . '" data-value="' . $value . '">' . $label . '</button>';
 }
 
 /**

--- a/includes/view/UserDriverLicenses_view.php
+++ b/includes/view/UserDriverLicenses_view.php
@@ -50,6 +50,6 @@ function UserDriverLicense_edit_view($user_source, $user_driver_license)
                     ),
             ], 'driving_license'),
             form_submit('submit', __('Save')),
-        ])
+        ]),
     ], true);
 }

--- a/includes/view/UserDriverLicenses_view.php
+++ b/includes/view/UserDriverLicenses_view.php
@@ -50,20 +50,6 @@ function UserDriverLicense_edit_view($user_source, $user_driver_license)
                     ),
             ], 'driving_license'),
             form_submit('submit', __('Save')),
-        ]),
-        '
-        <script>
-            const checkboxElement = document.getElementById("wants_to_drive");
-            const drivingLicenseElement = document.getElementById("driving_license");
-
-            if (checkboxElement && drivingLicenseElement) {
-                drivingLicenseElement.hidden = !checkboxElement.checked;
-
-                checkboxElement.addEventListener("click", () => {
-                    drivingLicenseElement.hidden = !checkboxElement.checked;
-                });
-            }
-        </script>
-        ',
+        ])
     ], true);
 }

--- a/includes/view/UserDriverLicenses_view.php
+++ b/includes/view/UserDriverLicenses_view.php
@@ -53,18 +53,14 @@ function UserDriverLicense_edit_view($user_source, $user_driver_license)
         ]),
         '
         <script>
+            const checkboxElement = document.getElementById("wants_to_drive");
             const drivingLicenseElement = document.getElementById("driving_license");
 
-            if (drivingLicenseElement) {
-                const checkbox = document.getElementById("wants_to_drive");
-                drivingLicenseElement.style.display = checkbox?.checked
-                    ? ""
-                    : "none";
+            if (checkboxElement && drivingLicenseElement) {
+                drivingLicenseElement.hidden = !checkboxElement.checked;
 
-                checkbox.addEventListener("click", () => {
-                    drivingLicenseElement.style.display = document.getElementById("wants_to_drive")?.checked
-                        ? ""
-                        : "none";
+                checkboxElement.addEventListener("click", () => {
+                    drivingLicenseElement.hidden = !checkboxElement.checked;
                 });
             }
         </script>

--- a/resources/assets/js/countdown.js
+++ b/resources/assets/js/countdown.js
@@ -6,7 +6,7 @@ import { ready } from './ready';
 ready(() => {
   const lang = document.documentElement.getAttribute('lang');
 
-  const rtf = new Intl.RelativeTimeFormat(lang, { numeric: 'auto' });
+  const rtf = new Intl.RelativeTimeFormat(lang ?? [], { numeric: 'auto' });
 
   const timeFrames = [
     [60 * 60 * 24 * 365, 'year'],

--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -284,27 +284,20 @@ ready(() => {
  * Uses DOMContentLoaded to prevent flickering
  */
 ready(() => {
-  const filter = document.getElementById('collapseShiftsFilterSelect');
-  if (!filter || localStorage.getItem('collapseShiftsFilterSelect') !== 'hidden.bs.collapse') {
-    return;
+  const collapseElement = document.getElementById('collapseShiftsFilterSelect');
+  if (collapseElement) {
+    if (localStorage.getItem('collapseShiftsFilterSelect') === 'hidden.bs.collapse') {
+      collapseElement.classList.remove('show');
+    }
+
+    /**
+     * @param {Event} event
+     */
+    const onChange = (event) => {
+      localStorage.setItem('collapseShiftsFilterSelect', event.type);
+    };
+
+    collapseElement.addEventListener('hidden.bs.collapse', onChange);
+    collapseElement.addEventListener('shown.bs.collapse', onChange);
   }
-
-  filter.classList.remove('show');
-});
-
-ready(() => {
-  if (typeof localStorage === 'undefined') {
-    return;
-  }
-
-  /**
-   * @param {Event} event
-   */
-  const onChange = (event) => {
-    localStorage.setItem('collapseShiftsFilterSelect', event.type);
-  };
-
-  document.getElementById('collapseShiftsFilterSelect')?.addEventListener('hidden.bs.collapse', onChange);
-
-  document.getElementById('collapseShiftsFilterSelect')?.addEventListener('shown.bs.collapse', onChange);
 });

--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -4,28 +4,24 @@ import { ready } from './ready';
 
 /**
  * Sets all checkboxes to the wanted state
- *
- * @param {string} id Id of the element containing all the checkboxes
- * @param {boolean} checked True if the checkboxes should be checked
  */
-global.checkAll = (id, checked) => {
-  document.querySelectorAll(`#${id} input[type="checkbox"]`).forEach((element) => {
-    element.checked = checked;
+ready(() => {
+  document.querySelectorAll('button.checkbox-selection').forEach((buttonElement) => {
+    buttonElement.addEventListener('click', () => {
+      document.querySelectorAll(`#${buttonElement.dataset.id} input[type="checkbox"]`).forEach((checkboxElement) => {
+        /**
+         * @type {boolean|int[]}
+         */
+        const value = JSON.parse(buttonElement.dataset.value);
+        if (typeof value === 'boolean') {
+          checkboxElement.checked = value;
+        } else {
+          checkboxElement.checked = value.includes(Number(checkboxElement.value));
+        }
+      });
+    });
   });
-};
-
-/**
- * Sets the checkboxes according to the given type
- *
- * @param {string} id The Id of the element containing all the checkboxes
- * @param {int[]} shiftsList A list of numbers
- */
-global.checkOwnTypes = (id, shiftsList) => {
-  document.querySelectorAll(`#${id} input[type="checkbox"]`).forEach((element) => {
-    const value = Number(element.value);
-    element.checked = shiftsList.includes(value);
-  });
-};
+});
 
 ready(() => {
   /**

--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -301,3 +301,19 @@ ready(() => {
     collapseElement.addEventListener('shown.bs.collapse', onChange);
   }
 });
+
+/**
+ * Show/hide checkboxes for User Driver-Licenses
+ */
+ready(() => {
+  const checkboxElement = document.getElementById('wants_to_drive');
+  const drivingLicenseElement = document.getElementById('driving_license');
+
+  if (checkboxElement && drivingLicenseElement) {
+    drivingLicenseElement.hidden = !checkboxElement.checked;
+
+    checkboxElement.addEventListener('click', () => {
+      drivingLicenseElement.hidden = !checkboxElement.checked;
+    });
+  }
+});

--- a/resources/assets/js/ready.js
+++ b/resources/assets/js/ready.js
@@ -2,9 +2,9 @@
  * @param {Function} callback
  */
 export const ready = (callback) => {
-  if (document.readyState !== 'loading') {
-    callback();
-  } else {
+  if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', callback);
+  } else {
+    callback();
   }
 };

--- a/resources/views/pages/design.twig
+++ b/resources/views/pages/design.twig
@@ -263,15 +263,15 @@
                         {{ f.checkbox('form-input-checkbox-2', 'Checkbox 2', false, '2') }}
                         {{ f.checkbox('form-input-checkbox-3', 'Checkbox 3', false, '3') }}
                         <div class="d-grid gap-2">
-                            <div id="select-all-checkboxes" class="btn btn-sm btn-block btn-primary">
+                            <button type="button" class="btn btn-secondary d-print-none checkbox-selection" data-id="checkboxes" data-value="true">
                                 Select all
-                            </div>
-                            <div id="select-23-checkboxes" class="btn btn-sm btn-block btn-primary">
+                            </button>
+                            <button type="button" class="btn btn-secondary d-print-none checkbox-selection" data-id="checkboxes" data-value="[2,3]">
                                 Select 2, 3
-                            </div>
-                            <div id="unselect-all-checkboxes" class="btn btn-sm btn-block btn-danger">
+                            </button>
+                            <button type="button" class="btn btn-secondary d-print-none checkbox-selection" data-id="checkboxes" data-value="false">
                                 Unselect all
-                            </div>
+                            </button>
                         </div>
                     </div>
                     <div class="col-md-3 col-lg-2 checkbox-inline">
@@ -432,18 +432,6 @@
     </div>
     </div>
     <script>
-        document.getElementById('select-all-checkboxes').addEventListener('click', () => {
-            checkAll('checkboxes', true);
-        });
-
-        document.getElementById('unselect-all-checkboxes').addEventListener('click', () => {
-            checkAll('checkboxes', false);
-        });
-
-        document.getElementById('select-23-checkboxes').addEventListener('click', () => {
-            checkOwnTypes('checkboxes', [2, 3]);
-        });
-
         document.getElementById('form').addEventListener('submit', (e) => {
             e.preventDefault();
             return false;


### PR DESCRIPTION
- move all js code into js files (except some lines for the `design` page)
- simplify some scripts
- remove type attribute

we could set the `defer` attribute on the `<script>` then we don't need the `ready` function any more. or should we use `async` (then we still need the `ready` function and/or set `type="module"`. if we still use `ready` then we should maybe put all(?) into one `ready` function.
see the following links to understand:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attributes
- https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState
- https://gist.github.com/jakub-g/385ee6b41085303a53ad92c7c8afd7a6

if we use `type="module"` maybe we don't need the javascript build process any more.

with this PR we should be done with the js improvements/refactorings