### PR TITLE
Tweak navbar collapse as guest + fix language dropdown position

### DIFF
--- a/resources/views/layouts/parts/language_dropdown.twig
+++ b/resources/views/layouts/parts/language_dropdown.twig
@@ -1,0 +1,12 @@
+{% import 'macros/base.twig' as m %}
+
+{% if config('locales')|length > 1 %}
+    <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {{ m.icon('translate') }}
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end">
+            {{ menuLanguages()|join(" ")|raw }}
+        </ul>
+    </li>
+{% endif %}

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -49,6 +49,8 @@
             {% endif %}
             <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                 {% if is_guest() %}
+                    {% include "layouts/parts/language_dropdown.twig" %}
+
                     {% if has_permission_to('register') and config('registration_enabled') %}
                         {{ _self.toolbar_item(__('Register'), url('register'), 'register', 'plus') }}
                     {% endif %}
@@ -72,6 +74,7 @@
 
                     {{ menuUserHints() }}
 
+                    {% include "layouts/parts/language_dropdown.twig" %}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             {{ m.angel() }} {{ user.displayName }}
@@ -88,17 +91,6 @@
                             {% if has_permission_to('logout') %}
                                 {{ _self.dropdown_item(__('Logout'), url('logout'), 'logout', m.icon('box-arrow-left')) }}
                             {% endif %}
-                        </ul>
-                    </li>
-                {% endif %}
-
-                {% if config('locales')|length > 1 %}
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            {{ m.icon('translate') }}
-                        </a>
-                        <ul class="dropdown-menu dropdown-menu-end">
-                            {{ menuLanguages()|join(" ")|raw }}
                         </ul>
                     </li>
                 {% endif %}

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -22,7 +22,14 @@
     </li>
 {% endmacro %}
 
-<nav class="navbar fixed-top navbar-expand-xxl border-bottom {{ theme['navbar_classes'] }}">
+
+{% if is_guest() %}
+    {% set navbar_expand_class = 'navbar-expand-md' %}
+{% else %}
+    {% set navbar_expand_class = 'navbar-expand-xxl' %}
+{% endif %}
+
+<nav class="navbar fixed-top {{ navbar_expand_class }} border-bottom {{ theme['navbar_classes'] }}">
     <div class="container-fluid">
         <a class="navbar-brand" href="{{ url('/') }}">
             {{ m.angel() }}


### PR DESCRIPTION
- If not logged in, the navbar does not need to collapse so early
- It is common sense that the upper right item is a primary action / the user menu. Currently this is annoyingly the language switcher. Swapping this with the Login/Register buttons as guest and the user menu as logged in user.

---

## Before

Login page small(er) screen

![login_before_1](https://user-images.githubusercontent.com/6216686/233160912-ba9f4985-17e9-44d5-b439-7bb066d13337.png)

Login page with expanded navbar

![login_before_2](https://user-images.githubusercontent.com/6216686/233160904-221f6a02-a2aa-4bee-9b34-41271d01bf9d.png)

Logged in view

![logged_in_before](https://user-images.githubusercontent.com/6216686/233160974-eab02ea3-5404-496a-b514-f4e3f62d4ccc.png)

---

## After

![login_after](https://user-images.githubusercontent.com/6216686/233161002-ddb095ac-3afc-4717-b29c-e19ceb8473c6.png)

![logged_in_after](https://user-images.githubusercontent.com/6216686/233160977-048baca7-12e9-4752-bff7-9a411b1bea58.png)