### PR TITLE
Fix msgfmt error: keyword "settings" unknown

### DIFF
--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -308,7 +308,7 @@ msgstr "Here you can change your theme."
 msgid "settings.theme.success"
 msgstr "Theme was changed successfully."
 
-msgid settings.certificates
+msgid "settings.certificates"
 msgstr "Certificates"
 
 msgid "settings.certificates.info"


### PR DESCRIPTION
When running
```
docker compose exec es_workspace find /var/www/resources/lang -type f -name '*.po' -exec sh -c 'file="{}"; msgfmt "${file%.*}.po" -o "${file%.*}.mo"' \;
```
(as instructed in DEVELOPMENT.md) I got this:

```
/var/www/resources/lang/en_US/default.po:311: keyword "settings" unknown
/var/www/resources/lang/en_US/default.po:311:15: syntax error
msgfmt: found 2 fatal errors
```