### PR TITLE
Add registration link when password is disabled (when using OAuth)

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -256,6 +256,9 @@ return [
     // Users are able to sign up
     'registration_enabled'    => (bool) env('REGISTRATION_ENABLED', true),
 
+    // URL to external registration page, used on login page
+    'external_registration_url'   => env('EXTERNAL_REGISTRATION_URL'),
+
     // Required user fields
     'required_user_fields' => [
         'pronoun'            => (bool) env('PRONOUN_REQUIRED', false),
@@ -300,9 +303,8 @@ return [
     // The minimum length for passwords
     'min_password_length'     => env('PASSWORD_MINIMUM_LENGTH', 8),
 
-    // Whether the Password field should be enabled on registration.
-    // This is useful when using oauth, disabling it also disables normal
-    // registration without oauth.
+    // Whether the login and registration via password should be enabled (login will be hidden)
+    // This is useful when using oauth, disabling it also disables normal registration without oauth
     'enable_password'         => (bool) env('ENABLE_PASSWORD', true),
 
     // Whether the DECT field should be enabled

--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -360,7 +360,7 @@ ready(() => {
  */
 ready(() => {
   [
-    ['welcome-title', '.btn-group .btn.d-none'],
+    ['welcome-title', '.registration .d-none'],
     ['settings-title', '.user-settings .nav-item'],
     ['oauth-settings-title', 'table tr.d-none'],
   ].forEach(([id, selector]) => {

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -63,7 +63,12 @@
                     {% include "layouts/parts/language_dropdown.twig" %}
 
                     {% if has_permission_to('register') and config('registration_enabled') %}
-                        {{ _self.toolbar_item(__('general.register'), url('/register'), 'register', 'plus') }}
+                        {{ _self.toolbar_item(
+                            __('general.register'),
+                            config('external_registration_url') ?: url('/register'),
+                            'register',
+                            'plus'
+                        ) }}
                     {% endif %}
 
                     {% if has_permission_to('login') %}

--- a/resources/views/pages/angeltypes/about.twig
+++ b/resources/views/pages/angeltypes/about.twig
@@ -15,7 +15,10 @@
                     </a>
                 {% else %}
                     {% if has_permission_to('register') and config('registration_enabled') %}
-                        <a href="{{ url('/register') }}" class="btn btn-secondary back">
+                        <a
+                            href="{{ config('external_registration_url') ?: url('/register') }}"
+                            class="btn btn-secondary back"
+                        >
                             {{ __('registration.register') }}
                         </a>
                     {% endif %}

--- a/resources/views/pages/login.twig
+++ b/resources/views/pages/login.twig
@@ -30,7 +30,8 @@
 
         <div class="row mb-5">
             <div class="col-md-6 offset-md-3 col-lg-4 offset-lg-4">
-                <div class="card {{ m.type_bg_class() }}">
+                <div class="card {{ m.type_bg_class() }} registration">
+                    {% set login_hidden = not config('enable_password') %}
                     <div class="card-body">
                         {% include 'layouts/parts/messages.twig' %}
 
@@ -40,7 +41,7 @@
 
                         <form action="" enctype="multipart/form-data" method="post">
                             {{ csrf() }}
-                            <div class="mb-3">
+                            <div class="mb-3{% if login_hidden %} d-none{% endif %}">
                                 <div class="input-group input-group-lg">
                                     <span class="input-group-text {{ m.type_text_class() }}">
                                         {{ m.angel }}
@@ -56,7 +57,7 @@
                                 </div>
                             </div>
 
-                            <div class="mb-3">
+                            <div class="mb-3{% if login_hidden %} d-none{% endif %}">
                                 <div class="input-group input-group-lg">
                                     <span class="input-group-text {{ m.type_text_class() }}">
                                         <i class="bi bi-key"></i>
@@ -68,7 +69,7 @@
                                 </div>
                             </div>
 
-                            <div class="mb-3 text-center">
+                            <div class="mb-3 text-center{% if login_hidden %} d-none{% endif %}">
                                 <button class="btn btn-primary btn-lg btn-block" type="submit" name="submit">
                                     {{ __('general.login') }}
                                 </button>
@@ -89,7 +90,7 @@
                                 </div>
                             {% endif %}
 
-                            <div class="text-center">
+                            <div class="text-center{% if login_hidden %} d-none{% endif %}">
                                 <a href="{{ url('/password/reset') }}" class="">
                                     {{ __('login.password.reset') }}
                                 </a>
@@ -103,15 +104,19 @@
         <div class="row mb-5">
             <div class="col-sm-6 text-center">
                 <h2>{{ __('general.register') }}</h2>
-                {% if has_permission_to('register') and config('registration_enabled') %}
-                    {% if config('enable_password') %}
-                        <p>{{ __('login.registration') }}</p>
-                        <a href="{{ url('/register') }}" class="btn btn-primary">{{ __('general.register') }} &raquo;</a>
-                    {% else %}
-                        <p>{{ __('login.registration.external') }}</p>
-                    {% endif %}
+                {% if
+                    (has_permission_to('register') and config('registration_enabled') and config('enable_password'))
+                    or config('external_registration_url') %}
+                    <p>{{ __('login.registration') }}</p>
+
+                    {% set registration_url = config('external_registration_url') ?: url('/register') %}
+                    <a href="{{ registration_url }}" class="btn btn-primary">{{ __('general.register') }} &raquo;</a>
                 {% else %}
-                    {{ m.alert(__('login.registration.disabled'), 'danger') }}
+                    {% if not config('enable_password') %}
+                        <p>{{ __('login.registration.external') }}</p>
+                    {% else %}
+                        {{ m.alert(__('login.registration.disabled'), 'danger') }}
+                    {% endif %}
                 {% endif %}
             </div>
 


### PR DESCRIPTION
Some small improvements to make oauth more smooth and less complains by users.

Allows you to set a link for the register button if register is disabled.
Does not show login form by default if enable_password is false. There is a small link to show the form or by passing password in the get parameter.
