### PR TITLE
Test all factories, fix dropdown, update error messages

### DIFF
--- a/db/factories/OAuthFactory.php
+++ b/db/factories/OAuthFactory.php
@@ -19,7 +19,7 @@ class OAuthFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
+            'user_id'   => User::factory(),
             'provider' => $this->faker->unique()->word(),
             'identifier' => $this->faker->unique()->word(),
             'access_token' => $this->faker->unique()->word(),

--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -238,6 +238,8 @@ ready(() => {
   document.querySelectorAll('select').forEach((element) => {
     element.choices = new Choices(element, {
       allowHTML: true,
+      shouldSort: false,
+      shouldSortItems: false,
       classNames: {
         containerInner: 'choices__inner form-control',
       },

--- a/resources/assets/themes/choices.scss
+++ b/resources/assets/themes/choices.scss
@@ -20,6 +20,10 @@ $es-choices-highlight-color: $choices-text-color !default;
   padding: $input-padding-y 1.75rem $input-padding-y $input-padding-x !important;
 }
 
+.#{$choices-selector} .#{$choices-selector}__list {
+  z-index: $zindex-sticky + 2;
+}
+
 .#{$choices-selector}__list--single {
   padding: 0;
 }

--- a/resources/views/macros/base.twig
+++ b/resources/views/macros/base.twig
@@ -35,7 +35,10 @@
 {% endmacro %}
 
 {% macro button(label, url, type, size, title, icon_left, icon_right) %}
-    <a href="{{ url }}" class="btn btn-{{ type|default('secondary') }}{% if size %} btn-{{ size }}{% endif %}"{% if title %} title="{{ title }}"{% endif %}>
+    <a href="{{ url }}" class="btn btn-{{ type|default('secondary') }}
+        {%- if size %} btn-{{ size }}{% endif %}"
+        {%- if title %} title="{{ title }}"{% endif -%}
+    >
         {%- if icon_left %}{{ _self.icon(icon_left) }}{% endif %}
         {{ label }}
         {%- if icon_right %}{{ _self.icon(icon_right) }}{% endif %}

--- a/resources/views/macros/form.twig
+++ b/resources/views/macros/form.twig
@@ -105,15 +105,9 @@ Also adds buttons to increment / decrement the value.
                 {%- if opt.min is defined %} min="{{ opt.min }}"{% endif %}
                 {%- if opt.max is defined %} max="{{ opt.max }}"{% endif %}
                 {%- if opt.step is defined %} step="{{ opt.step }}"{% endif %}
-                {%- if opt.required|default(false) %}
-                    required
-                {%- endif -%}
-                {%- if opt.disabled|default(false) %}
-                    disabled
-                {%- endif -%}
-                {%- if opt.readonly|default(false) %}
-                    readonly
-                {%- endif -%}
+                {%- if opt.required|default(false) %} required{% endif -%}
+                {%- if opt.disabled|default(false) %} disabled{% endif -%}
+                {%- if opt.readonly|default(false) %} readonly{% endif -%}
             >
 
             <button class="btn btn-secondary spinner-down" type="button" data-input-id="{{ name }}">
@@ -152,12 +146,8 @@ Also adds buttons to increment / decrement the value.
             {% endif %}
         {%- endif %}
         <textarea class="form-control" id="{{ name }}" name="{{ name }}"
-            {%- if opt.required|default(false) %}
-                required
-            {%- endif -%}
-            {%- if opt.rows|default(0) %}
-                rows="{{ opt.rows }}"
-            {%- endif -%}
+            {%- if opt.required|default(false) %} required{%- endif -%}
+            {%- if opt.rows|default(0) %} rows="{{ opt.rows }}"{%- endif -%}
         >{{ opt.value|default('') }}</textarea>
     </div>
 {%- endmacro %}
@@ -193,7 +183,7 @@ Renders a select element wrapped in a DIV with mb-3.
         {% endif %}
         <select id="{{ name }}" name="{{ name }}"
             class="form-control {%- if opt.class is defined %} {{ opt.class }}{% endif %}"
-            {%- if opt.required|default(false) %}required{%- endif -%}>
+            {%- if opt.required|default(false) %} required{%- endif -%}>
             {%- if opt.default_option is defined %}
                 <option value="">{{ opt.default_option }}</option>
             {% endif %}

--- a/src/Controllers/FeedController.php
+++ b/src/Controllers/FeedController.php
@@ -73,51 +73,54 @@ class FeedController extends BaseController
             // ! All attributes not defined in $data might change at any time !
             $data = [
                 // Name of the shift (type)
-                'name'           => $shift->shiftType->name,
+                /** @deprecated, use shifttype_name instead */
+                'name'           => (string) $shift->shiftType->name,
                 // Shift / Talk title
-                'title'          => $shift->title,
+                'title'          => (string) $shift->title,
                 // Shift description, should be shown after shifttype_description, markdown formatted
-                'description'    => $shift->description,
+                'description'    => (string) $shift->description,
 
-                'link'           => $this->url->to('/shifts', ['action' => 'view', 'shift_id' => $shift->id]),
+                'link'           => (string) $this->url->to('/shifts', ['action' => 'view', 'shift_id' => $shift->id]),
 
-                // Users comment
-                'Comment'        => $entry->user_comment,
+                // Users comment, might be empty
+                'Comment'        => (string) $entry->user_comment,
 
                 // Shift id
-                'SID'            => $shift->id,
+                'SID'            => (int) $shift->id,
 
                 // Shift type
-                'shifttype_id'   => $shift->shiftType->id,
-                'shifttype_name' => $shift->shiftType->name, // General type of the task
-                'shifttype_description' => $shift->shiftType->description, // General description, markdown formatted
+                'shifttype_id'   => (int) $shift->shiftType->id,
+                // General type of the task
+                'shifttype_name' => (string) $shift->shiftType->name,
+                // General description, markdown formatted, might be empty
+                'shifttype_description' => (string) $shift->shiftType->description,
 
-                // Talk URL
-                'URL'            => $shift->url,
+                // Talk URL, mostly empty
+                'URL'            => (string) $shift->url,
 
                 // Location (room) id
-                'RID'            => $shift->location->id,
+                'RID'            => (int) $shift->location->id,
                 // Location (room) name
-                'Name'           => $shift->location->name,
-                // Location map url
-                'map_url'        => $shift->location->map_url,
+                'Name'           => (string) $shift->location->name,
+                // Location map url, can be empty
+                'map_url'        => (string) $shift->location->map_url,
 
                 // Start timestamp
                 /** @deprecated start_date should be used */
-                'start'          => $shift->start->timestamp,
+                'start'          => (int) $shift->start->timestamp,
                 // Start date
-                'start_date'     => $shift->start->toRfc3339String(),
+                'start_date'     => (string) $shift->start->toRfc3339String(),
                 // End timestamp
                 /** @deprecated end_date should be used */
-                'end'            => $shift->end->timestamp,
+                'end'            => (int) $shift->end->timestamp,
                 // End date
-                'end_date'       => $shift->end->toRfc3339String(),
+                'end_date'       => (string) $shift->end->toRfc3339String(),
 
                 // Timezone offset like "+01:00"
                 /** @deprecated should be retrieved from start_date or end_date */
-                'timezone'       => $timeZone->toOffsetName(),
+                'timezone'       => (string) $timeZone->toOffsetName(),
                 // The events timezone like "Europe/Berlin"
-                'event_timezone' => $timeZone->getName(),
+                'event_timezone' => (string) $timeZone->getName(),
             ];
 
             $response[] = [

--- a/src/Middleware/ResolvesMiddlewareTrait.php
+++ b/src/Middleware/ResolvesMiddlewareTrait.php
@@ -15,7 +15,7 @@ trait ResolvesMiddlewareTrait
      * Resolve the middleware with the container
      */
     protected function resolveMiddleware(
-        string|callable|MiddlewareInterface|RequestHandlerInterface $middleware
+        string|callable|array|MiddlewareInterface|RequestHandlerInterface $middleware
     ): MiddlewareInterface|RequestHandlerInterface {
         if ($this->isMiddleware($middleware)) {
             return $middleware;

--- a/tests/Unit/FactoriesTest.php
+++ b/tests/Unit/FactoriesTest.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Engelsystem\Test\Unit;
 
+use Engelsystem\Models\AngelType;
 use Engelsystem\Models\Faq;
+use Engelsystem\Models\Group;
 use Engelsystem\Models\Message;
 use Engelsystem\Models\News;
 use Engelsystem\Models\NewsComment;
+use Engelsystem\Models\OAuth;
+use Engelsystem\Models\Privilege;
 use Engelsystem\Models\Question;
 use Engelsystem\Models\Location;
+use Engelsystem\Models\Session;
+use Engelsystem\Models\Shifts\NeededAngelType;
 use Engelsystem\Models\Shifts\Schedule;
 use Engelsystem\Models\Shifts\Shift;
 use Engelsystem\Models\Shifts\ShiftEntry;
+use Engelsystem\Models\Shifts\ShiftType;
 use Engelsystem\Models\User\Contact;
 use Engelsystem\Models\User\License;
 use Engelsystem\Models\User\PasswordReset;
@@ -20,6 +27,7 @@ use Engelsystem\Models\User\PersonalData;
 use Engelsystem\Models\User\Settings;
 use Engelsystem\Models\User\State;
 use Engelsystem\Models\User\User;
+use Engelsystem\Models\UserAngelType;
 use Engelsystem\Models\Worklog;
 use Illuminate\Database\Eloquent\Model;
 
@@ -33,21 +41,29 @@ class FactoriesTest extends TestCase
     public function factoriesProvider(): array
     {
         return [
+            [AngelType::class],
             [Contact::class],
             [Faq::class],
+            [Group::class],
             [License::class],
+            [Location::class],
             [Message::class],
+            [NeededAngelType::class],
             [News::class],
             [NewsComment::class],
+            [OAuth::class],
             [PasswordReset::class],
             [PersonalData::class],
+            [Privilege::class],
             [Question::class],
-            [Location::class],
             [Schedule::class],
-            [ShiftEntry::class],
+            [Session::class],
             [Settings::class],
             [Shift::class],
+            [ShiftEntry::class],
+            [ShiftType::class],
             [State::class],
+            [UserAngelType::class],
             [User::class],
             [Worklog::class],
         ];
@@ -56,19 +72,28 @@ class FactoriesTest extends TestCase
     /**
      * Test all model factories
      *
-     * @covers       \Database\Factories\Engelsystem\Models\User\ContactFactory
+     * @covers       \Database\Factories\Engelsystem\Models\AngelTypeFactory
      * @covers       \Database\Factories\Engelsystem\Models\FaqFactory
-     * @covers       \Database\Factories\Engelsystem\Models\User\LicenseFactory
+     * @covers       \Database\Factories\Engelsystem\Models\GroupFactory
+     * @covers       \Database\Factories\Engelsystem\Models\LocationFactory
      * @covers       \Database\Factories\Engelsystem\Models\MessageFactory
-     * @covers       \Database\Factories\Engelsystem\Models\NewsFactory
      * @covers       \Database\Factories\Engelsystem\Models\NewsCommentFactory
+     * @covers       \Database\Factories\Engelsystem\Models\NewsFactory
+     * @covers       \Database\Factories\Engelsystem\Models\OAuthFactory
+     * @covers       \Database\Factories\Engelsystem\Models\PrivilegeFactory
+     * @covers       \Database\Factories\Engelsystem\Models\QuestionFactory
+     * @covers       \Database\Factories\Engelsystem\Models\SessionFactory
+     * @covers       \Database\Factories\Engelsystem\Models\Shifts\NeededAngelTypeFactory
+     * @covers       \Database\Factories\Engelsystem\Models\Shifts\ScheduleFactory
+     * @covers       \Database\Factories\Engelsystem\Models\Shifts\ShiftEntryFactory
+     * @covers       \Database\Factories\Engelsystem\Models\Shifts\ShiftFactory
+     * @covers       \Database\Factories\Engelsystem\Models\Shifts\ShiftTypeFactory
+     * @covers       \Database\Factories\Engelsystem\Models\UserAngelTypeFactory
+     * @covers       \Database\Factories\Engelsystem\Models\User\ContactFactory
+     * @covers       \Database\Factories\Engelsystem\Models\User\LicenseFactory
      * @covers       \Database\Factories\Engelsystem\Models\User\PasswordResetFactory
      * @covers       \Database\Factories\Engelsystem\Models\User\PersonalDataFactory
-     * @covers       \Database\Factories\Engelsystem\Models\QuestionFactory
-     * @covers       \Database\Factories\Engelsystem\Models\LocationFactory
-     * @covers       \Database\Factories\Engelsystem\Models\Shifts\ScheduleFactory
      * @covers       \Database\Factories\Engelsystem\Models\User\SettingsFactory
-     * @covers       \Database\Factories\Engelsystem\Models\Shifts\ShiftFactory
      * @covers       \Database\Factories\Engelsystem\Models\User\StateFactory
      * @covers       \Database\Factories\Engelsystem\Models\User\UserFactory
      * @covers       \Database\Factories\Engelsystem\Models\WorklogFactory

--- a/tests/Unit/Middleware/ResolvesMiddlewareTraitTest.php
+++ b/tests/Unit/Middleware/ResolvesMiddlewareTraitTest.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\MiddlewareInterface;
+use stdClass;
 
 class ResolvesMiddlewareTraitTest extends TestCase
 {
@@ -49,6 +50,20 @@ class ResolvesMiddlewareTraitTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $middleware->callResolveMiddleware('UnresolvableClass');
+    }
+
+    /**
+     * @covers \Engelsystem\Middleware\ResolvesMiddlewareTrait::resolveMiddleware
+     */
+    public function testResolveMiddlewareNotCallable(): void
+    {
+        /** @var Application|MockObject $container */
+        $container = $this->createMock(Application::class);
+
+        $middleware = new ResolvesMiddlewareTraitImplementation($container);
+
+        $this->expectException(InvalidArgumentException::class);
+        $middleware->callResolveMiddleware([new stdClass(), 'test']);
     }
 
     /**

--- a/tests/Unit/Middleware/Stub/ResolvesMiddlewareTraitImplementation.php
+++ b/tests/Unit/Middleware/Stub/ResolvesMiddlewareTraitImplementation.php
@@ -18,7 +18,7 @@ class ResolvesMiddlewareTraitImplementation
     }
 
     public function callResolveMiddleware(
-        string|callable|MiddlewareInterface|RequestHandlerInterface $middleware
+        string|callable|array|MiddlewareInterface|RequestHandlerInterface $middleware
     ): MiddlewareInterface|RequestHandlerInterface {
         return $this->resolveMiddleware($middleware);
     }


### PR DESCRIPTION
* Test all factories in unit tests
* Fix dropdown sorting (fixes #1235 & fixes #1210)
* Show better error message when route function can not be called
* Update macro spacing
* Enforce int or  string on json shifts export fields