### PR TITLE
Smaller changes

### DIFF
--- a/includes/pages/admin_user.php
+++ b/includes/pages/admin_user.php
@@ -79,7 +79,7 @@ function admin_user()
                     'eSize',
                     $tshirt_sizes,
                     $user_source->personalData->shirt_size,
-                    __('Please select...')
+                    __('form.select_placeholder')
                 )
                 . '</td></tr>' . "\n";
         }

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -435,7 +435,7 @@ function guest_register()
                     form_checkbox(
                         'email_shiftinfo',
                         __(
-                            'The %s is allowed to send me an email (e.g. when my shifts change)',
+                            'settings.profile.email_shiftinfo',
                             [config('app_name')]
                         ),
                         $email_shiftinfo

--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -505,7 +505,7 @@ function guest_register()
                         __('Shirt size') . ' ' . entry_required(),
                         $tshirt_sizes,
                         $tshirt_size,
-                        __('Please select...')
+                        __('form.select_placeholder')
                     ) : '',
                 ]),
             ]),

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1067,9 +1067,6 @@ msgstr ""
 "Mit diesem Formular registrierst Du Dich als Engel. Du bekommst ein Konto in "
 "der Engel-Aufgabenverwaltung."
 
-msgid "The %s is allowed to send me an email (e.g. when my shifts change)"
-msgstr "Das %s darf mir E-Mails senden (z.B. wenn sich meine Schichten ändern)"
-
 msgid "Notify me of new news"
 msgstr "Benachrichtige mich bei neuen News"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -999,9 +999,6 @@ msgstr "Alle Engel"
 msgid "This user does not exist."
 msgstr "Benutzer existiert nicht."
 
-msgid "Please select..."
-msgstr "Bitte auswählen..."
-
 msgid "Yes"
 msgstr "Ja"
 
@@ -1952,6 +1949,9 @@ msgstr ""
 
 
 
+
+msgid "form.select_placeholder"
+msgstr "Bitte auswählen..."
 
 msgid "form.load_schedule"
 msgstr "Programm laden"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -49,6 +49,9 @@ msgstr ""
 "[contributors list on GitHub](https://github.com/engelsystem/engelsystem/graphs/contributors)"
 " for a complete list."
 
+msgid "form.select_placeholder"
+msgstr "Please select..."
+
 msgid "form.load_schedule"
 msgstr "Load schedule"
 

--- a/resources/lang/pt_BR/default.po
+++ b/resources/lang/pt_BR/default.po
@@ -1339,8 +1339,7 @@ msgstr ""
 
 #: includes/pages/guest_login.php:229 includes/view/User_view.php:50
 #, php-format
-msgid ""
-"The %s is allowed to send me an email (e.g. when my shifts change)"
+msgid "settings.profile.email_shiftinfo"
 msgstr ""
 "Permito que o %s me envie emails (por exemplo, quando meus turnos "
 "mudam)"

--- a/resources/lang/pt_BR/default.po
+++ b/resources/lang/pt_BR/default.po
@@ -2168,7 +2168,7 @@ msgid "Truck 12t"
 msgstr "Caminhão 12t"
 
 #: includes/view/User_view.php:7
-msgid "Please select..."
+msgid "form.select_placeholder"
 msgstr "Por favor selecione..."
 
 #: includes/view/User_view.php:38

--- a/resources/views/admin/user/edit-shirt.twig
+++ b/resources/views/admin/user/edit-shirt.twig
@@ -22,7 +22,7 @@
                             'selected': userdata.personalData.shirt_size,
                             'required': true,
                             'required_icon': true,
-                            'default_option': __('Please select...'),
+                            'default_option': __('form.select_placeholder'),
                         }) }}
                     </div>
                 {% endif %}

--- a/resources/views/api/ical.twig
+++ b/resources/views/api/ical.twig
@@ -1,8 +1,8 @@
 {% set dateFormat = 'Ymd\\THis\\Z' %}
-{% set replacement = {'\n': '\\n'} %}
+{% set replacement = {'\\': '\\\\', ';': '\\;', ',': '\\,', '\n': '\\n'} %}
 BEGIN:VCALENDAR
 VERSION:2.0
-PRODID:-//-/{{ config('app_name') }}//DE
+PRODID:-//-/{{ config('app_name') | replace(replacement) | raw }}//DE
 CALSCALE:GREGORIAN
 {% for entry in shiftEntries %}
 BEGIN:VEVENT
@@ -12,12 +12,14 @@ DTSTART:{{ entry.shift.start.utc().format(dateFormat) }}
 DTEND:{{ entry.shift.end.utc().format(dateFormat) }}
 STATUS:CONFIRMED
 TRANSP:OPAQUE
-SUMMARY:{{ entry.shift.shiftType.name ~ ' (' ~ entry.shift.title ~ ')' | replace(replacement) | raw }}
+SUMMARY:{{ (entry.shift.shiftType.name ~ ' (' ~ entry.shift.title ~ ')') | replace(replacement) | raw }}
 LOCATION:{{ entry.shift.room.name | replace(replacement) | raw }}
 DESCRIPTION:{{
-    entry.shift.shiftType.description
-    ~ '\\n' ~ entry.shift.description
-    ~ '\\n' ~ entry.user_comment
+    (
+        entry.shift.shiftType.description
+        ~ '\n' ~ entry.shift.description
+        ~ '\n' ~ entry.user_comment
+    )
     | replace(replacement) | raw
 }}
 URL:{{ url('/shifts', {'action': 'view', 'shift_id': entry.shift.id}) | raw }}

--- a/resources/views/macros/base.twig
+++ b/resources/views/macros/base.twig
@@ -36,9 +36,9 @@
 
 {% macro button(label, url, type, size, title, icon_left, icon_right) %}
     <a href="{{ url }}" class="btn btn-{{ type|default('secondary') }}{% if size %} btn-{{ size }}{% endif %}"{% if title %} title="{{ title }}"{% endif %}>
-        {%- if icon_left is defined %}{{ _self.icon(icon_left) }}{% endif %}
+        {%- if icon_left %}{{ _self.icon(icon_left) }}{% endif %}
         {{ label }}
-        {%- if icon_right is defined %}{{ _self.icon(icon_right) }}{% endif %}
+        {%- if icon_right %}{{ _self.icon(icon_right) }}{% endif %}
     </a>
 {% endmacro %}
 

--- a/resources/views/macros/form.twig
+++ b/resources/views/macros/form.twig
@@ -87,7 +87,7 @@ Also adds buttons to increment / decrement the value.
 #}
 {% macro number(name, label, opt) %}
     <div class="mb-3">
-        {% if label is defined -%}
+        {% if label -%}
             <label class="form-label" for="{{ name }}">{{ label }}</label>
             {% if opt.required_icon|default(false) %}
                 {{ _self.entry_required() }}
@@ -142,7 +142,7 @@ Also adds buttons to increment / decrement the value.
 #}
 {% macro textarea(name, label, opt) %}
     <div class="mb-3">
-        {% if label is defined  -%}
+        {% if label  -%}
             <label class="form-label" for="{{ name }}">{{ label }}</label>
             {% if opt.required_icon|default(false) %}
                 {{ _self.entry_required() }}
@@ -180,7 +180,7 @@ Renders a select element wrapped in a DIV with mb-3.
 #}
 {% macro select(name, label, data, opt) %}
     <div class="mb-3">
-        {% if label is defined -%}
+        {% if label -%}
             <label class="form-label" for="{{ name }}">
                 {{ label }}
                 {% if opt.required_icon|default(false) %}

--- a/resources/views/pages/design.twig
+++ b/resources/views/pages/design.twig
@@ -333,7 +333,7 @@
                             {{ f.button('Button') }}
                         </div>
                         <div class="mb-3">
-                            {{ f.button('Small button with icons', {
+                            {{ f.button('sm button with icons', {
                                 'size': 'sm',
                                 'icon_left': 'check',
                                 'icon_right': 'info',

--- a/resources/views/pages/messages/overview.twig
+++ b/resources/views/pages/messages/overview.twig
@@ -21,7 +21,7 @@
                         'default_option': __('message.choose_angel'),
                     }) }}
                 </div>
-                <div class="col">
+                <div class="col-auto">
                     {{ f.submit(__('message.to_conversation'), {'btn_type': 'secondary'}) }}
                 </div>
             </div>

--- a/resources/views/pages/settings/profile.twig
+++ b/resources/views/pages/settings/profile.twig
@@ -109,9 +109,8 @@
             </div>
 
             <div class="col-md-6">
-                {{ f.checkbox('email_shiftinfo', __('settings.profile.email_shiftinfo'), {
-                    'checked': [config('app_name')],
-                    'value': user.settings.email_shiftinfo,
+                {{ f.checkbox('email_shiftinfo', __('settings.profile.email_shiftinfo', [config('app_name')]), {
+                    'checked': user.settings.email_shiftinfo,
                 }) }}
                 {{ f.checkbox('email_news', __('settings.profile.email_news'), {
                     'checked': user.settings.email_news,
@@ -129,7 +128,6 @@
                     %}
                     {{ f.checkbox('email_goody', email_goody_label, {
                         'checked': user.settings.email_goody,
-                        'value': user.settings.email_goody,
                         'raw_label': true,
                     }) }}
                 {% endif %}

--- a/resources/views/pages/settings/profile.twig
+++ b/resources/views/pages/settings/profile.twig
@@ -141,7 +141,7 @@
                         'selected': user.personalData.shirt_size,
                         'required': true,
                         'required_icon': true,
-                        'default_option': __('Please select...'),
+                        'default_option': __('form.select_placeholder'),
                     }) }}
                 </div>
             {% endif %}

--- a/src/Controllers/FeedController.php
+++ b/src/Controllers/FeedController.php
@@ -152,6 +152,6 @@ class FeedController extends BaseController
             ->leftJoin('shifts', 'shifts.id', 'shift_entries.shift_id')
             ->orderBy('shifts.start')
             ->with(['shift', 'shift.room', 'shift.shiftType'])
-            ->get();
+            ->get(['*', 'shift_entries.id']);
     }
 }


### PR DESCRIPTION
* Fix shiftinfo email text
* Cleanup twig macros
* Use translation key for `Please select...`
* Fixed ics escaping (closes  #1143: ics Export not working in Google Calendar) and IDs