### PR TITLE
Add git to dev container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ _vimrc_local.vim
 /public/assets
 /package-lock.json
 /yarn-error.log
+/.yarn-cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,9 @@ yarn lint:
   image: node:alpine
   stage: validate
   script:
+    # Install git, so that tools can use .gitignore.
+    # Not done in before_script because of <<: *use_yarn.
+    - apk add --no-cache git
     - yarn lint
 
 #

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -25,6 +25,6 @@ ENV TRUSTED_PROXIES 10.0.0.0/8,::ffff:10.0.0.0/8,\
 # Contains all tools required to build / manage the system
 FROM es_base AS es_workspace
 RUN echo 'memory_limit = 512M' > /usr/local/etc/php/conf.d/docker-php.ini
-RUN apk add --no-cache gettext nodejs npm yarn
+RUN apk add --no-cache gettext git nodejs npm yarn
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 ENTRYPOINT php -r 'sleep(PHP_INT_MAX);'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "yarn lint:eslint && yarn lint:prettier && yarn lint:ec",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check resources/assets",
-    "lint:ec": "ec --exclude \"node_modules|vendor|public/assets|.git\"",
+    "lint:ec": "ec",
     "lint:fix": "yarn lint:fix:eslint && yarn lint:fix:prettier",
     "lint:fix:eslint": "eslint --fix .",
     "lint:fix:prettier": "prettier --write resources/assets"


### PR DESCRIPTION
This was the reason why editorconfig-checker did not ignore the files.

Personal files, such as tools or editor data, should now go to a global `.gitignore`:

```
git config --global core.excludesfile ~/.gitignore
$EDITOR ~/.gitignore
```