### PR TITLE
Add .devcontainer for easy IDE integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "dockerComposeFile": "docker/dev/docker-compose.yml",
+	"service": "es_workspace",
+    "runServices": [
+        "es_database",
+        "es_server"
+    ],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"DEVSENSE.phptools-vscode",
+                "mblode.twig-language"
+			]
+		}
+	},
+    "workspaceFolder": "/var/www"
+}


### PR DESCRIPTION
Allows to easily start and connect to the docker compose dev environment.

Uses the already provided compose file