### PR TITLE
Shifts feed: Added URL to shit and shifttype name & description

### DIFF
--- a/src/Controllers/FeedController.php
+++ b/src/Controllers/FeedController.php
@@ -8,6 +8,7 @@ use Carbon\CarbonTimeZone;
 use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
+use Engelsystem\Http\UrlGenerator;
 use Engelsystem\Models\News;
 use Engelsystem\Models\Shifts\ShiftEntry;
 use Illuminate\Support\Collection;
@@ -26,6 +27,7 @@ class FeedController extends BaseController
         protected Authenticator $auth,
         protected Request $request,
         protected Response $response,
+        protected UrlGenerator $url,
     ) {
     }
 
@@ -74,16 +76,22 @@ class FeedController extends BaseController
                 'name'           => $shift->shiftType->name,
                 // Shift / Talk title
                 'title'          => $shift->title,
-                // Shift description
+                // Shift description, should be shown after shifttype_description, markdown formatted
                 'description'    => $shift->description,
+
+                'link'           => $this->url->to('/shifts', ['action' => 'view', 'shift_id' => $shift->id]),
 
                 // Users comment
                 'Comment'        => $entry->user_comment,
 
                 // Shift id
                 'SID'            => $shift->id,
-                // Shift type id
+
+                // Shift type
                 'shifttype_id'   => $shift->shiftType->id,
+                'shifttype_name' => $shift->shiftType->name, // General type of the task
+                'shifttype_description' => $shift->shiftType->description, // General description, markdown formatted
+
                 // Talk URL
                 'URL'            => $shift->url,
 


### PR DESCRIPTION
Closes #1104

New output:

```json
[
  {
    "id": 3,
    "shift_id": 198,
    "angel_type_id": 1,
    "user_id": 1,
    "user_comment": "",
    "freeloaded": false,
    "title": "Bar Runner",
    "description": "Foo Bar!\n**Baz!**",
    "url": "",
    "start": 1685829600,
    "end": 1685836800,
    "shift_type_id": 4,
    "room_id": 1,
    "transaction_id": "d171dc41-7ab7-4470-91bb-8668ba725242",
    "created_by": 1,
    "updated_by": 1,
    "created_at": "2023-06-04 22:29:53",
    "updated_at": "2023-10-17 19:29:19",
    "shift": {
      // ...
      },
      "shift_type": {
        "id": 4,
        "name": "Schichttyp1",
        "description": "The first shift type or whatever"
      }
    },
    "name": "Schichttyp1",
    "link": "http://localhost:5080/shifts?action=view&shift_id=198",
    "Comment": "",
    "SID": 198,
    "shifttype_id": 4,
    "shifttype_name": "Schichttyp1",
    "shifttype_description": "The first shift type",
    "URL": "",
    "RID": 1,
    "Name": "Testraum",
    "map_url": null,
    "start_date": "2023-06-04T00:00:00+02:00",
    "end_date": "2023-06-04T02:00:00+02:00",
    "timezone": "+02:00",
    "event_timezone": "Europe/Berlin"
  },
// ...
]
```
