### PR TITLE
Signup advance hours for shift types

### DIFF
--- a/db/factories/Shifts/ShiftTypeFactory.php
+++ b/db/factories/Shifts/ShiftTypeFactory.php
@@ -14,9 +14,11 @@ class ShiftTypeFactory extends Factory
 
     public function definition(): array
     {
+        $advanceMinutes = $this->faker->optional(.2)->numberBetween(1, 8 * 12) / 12; // 5 minutes steps
         return [
-            'name'        => $this->faker->unique()->firstName(),
+            'name' => $this->faker->unique()->firstName(),
             'description' => $this->faker->text(),
+            'signup_advance_hours' => $advanceMinutes ? round($advanceMinutes) / 60 : null,
         ];
     }
 }

--- a/db/migrations/2023_11_24_000000_add_signup_advance_hours_to_shift_types.php
+++ b/db/migrations/2023_11_24_000000_add_signup_advance_hours_to_shift_types.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddSignupAdvanceHoursToShiftTypes extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        $this->schema->table('shift_types', function (Blueprint $table): void {
+            $table->float('signup_advance_hours')->nullable()->default(null)->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        $this->schema->table('shift_types', function (Blueprint $table): void {
+            $table->dropColumn('signup_advance_hours');
+        });
+    }
+}

--- a/includes/model/Shifts_model.php
+++ b/includes/model/Shifts_model.php
@@ -481,7 +481,8 @@ function Shift_signup_allowed_angel(
         return new ShiftSignupState(ShiftSignupStatus::COLLIDES, $free_entries);
     }
 
-    if (config('signup_advance_hours') && $shift->start->timestamp > time() + config('signup_advance_hours') * 3600) {
+    $signupAdvanceHours = $shift->shiftType->signup_advance_hours ?: config('signup_advance_hours');
+    if ($signupAdvanceHours && $shift->start->timestamp > time() + $signupAdvanceHours * 3600) {
         return new ShiftSignupState(ShiftSignupStatus::NOT_YET, $free_entries);
     }
 

--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -348,7 +348,7 @@ class ShiftCalendarRenderer
             badge(__('Help needed'), 'danger'),
             badge(__('Other angel type needed / collides with my shifts'), 'warning'),
             badge(__('Shift is full'), 'success'),
-            badge(__('Shift is running/ended or you have not arrived'), 'secondary'),
+            badge(__('Shift is running/has ended, you have not arrived or signup is blocked otherwise'), 'secondary'),
         ]);
     }
 }

--- a/includes/view/ShiftCalendarShiftRenderer.php
+++ b/includes/view/ShiftCalendarShiftRenderer.php
@@ -199,7 +199,7 @@ class ShiftCalendarShiftRenderer
             ShiftSignupStatus::SHIFT_ENDED => $inner_text . ' (' . __('ended') . ')',
             // No link and add a text hint, when the shift ended
             ShiftSignupStatus::NOT_ARRIVED => $inner_text . ' (' . __('please arrive for signup') . ')',
-            ShiftSignupStatus::NOT_YET => $inner_text . ' (' . __('not yet') . ')',
+            ShiftSignupStatus::NOT_YET => $inner_text . ' (' . __('not yet possible') . ')',
             ShiftSignupStatus::ANGELTYPE => $angeltype->restricted || !$angeltype->shift_self_signup
                 // User has to be confirmed on the angeltype first or can't sign up by themselves
                 ? $inner_text . icon('mortarboard-fill')

--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -206,10 +206,11 @@ function Shift_view(
                 : ''), true);
     }
 
-    if (config('signup_advance_hours') && $shift->start->timestamp > time() + config('signup_advance_hours') * 3600) {
+    $signupAdvanceSeconds = ($shift->shiftType->signup_advance_hours ?: config('signup_advance_hours')) * 3600;
+    if ($signupAdvanceSeconds && $shift->start->timestamp > time() + $signupAdvanceSeconds) {
         $content[] = info(sprintf(
-            __('This shift is in the far future and becomes available for signup at %s.'),
-            date(__('general.datetime'), $shift->start->timestamp - config('signup_advance_hours') * 3600)
+            __('This shift is in the far future. It becomes available for signup at %s.'),
+            date(__('general.datetime'), $shift->start->timestamp - $signupAdvanceSeconds)
         ), true);
     }
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -962,8 +962,8 @@ msgstr "Andere Engeltypen benötigt / kollidiert mit meinen Schichten"
 msgid "Shift is full"
 msgstr "Schicht ist voll"
 
-msgid "Shift is running/ended or you have not arrived"
-msgstr "Schicht läuft/vorbei oder du bist noch nicht angekommen"
+msgid "Shift is running/has ended, you have not arrived or signup is blocked otherwise"
+msgstr "Schicht läuft/ist vorbei, du bist noch nicht angekommen oder das eintragen ist blockiert"
 
 msgid "Add more angels"
 msgstr "Mehr Engel hinzufügen"
@@ -982,8 +982,8 @@ msgstr "vorbei"
 msgid "please arrive for signup"
 msgstr "Ankommen zum Eintragen"
 
-msgid "not yet"
-msgstr "noch nicht"
+msgid "not yet possible"
+msgstr "noch nicht möglich"
 
 msgid "m-d"
 msgstr "d.m."
@@ -1045,9 +1045,8 @@ msgstr "bearbeitet am %s von %s"
 msgid "History ID: %s"
 msgstr "Historien-ID: %s"
 
-msgid "This shift is in the far future and becomes available for signup at %s."
-msgstr ""
-"Diese Schicht liegt in der fernen Zukunft und du kannst dich ab %s eintragen."
+msgid "This shift is in the far future. It becomes available for signup at %s."
+msgstr "Diese Schicht liegt in der fernen Zukunft. Du kannst dich ab %s eintragen."
 
 msgid "Do you really want to add supporter rights for %s to %s?"
 msgstr "Sollen %s %s als neuen Supporter bekommen?"
@@ -1969,6 +1968,12 @@ msgstr "Schichttyp \"%s\" löschen"
 
 msgid "shifttype.required_angels"
 msgstr "Benötigte Engel (bei Fahrplan import)"
+
+msgid "shifttype.edit.signup_advance_hours"
+msgstr "Selbsteintragen im voraus in Stunden"
+
+msgid "shifttype.edit.signup_advance_hours.info"
+msgstr "Anzahl Stunden vor Schicht start in welchen die Eintragung möglich ist"
 
 msgid "event.day"
 msgstr "Tag %1$d"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -780,6 +780,12 @@ msgstr "Delete shift type \"%s\""
 msgid "shifttype.required_angels"
 msgstr "Required angels (on schedule import)"
 
+msgid "shifttype.edit.signup_advance_hours"
+msgstr "Self signup advance hours"
+
+msgid "shifttype.edit.signup_advance_hours.info"
+msgstr "Number of hours before a shift starts where self sign up is allowed"
+
 msgid "event.day"
 msgstr "Day %1$d"
 

--- a/resources/views/admin/shifttypes/edit.twig
+++ b/resources/views/admin/shifttypes/edit.twig
@@ -23,6 +23,13 @@
                     'rows': 5,
                     'info': __('form.markdown')
                 }) }}
+
+                {{ f.number('signup_advance_hours', __('shifttype.edit.signup_advance_hours'), {
+                    'value': f.formData('signup_advance_hours', shifttype ? shifttype.signup_advance_hours : ''),
+                    'info': __('shifttype.edit.signup_advance_hours.info'),
+                    'step': 0.01,
+                    'min': 0,
+                }) }}
             </div>
 
             <div class="col-lg-6">

--- a/resources/views/admin/shifttypes/view.twig
+++ b/resources/views/admin/shifttypes/view.twig
@@ -5,10 +5,16 @@
 {% block title %}{{ shifttype.name }}{% endblock %}
 
 {% block row_content %}
+    {% if shifttype.signup_advance_hours %}
+        <div class="col-md-12">
+            {{ __('shifttype.edit.signup_advance_hours') }} {{ f.info(__('shifttype.edit.signup_advance_hours.info')) }}: {{ shifttype.signup_advance_hours }}
+        </div>
+    {% endif %}
+
     <div class="col-md-12">
-        <h3>{{ __('general.description') }}</h3>
-        {{ shifttype.description|md }}
+        <h3>{{ __('general.description') }}</h3>{{ shifttype.description|md }}
     </div>
+
     {% if shifttype.neededAngelTypes.isNotEmpty() %}
         <div class="col-md-12">
             <h3>{{ __('location.required_angels') }}</h3>

--- a/src/Controllers/Admin/ShiftTypesController.php
+++ b/src/Controllers/Admin/ShiftTypesController.php
@@ -100,6 +100,7 @@ class ShiftTypesController extends BaseController
             [
                 'name' => 'required|max:255',
                 'description' => 'optional',
+                'signup_advance_hours' => 'optional|float',
             ] + $validation
         );
 
@@ -109,6 +110,7 @@ class ShiftTypesController extends BaseController
 
         $shiftType->name = $data['name'];
         $shiftType->description = $data['description'] ?? '';
+        $shiftType->signup_advance_hours = $data['signup_advance_hours'] ?: null;
 
         $shiftType->save();
         $shiftType->neededAngelTypes()->delete();
@@ -134,10 +136,11 @@ class ShiftTypesController extends BaseController
         }
 
         $this->log->info(
-            'Updated shift type "{name}": {description} {angels}',
+            'Updated shift type "{name}": {description}, {signup_advance_hours}, {angels}',
             [
                 'name' => $shiftType->name,
                 'description' => $shiftType->description,
+                'signup_advance_hours' => $shiftType->signup_advance_hours,
                 'angels' => $angelsInfo,
             ]
         );

--- a/src/Models/Shifts/ShiftType.php
+++ b/src/Models/Shifts/ShiftType.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property int                        $id
  * @property string                     $name
  * @property string                     $description
+ * @property float|null                 $signup_advance_hours
  *
  * @property-read Collection|NeededAngelType[] $neededAngelTypes
  * @property-read Collection|Schedule[] $schedules
@@ -22,6 +23,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @method static QueryBuilder|ShiftType[] whereId($value)
  * @method static QueryBuilder|ShiftType[] whereName($value)
  * @method static QueryBuilder|ShiftType[] whereDescription($value)
+ * @method static QueryBuilder|ShiftType[] whereSignupAdvanceHours($value)
  */
 class ShiftType extends BaseModel
 {
@@ -31,6 +33,12 @@ class ShiftType extends BaseModel
     protected $fillable = [ // phpcs:ignore
         'name',
         'description',
+        'signup_advance_hours',
+    ];
+
+    /** @var array<string, null> default attributes */
+    protected $attributes = [ // phpcs:ignore
+        'signup_advance_hours' => null,
     ];
 
     public function neededAngelTypes(): HasMany

--- a/tests/Unit/Controllers/Admin/ShiftTypesControllerTest.php
+++ b/tests/Unit/Controllers/Admin/ShiftTypesControllerTest.php
@@ -129,6 +129,7 @@ class ShiftTypesControllerTest extends ControllerTest
         $this->request = $this->request->withParsedBody([
             'name' => 'Test shift type',
             'description' => 'Something',
+            'signup_advance_hours' => 42.5,
             'angel_type_' . $angelType->id => 3,
             'angel_type_' . $angelType->id + 1 => 0,
         ]);
@@ -138,6 +139,8 @@ class ShiftTypesControllerTest extends ControllerTest
         $this->assertTrue($this->log->hasInfoThatContains('Updated shift type'));
         $this->assertHasNotification('shifttype.edit.success');
         $this->assertCount(1, ShiftType::whereName('Test shift type')->get());
+        $this->assertCount(1, ShiftType::whereDescription('Something')->get());
+        $this->assertCount(1, ShiftType::whereSignupAdvanceHours(42.5)->get());
         $this->assertCount(1, ShiftType::first()->neededAngelTypes);
     }
 


### PR DESCRIPTION
Implements parts of #372: Make signup hours in advance configurable by shift type (useful for example for bar shifts which are already full long before the average angel arrives on location).
It also contains some cleanup on migrations ;)