### PR TITLE
Schedule import: Show error message on schedule parsing errors

### DIFF
--- a/src/Helpers/Schedule/XmlParser.php
+++ b/src/Helpers/Schedule/XmlParser.php
@@ -15,8 +15,7 @@ class XmlParser
 
     public function load(string $xml): bool
     {
-        $scheduleXML = simplexml_load_string($xml);
-
+        $scheduleXML = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOWARNING | LIBXML_NOERROR);
         if (!$scheduleXML) {
             return false;
         }

--- a/tests/Unit/Helpers/Schedule/Assets/schedule-invalid.html
+++ b/tests/Unit/Helpers/Schedule/Assets/schedule-invalid.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="">
+<head>
+    <title>I'm HTML!</title>
+</head>
+<body>
+This is not a schedule<br>
+and thus must be ignored.
+</body>
+</html>

--- a/tests/Unit/Helpers/Schedule/XmlParserTest.php
+++ b/tests/Unit/Helpers/Schedule/XmlParserTest.php
@@ -23,12 +23,13 @@ class XmlParserTest extends TestCase
      */
     public function testLoad(): void
     {
-        libxml_use_internal_errors(true);
-
         $parser = new XmlParser();
 
         // Invalid XML
         $this->assertFalse($parser->load('foo'));
+        // Invalid schedule
+        $this->assertFalse($parser->load(file_get_contents(__DIR__ . '/Assets/schedule-invalid.html')));
+
         // Minimal import
         $this->assertTrue($parser->load(file_get_contents(__DIR__ . '/Assets/schedule-minimal.xml')));
         // Basic import


### PR DESCRIPTION
At the moment, when an invalid XML file is loaded, the UI shows an error page.