### PR TITLE
Extended shifts view, fixed ifsg displays, prevent duplicated news

### DIFF
--- a/includes/controller/shifttypes_controller.php
+++ b/includes/controller/shifttypes_controller.php
@@ -122,7 +122,7 @@ function shifttype_controller()
  */
 function shifttypes_list_controller()
 {
-    $shifttypes = ShiftType::all();
+    $shifttypes = ShiftType::all()->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE);
 
     return [
         shifttypes_title(),

--- a/includes/controller/user_driver_licenses_controller.php
+++ b/includes/controller/user_driver_licenses_controller.php
@@ -41,7 +41,11 @@ function user_ifsg_certificate_required_hint()
 
     $angeltypes = $user->userAngelTypes;
     foreach ($angeltypes as $angeltype) {
-        if ($angeltype->requires_ifsg_certificate) {
+        if (
+            $angeltype->requires_ifsg_certificate && !(
+                $user->license->ifsg_certificate || $user->license->ifsg_certificate_light
+            )
+        ) {
             return sprintf(
                 __('angeltype.ifsg.required.info.here'),
                 '<a href="' . url('/settings/certificates') . '">' . __('ifsg.info') . '</a>'

--- a/includes/pages/admin_arrive.php
+++ b/includes/pages/admin_arrive.php
@@ -78,7 +78,13 @@ function admin_arrive()
     foreach ($users as $usr) {
         if (count($tokens) > 0) {
             $match = false;
-            $index = join(' ', $usr->attributesToArray());
+            $data = collect($usr->toArray())->flatten()->filter(function ($value) {
+                // Remove empty values
+                return !empty($value) &&
+                    // Skip datetime
+                    !preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z$/', (string) $value);
+            });
+            $index = join(' ', $data->toArray());
             foreach ($tokens as $token) {
                 $token = trim($token);
                 if (!empty($token) && stristr($index, $token)) {

--- a/includes/pages/admin_shifts.php
+++ b/includes/pages/admin_shifts.php
@@ -310,13 +310,20 @@ function admin_shifts()
 
             $shifts_table = [];
             foreach ($shifts as $shift) {
+                /** @var Carbon $start */
+                $start = $shift['start'];
+                /** @var Carbon $end */
+                $end = $shift['end'];
                 $shifts_table_entry = [
                     'timeslot'      =>
                         icon('clock-history') . ' '
-                        . $shift['start']->format(__('Y-m-d H:i'))
+                        . $start->format(__('Y-m-d H:i'))
                         . ' - '
-                        . $shift['end']->format(__('H:i'))
-                        . '<br />'
+                        . '<span title="' . $end->format(__('Y-m-d')) . '">'
+                        . $end->format(__('H:i'))
+                        . '</span>'
+                        . ', ' . round($end->copy()->diffInMinutes($start) / 60, 2) . 'h'
+                        . '<br>'
                         . Room_name_render(Room::find($shift['room_id'])),
                     'title'         =>
                         ShiftType_name_render(ShiftType::find($shifttype_id))

--- a/includes/view/AngelTypes_view.php
+++ b/includes/view/AngelTypes_view.php
@@ -191,7 +191,11 @@ function AngelType_view_buttons(
             error(__('This angeltype requires a driver license. Please enter your driver license information!'));
         }
 
-        if (config('ifsg_enabled') && $angeltype->requires_ifsg_certificate && (!$user->license->ifsg_certificate_light || !$user->license->ifsg_certificate)) {
+        if (
+            config('ifsg_enabled') && $angeltype->requires_ifsg_certificate && !(
+            $user->license->ifsg_certificate_light || $user->license->ifsg_certificate
+            )
+        ) {
             error(__('angeltype.ifsg.required.info'));
         }
 
@@ -250,6 +254,10 @@ function AngelType_view_members(AngelType $angeltype, $members, $admin_user_ange
             $member['has_license_7_5t_truck'] = icon_bool($member->license->drive_7_5t);
             $member['has_license_12t_truck'] = icon_bool($member->license->drive_12t);
             $member['has_license_forklift'] = icon_bool($member->license->drive_forklift);
+        }
+        if ($angeltype->requires_ifsg_certificate) {
+            $member['ifsg_certificate'] = icon_bool($member->license->ifsg_certificate);
+            $member['ifsg_certificate_light'] = icon_bool($member->license->ifsg_certificate_light);
         }
 
         if ($angeltype->restricted && empty($member->pivot->confirm_user_id)) {
@@ -336,13 +344,14 @@ function AngelType_view_table_headers(AngelType $angeltype, $supporter, $admin_a
 {
     $headers = [
         'name'    => __('Nick'),
-        'dect'    => __('DECT'),
-        'actions' => '',
     ];
+
+    if (config('enable_dect')) {
+        $headers['dect'] = __('DECT');
+    }
+
     if ($angeltype->requires_driver_license && ($supporter || $admin_angeltypes)) {
-        $headers = [
-            'name'                         => __('Nick'),
-            'dect'                         => __('DECT'),
+        $headers = array_merge($headers, [
             'wants_to_drive'               => __('Driver'),
             'has_car'                      => __('Has car'),
             'has_license_car'              => __('Car'),
@@ -350,12 +359,16 @@ function AngelType_view_table_headers(AngelType $angeltype, $supporter, $admin_a
             'has_license_7_5t_truck'       => __('7,5t Truck'),
             'has_license_12t_truck'        => __('12t Truck'),
             'has_license_forklift'         => __('Forklift'),
-            'actions'                      => '',
-        ];
+        ]);
     }
-    if (!config('enable_dect')) {
-        unset($headers['dect']);
+
+    if (config('ifsg_enabled') && $angeltype->requires_ifsg_certificate && ($supporter || $admin_angeltypes)) {
+        $headers['ifsg_certificate_light'] = __('ifsg.certificate_light');
+        $headers['ifsg_certificate'] = __('ifsg.certificate');
     }
+
+    $headers['actions'] = '';
+
     return $headers;
 }
 

--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -2,6 +2,7 @@
 
 namespace Engelsystem;
 
+use Engelsystem\Helpers\Carbon;
 use Engelsystem\Models\Shifts\Shift;
 use Engelsystem\Models\Shifts\ShiftEntry;
 use Illuminate\Support\Collection;
@@ -212,20 +213,21 @@ class ShiftCalendarRenderer
      */
     private function renderTick($time, $label = false)
     {
+        $time = Carbon::createFromTimestamp($time);
         $class = $label ? 'tick bg-' . theme_type() : 'tick ';
-        if ($time % (24 * 60 * 60) == 23 * 60 * 60) {
+        if ($time->isStartOfDay()) {
             if (!$label) {
                 return div($class . ' day');
             }
             return div($class . ' day', [
-                date(__('m-d'), $time) . '<br>' . date(__('H:i'), $time),
+                $time->format(__('m-d')) . '<br>' . $time->format(__('H:i')),
             ]);
-        } elseif ($time % (60 * 60) == 0) {
+        } elseif ($time->isStartOfHour()) {
             if (!$label) {
                 return div($class . ' hour');
             }
             return div($class . ' hour', [
-                date(__('m-d'), $time) . '<br>' . date(__('H:i'), $time),
+                $time->format(__('m-d')) . '<br>' . $time->format(__('H:i')),
             ]);
         }
         return div($class);

--- a/resources/lang/de_DE/additional.po
+++ b/resources/lang/de_DE/additional.po
@@ -80,6 +80,9 @@ msgstr "Kommentar gespeichert."
 msgid "news.comment-delete.success"
 msgstr "Kommentar erfolgreich gelöscht."
 
+msgid "news.edit.duplicate"
+msgstr "Diese News wurde bereits erstellt."
+
 msgid "news.edit.success"
 msgstr "News erfolgreich aktualisiert."
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -2233,6 +2233,9 @@ msgstr "Benötigt eine Gesundheitsbelehrung"
 msgid "ifsg.certificate"
 msgstr "Gesundheitsbelehrung"
 
+msgid "ifsg.certificate_light"
+msgstr "Gesundheitsbelehrung vor Ort"
+
 msgid "angeltype.ifsg.own"
 msgstr "Meine Gesundheitsbelehrung"
 

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -78,6 +78,9 @@ msgstr "Comment saved."
 msgid "news.comment-delete.success"
 msgstr "Comment successfully deleted."
 
+msgid "news.edit.duplicate"
+msgstr "Diese News wurde bereits erstellt."
+
 msgid "news.edit.success"
 msgstr "News successfully updated."
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -331,6 +331,9 @@ msgstr "Requires health instruction"
 msgid "ifsg.certificate"
 msgstr "health instruction"
 
+msgid "ifsg.certificate_light"
+msgstr "health instruction on site"
+
 msgid "angeltype.ifsg.own"
 msgstr "my health instruction"
 

--- a/src/Controllers/Admin/NewsController.php
+++ b/src/Controllers/Admin/NewsController.php
@@ -6,6 +6,7 @@ namespace Engelsystem\Controllers\Admin;
 
 use Engelsystem\Controllers\BaseController;
 use Engelsystem\Controllers\HasUserNotifications;
+use Engelsystem\Controllers\NotificationType;
 use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Redirector;
 use Engelsystem\Http\Request;
@@ -104,6 +105,10 @@ class NewsController extends BaseController
         }
 
         $isNewNews = !$news->id;
+        if ($isNewNews && News::where('title', $news->title)->where('text', $news->text)->count()) {
+            $this->addNotification('news.edit.duplicate', NotificationType::ERROR);
+            return $this->showEdit($news);
+        }
         $news->save();
 
         if ($isNewNews) {

--- a/src/Controllers/Admin/UserWorkLogController.php
+++ b/src/Controllers/Admin/UserWorkLogController.php
@@ -64,9 +64,9 @@ class UserWorkLogController extends BaseController
         $user = $this->user->findOrFail($userId);
 
         $data = $this->validate($request, [
-            'work_date'  => 'required|date:Y-m-d',
+            'work_date' => 'required|date:Y-m-d',
             'work_hours' => 'float|min:0',
-            'comment'    => 'required|max:200',
+            'comment' => 'required|max:200',
         ]);
 
         if (isset($worklogId)) {
@@ -85,6 +85,16 @@ class UserWorkLogController extends BaseController
         $worklog->comment = $data['comment'];
         $worklog->save();
 
+        $this->log->info(
+            'Added worklog for {name} ({id}) at {time} about {hours}h: {text}',
+            [
+                'name' => $user->name,
+                'id' => $user->id,
+                'time' => $worklog->worked_at,
+                'hours' => $worklog->hours,
+                'text' => $worklog->comment,
+            ]
+        );
         $this->addNotification(isset($worklogId) ? 'worklog.edit.success' : 'worklog.add.success');
 
         return $this->redirect->to('/users?action=view&user_id=' . $userId);

--- a/src/Helpers/Carbon.php
+++ b/src/Helpers/Carbon.php
@@ -18,7 +18,7 @@ class Carbon extends \Carbon\Carbon
     /**
      * Parses HTML datetime-local and ISO date/time strings.
      *
-     * @return \Carbon\Carbon|null Carbon if parseable, else null
+     * @return self|null Carbon if parseable, else null
      * @see self::DATETIME_FORMATS
      */
     public static function createFromDatetime(string $value): ?\Carbon\Carbon
@@ -42,5 +42,17 @@ class Carbon extends \Carbon\Carbon
     {
         $carbon = self::createFromDateTime($value);
         return $carbon === null ? null : $carbon->timestamp;
+    }
+
+    /**
+     * Check if the instance is at the start of an hour.
+     *
+     * @param bool $checkMicroseconds check time at microseconds precision
+     */
+    public function isStartOfHour(bool $checkMicroseconds = false): bool
+    {
+        return $checkMicroseconds
+            ? $this->rawFormat('i:s.u') === '00:00.000000'
+            : $this->rawFormat('i:s') === '00:00';
     }
 }

--- a/src/Models/User/License.php
+++ b/src/Models/User/License.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property bool $drive_3_5t
  * @property bool $drive_7_5t
  * @property bool $drive_12t
+ * @property bool $ifsg_certificate_light
+ * @property bool $ifsg_certificate
  *
  * @method static QueryBuilder|License[] whereHasCar($value)
  * @method static QueryBuilder|License[] whereDriveForklift($value)
@@ -21,6 +23,8 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @method static QueryBuilder|License[] whereDrive35T($value)
  * @method static QueryBuilder|License[] whereDrive75T($value)
  * @method static QueryBuilder|License[] whereDrive12T($value)
+ * @method static QueryBuilder|License[] whereIfsgCertificateLight($value)
+ * @method static QueryBuilder|License[] whereIfsgCertificate($value)
  */
 class License extends HasUserModel
 {

--- a/tests/Unit/Controllers/Admin/NewsControllerTest.php
+++ b/tests/Unit/Controllers/Admin/NewsControllerTest.php
@@ -229,6 +229,29 @@ class NewsControllerTest extends ControllerTest
     }
 
     /**
+     * @covers \Engelsystem\Controllers\Admin\NewsController::save
+     */
+    public function testSaveDuplicated(): void
+    {
+        $previousNews = News::first();
+        $this->request = $this->request->withParsedBody([
+            'title'  => $previousNews->title,
+            'text'   => $previousNews->text,
+        ]);
+        $this->response->expects($this->once())
+            ->method('withView')
+            ->willReturn($this->response);
+
+        /** @var NewsController $controller */
+        $controller = $this->app->make(NewsController::class);
+        $controller->setValidator(new Validator());
+
+        $controller->save($this->request);
+
+        $this->assertHasNotification('news.edit.duplicate', NotificationType::ERROR);
+    }
+
+    /**
      * Creates a new user
      */
     protected function addUser(): void

--- a/tests/Unit/Controllers/Admin/UserWorkLogControllerTest.php
+++ b/tests/Unit/Controllers/Admin/UserWorkLogControllerTest.php
@@ -109,7 +109,7 @@ class UserWorkLogControllerTest extends ControllerTest
     /**
      * @covers \Engelsystem\Controllers\Admin\UserWorkLogController::saveWorklog
      */
-    public function testSaveWorklogWithUnkownUserIdThrows(): void
+    public function testSaveWorklogWithUnknownUserIdThrows(): void
     {
         $request = $this->request->withAttribute('user_id', 1234)->withParsedBody([]);
         $this->expectException(ModelNotFoundException::class);
@@ -147,6 +147,8 @@ class UserWorkLogControllerTest extends ControllerTest
         $this->controller->saveWorklog($request);
 
         $this->assertHasNotification('worklog.add.success');
+        $this->assertTrue($this->log->hasInfoThatContains('Added worklog for'));
+
         $this->assertEquals(1, $this->user->worklogs->count());
         $new_worklog = $this->user->worklogs[0];
         $this->assertEquals($this->user->id, $new_worklog->user->id);

--- a/tests/Unit/Helpers/CarbonTest.php
+++ b/tests/Unit/Helpers/CarbonTest.php
@@ -65,4 +65,28 @@ class CarbonTest extends TestCase
         $timestamp = Carbon::createTimestampFromDatetime($value);
         self::assertNull($timestamp);
     }
+
+    public function startOfHourDates(): array
+    {
+        return [
+            ['2022-04-16 10:00:00.000000', true],
+            ['2022-04-16 10:00:00.000000', true, true],
+            ['2022-04-16 10:00:00.123456', true, false],
+            ['2022-04-16 23:00:00.000000', true, false],
+            ['2022-04-16 10:00:42.000000', false],
+            ['2022-04-16 10:23:00.000000', false],
+            ['2022-04-16 10:00:00.123456', false, true],
+        ];
+    }
+
+    /**
+     * @covers       \Engelsystem\Helpers\Carbon::isStartOfHour
+     * @dataProvider startOfHourDates
+     */
+    public function testIsStartOfHour(string $value, bool $expected, bool $checkMicroseconds = false): void
+    {
+        $date = Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+
+        $this->assertEquals($expected, $date->isStartOfHour($checkMicroseconds));
+    }
 }


### PR DESCRIPTION
* Add ifsg ofno to angeltype user table, fixed hint messages
* Log worklog creation
* sort shift types by name
* Add more info to shifts creation preview about length
* Ignore dates in arrive search (for example 23 shows all angels)
* Show error when saving the same news a second time (might happen when reloading the page after an error occurred)
* Fix start of day marker on shifts view