### PR TITLE
Improve usability

### DIFF
--- a/includes/model/User_model.php
+++ b/includes/model/User_model.php
@@ -149,7 +149,10 @@ function User_get_eligable_voucher_count($user)
         : null;
 
     $shiftEntries = ShiftEntries_finished_by_user($user, $start);
-    $worklog = UserWorkLogsForUser($user->id, $start);
+    $worklog = $user->worklogs()
+        ->whereDate('worked_at', '>=', $start ?: 0)
+        ->with(['user', 'creator'])
+        ->get();
     $shifts_done =
         count($shiftEntries)
         + $worklog->count();

--- a/includes/pages/schedule/ImportSchedule.php
+++ b/includes/pages/schedule/ImportSchedule.php
@@ -91,11 +91,7 @@ class ImportSchedule extends BaseController
     public function edit(Request $request): Response
     {
         $scheduleId = $request->getAttribute('schedule_id'); // optional
-
         $schedule = ScheduleUrl::find($scheduleId);
-        if ($schedule == null) {
-            $schedule = new ScheduleUrl();
-        }
 
         return $this->response->withView(
             'admin/schedule/edit.twig',

--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -72,6 +72,12 @@ function Shift_editor_info_render(Shift $shift)
             User_Nick_render($shift->updatedBy)
         );
     }
+    if ($shift->transaction_id) {
+        $info[] = sprintf(
+            icon('clock-history') . __('History ID: %s'),
+            $shift->transaction_id
+        );
+    }
     return join('<br />', $info);
 }
 

--- a/includes/view/UserAngelTypes_view.php
+++ b/includes/view/UserAngelTypes_view.php
@@ -165,10 +165,11 @@ function UserAngelType_add_view(AngelType $angeltype, $users_source, $user_id)
  */
 function UserAngelType_join_view($user, AngelType $angeltype)
 {
+    $isOther = $user->id != auth()->user()->id;
     return page_with_title(sprintf(__('Become a %s'), htmlspecialchars($angeltype->name)), [
         msg(),
         info(sprintf(
-            __('Do you really want to add %s to %s?'),
+            $isOther ? __('Do you really want to add %s to %s?') : __('Do you want to become a %2$s?'),
             $user->displayName,
             $angeltype->name
         ), true),

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1089,6 +1089,9 @@ msgstr "erstellt am %s von %s"
 msgid "edited at %s by %s"
 msgstr "bearbeitet am %s von %s"
 
+msgid "History ID: %s"
+msgstr "Historien-ID: %s"
+
 msgid "This shift is in the far future and becomes available for signup at %s."
 msgstr ""
 "Diese Schicht liegt in der fernen Zukunft und du kannst dich ab %s eintragen."
@@ -1935,6 +1938,9 @@ msgstr "Auf Schicht-Ansicht ausblenden"
 msgid "angeltypes.hide_on_shift_view.info"
 msgstr "Wenn ausgewählt, können nur Admins und Mitglieder des Engeltyps auf der "
 "Schicht Seite die Filteroption für diesen Engeltyp sehen."
+
+msgid "location.location"
+msgstr "Ort"
 
 msgid "location.locations"
 msgstr "Orte"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -32,6 +32,9 @@ msgstr ""
 msgid "password.email.message"
 msgstr "Um dein Passwort zurückzusetzen, besuche %s"
 
+msgid "page.error.title"
+msgstr "Fehler %s"
+
 msgid "page.403.title"
 msgstr "Nicht erlaubt"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1114,6 +1114,9 @@ msgstr "Möchtest Du wirklich %s von %s entfernen?"
 msgid "Do you really want to add %s to %s?"
 msgstr "Möchtest Du wirklich %s zu %s hinzufügen?"
 
+msgid "Do you want to become a %2$s?"
+msgstr "Möchtest Du ein %2$s werden?"
+
 msgid "Confirm user"
 msgstr "Benutzer bestätigen"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -46,6 +46,9 @@ msgstr "You are not allowed to access this page"
 msgid "page.403.login"
 msgstr "Please log in."
 
+msgid "page.error.title"
+msgstr "Error %s"
+
 msgid "page.404.title"
 msgstr "Page not found"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -675,6 +675,9 @@ msgstr "If checked only admins and members of the angeltype "
 msgid "registration.register"
 msgstr "Register"
 
+msgid "location.location"
+msgstr "Location"
+
 msgid "location.locations"
 msgstr "Locations"
 

--- a/resources/views/admin/schedule/edit.twig
+++ b/resources/views/admin/schedule/edit.twig
@@ -64,7 +64,11 @@
                 <div class="row">
                     {% for id,name in locations %}
                         <div class="col-md-3">
-                            {{ f.checkbox('location_' ~ id, name, {'checked': id in schedule.activeLocations.pluck('id')}) }}
+                            {{ f.checkbox(
+                                'location_' ~ id,
+                                name,
+                                {'checked': schedule and id in schedule.activeLocations.pluck('id')}
+                            ) }}
                         </div>
                     {% endfor %}
                 </div>

--- a/resources/views/admin/shifts/history.twig
+++ b/resources/views/admin/shifts/history.twig
@@ -22,6 +22,7 @@
                 <tr>
                     <th>{{ __('general.id') }}</th>
                     <th>{{ __('title.title') }}</th>
+                    <th>{{ __('location.location') }}</th>
                     <th>{{ __('general.count') }}</th>
                     <th>{{ __('shifts.start') }}</th>
                     <th>{{ __('shifts.end') }}</th>
@@ -40,8 +41,10 @@
                                 {{ __('shifts.history.schedule', [shift.schedule.name]) }}
                             {% else %}
                                 {{ shift.title }}
-                            {% endif %}
+                            {% endif %}<br>
+                            {{ shift.shiftType.name }}
                         </td>
+                        <td>{{ shift.location.name }}</td>
                         <td>{{ shift.count }}</td>
                         <td>{{ shift.start.format(__('general.datetime')) }}</td>
                         <td>{{ shift.end.format(__('general.datetime')) }}</td>

--- a/resources/views/admin/shifttypes/index.twig
+++ b/resources/views/admin/shifttypes/index.twig
@@ -15,6 +15,8 @@
 
             {% if is_index|default(false) %}
                 {{ m.button(m.icon('plus-lg'), url('/admin/shifttypes/edit'), 'secondary') }}
+            {% elseif has_permission_to('shifttypes') and is_view|default(false) %}
+                {{ m.button(m.icon('pencil'), url('admin/shifttypes/edit/' ~ shifttype.id), null, 'sm', __('form.edit')) }}
             {% endif %}
         </h1>
 

--- a/resources/views/errors/default.twig
+++ b/resources/views/errors/default.twig
@@ -1,6 +1,6 @@
 {% extends "layouts/app.twig" %}
 
-{% block title %}Error {{ status }}{% endblock %}
+{% block title %}{{ __('page.error.title', [status]) }}{% endblock %}
 
 {% block content %}
     <div class="container">
@@ -8,7 +8,7 @@
             <div class="alert alert-info" role="alert">
 
                 {% block content_headline %}
-                    <h2>{% block content_headline_text %}Error {{ status }}{% endblock %}</h2>
+                    <h2>{% block content_headline_text %}{{ __('page.error.title', [status]) }}{% endblock %}</h2>
                 {% endblock %}
 
                 {% block content_text %}

--- a/resources/views/layouts/maintenance.html
+++ b/resources/views/layouts/maintenance.html
@@ -47,7 +47,7 @@
         <p>This may be due to</p>
 
         <ul>
-            <li>Archangels closing the gates of heaven.</li>
+            <li>The gates of heaven were closed.</li>
             <li>Someone tried to do a simple maintenance task which did not go as planned.</li>
             <li>DHCP decided to give me another ip address.</li>
             <li>Somebody's stolen the power chord and now the battery is empty.</li>

--- a/resources/views/layouts/parts/footer.twig
+++ b/resources/views/layouts/parts/footer.twig
@@ -2,7 +2,7 @@
 
 <div class="col-md-12">
     <hr/>
-    <div class="text-center footer" style="margin-bottom: 10px;">
+    <div class="text-center footer mb-3">
         {% block eventinfo %}
             {% if config('name') %}
                 {% if config('event_start') and config('event_end') %}

--- a/resources/views/macros/form.twig
+++ b/resources/views/macros/form.twig
@@ -133,11 +133,19 @@ Also adds buttons to increment / decrement the value.
 @param {bool} [opt.required] - Whether to add the "required" attribute. Defaults to false.
 @param {int} [opt.rows=0] - Optional value of the "rows" attriute. Defaults to 0.
 @param {string} [opt.value=""] - Optional value to set. Defaults to empty string.
+@param {string} [opt.label_hidden=true] - Optionaly hide the label. Defaults to false.
+@param {string} [opt.no_div=false] - Optionaly don't add a div. Defaults to false.
 #}
 {% macro textarea(name, label, opt) %}
-    <div class="mb-3">
-        {% if label  -%}
-            <label class="form-label" for="{{ name }}">{{ label }}</label>
+    {% if not opt.no_div|default(false) -%}
+        <div class="mb-3">
+    {% endif -%}
+        {% if label -%}
+            <label class="form-label
+                    {%- if opt.label_hidden|default(false) %} visually-hidden{% endif -%}
+                " for="{{ name }}">
+                {{ label }}
+            </label>
             {% if opt.required_icon|default(false) %}
                 {{ _self.entry_required() }}
             {% endif %}
@@ -146,10 +154,12 @@ Also adds buttons to increment / decrement the value.
             {% endif %}
         {%- endif %}
         <textarea class="form-control" id="{{ name }}" name="{{ name }}"
-            {%- if opt.required|default(false) %} required{%- endif -%}
+                    {%- if opt.required|default(false) %} required{%- endif -%}
             {%- if opt.rows|default(0) %} rows="{{ opt.rows }}"{%- endif -%}
-        >{{ opt.value|default('') }}</textarea>
-    </div>
+                >{{ opt.value|default('') }}</textarea>
+    {% if not opt.no_div|default(false) -%}
+        </div>
+    {%- endif %}
 {%- endmacro %}
 
 {#

--- a/resources/views/pages/faq/edit.twig
+++ b/resources/views/pages/faq/edit.twig
@@ -61,7 +61,7 @@
                     <div class="col-md-12">
                         <h2>{{ __('form.preview') }}</h2>
 
-                        <div class="card {% if theme.type =='light' %}bg-light{% else %}bg-dark{% endif %}">
+                        <div class="card {{ m.type_bg_class() }}">
                             <div class="card-header">
                                 {{ faq.question }}
                             </div>

--- a/resources/views/pages/faq/overview.twig
+++ b/resources/views/pages/faq/overview.twig
@@ -35,7 +35,7 @@
                 {% for item in items %}
                     <div class="col-md-12 faq">
                         <span id="faq-{{ item.id }}" class="ref-id"></span>
-                        <div class="card {% if theme.type =='light' %}bg-light{% else %}bg-dark{% endif %} mb-4">
+                        <div class="card {{ m.type_bg_class() }} mb-4">
                             <h4 class="card-header">
                                 {{ item.question }}
                                 <small class="text-muted">
@@ -47,7 +47,7 @@
                                 {{ item.text|markdown }}
                             </div>
 
-                            <div class="card-footer {% if theme.type =='light' %}bg-light{% else %}bg-dark{% endif %} d-flex align-items-center">
+                            <div class="card-footer {{ m.type_bg_class() }} d-flex align-items-center">
                                 <div class="me-3">
                                     {{ m.icon('clock') }} {{ item.updated_at.format(__('general.datetime')) }}
                                 </div>

--- a/resources/views/pages/messages/conversation.twig
+++ b/resources/views/pages/messages/conversation.twig
@@ -48,8 +48,11 @@
                     {{ csrf() }}
 
                     <div class="input-group">
-                        <label for="message" class="visually-hidden">{{ __('message.message') }}</label>
-                        <textarea class="form-control" id="message" name="text" required="" rows="3"></textarea>
+                        {{ f.textarea(
+                            'text',
+                            __('message.message'),
+                            {'required': true, 'rows': 3, 'label_hidden': true, 'no_div': true}
+                        ) }}
                         {{ f.submit(m.icon('send-fill')) }}
                     </div>
                 </form>

--- a/resources/views/pages/news/news.twig
+++ b/resources/views/pages/news/news.twig
@@ -17,7 +17,7 @@
                 <div class="card-body {{ m.type_bg_class() }}">
                     {{ comment.text|nl2br }}
                 </div>
-                <div class="card-footer {% if theme.type =='light' %}bg-light{% else %}bg-dark{% endif %} text-muted d-flex align-items-center">
+                <div class="card-footer {{ m.type_bg_class() }} text-muted d-flex align-items-center">
                     <div class="me-3">
                         {{ m.icon('clock') }}
                         {{ comment.created_at.format(__('general.datetime')) }}

--- a/resources/views/pages/news/overview.twig
+++ b/resources/views/pages/news/overview.twig
@@ -52,7 +52,7 @@
 {% endblock %}
 
 {% macro news(news, show_comments_link, is_overview) %}
-    <div class="card {% if news.is_highlighted %}bg-warning{% elseif news.is_meeting %}bg-info{% elseif theme.type =='light' %}bg-light{% else %}bg-dark{% endif %} mb-4">
+    <div class="card {% if news.is_highlighted %}bg-warning{% elseif news.is_meeting %}bg-info{% else %}{{ m.type_bg_class() }}{% endif %} mb-4">
         {% if is_overview|default(false) %}
         <div class="card-header {% if news.is_meeting and theme.type == 'dark' %}text-white{% endif %}">
                 <a href="{{ url('/news/' ~ news.id) }}" class="text-inherit">
@@ -70,7 +70,7 @@
             {% endif %}
         </div>
 
-        <div class="card-footer text-nowrap {% if theme.type =='light' %}bg-light{% else %}bg-dark{% endif %} text-muted">
+        <div class="card-footer text-nowrap {{ m.type_bg_class() }} text-muted">
             <div class="d-flex flex-column flex-md-row align-items-md-center gap-3">
                 {% if news.updated_at != news.created_at and not is_overview %}
                     <div>

--- a/resources/views/pages/questions/overview.twig
+++ b/resources/views/pages/questions/overview.twig
@@ -33,7 +33,7 @@
                                             {{ question.text|nl2br }}
                                         </div>
 
-                                        <div class="card-footer {% if theme.type =='light' %}bg-light{% else %}bg-dark{% endif %} d-flex align-items-center">
+                                        <div class="card-footer {{ m.type_bg_class() }} d-flex align-items-center">
                                             <div class="me-3">
                                                 {{ m.icon('clock') }} {{ question.created_at.format(__('general.datetime')) }}
                                             </div>
@@ -68,7 +68,7 @@
                                             <div class="card-body bg-body {{ m.type_text_class() }}">
                                                 {{ question.answer|markdown }}
                                             </div>
-                                            <div class="card-footer bg-dark d-flex align-items-center {{ m.type_text_class() }}">
+                                            <div class="card-footer {{ m.type_bg_class() }} d-flex align-items-center {{ m.type_text_class() }}">
                                                 <div class="me-3">
                                                     {{ m.icon('clock') }} {{ question.updated_at.format(__('general.datetime')) }}
                                                 </div>

--- a/resources/views/pages/user-shifts.html
+++ b/resources/views/pages/user-shifts.html
@@ -34,7 +34,7 @@
                     </div>
                 </div>
             </div>
-            <div class="form-group d-print-none" style="margin-top: .5em">
+            <div class="form-group d-print-none mt-2">
                 <div class="btn-group mb-1" role="group">
                     <button type="button" class="btn btn-secondary set-date" data-days="-1">%set_yesterday%</button>
                     <button type="button" class="btn btn-secondary set-date" data-days="0">%set_today%</button>
@@ -55,7 +55,7 @@
             </div>
             <div class="row d-print-none">
                 <div class="col-md-12">
-                    <button class="btn btn-primary" type="submit" style="width:100%; margin: 1em 0">%filter%</button>
+                    <button class="btn btn-primary mt-3 mb-3 w-100" type="submit">%filter%</button>
                 </div>
             </div>
         </div>
@@ -73,11 +73,12 @@
                     <div class="col col-12 col-sm-5 col-md-12 col-lg-7 col-xl-5 col-xxl-4">%type_select%</div>
                     <div class="col col-12 col-sm-3 col-md-12 col-lg-5 col-xl-3 col-xxl-4">%filled_select%</div>
                 </div>
+                <div class="row">
+                    <div class="col-md-12 d-print-none d-md-none">
+                        <button class="btn btn-primary mb-3 w-100" type="submit">%filter%</button>
+                    </div>
+                </div>
             </div>
-        </div>
-
-        <div class="col-md-12 d-print-none d-md-none">
-            <button class="btn btn-primary" type="submit" style="width:100%; margin: 1em 0">%filter%</button>
         </div>
     </div>
 </form>

--- a/src/Controllers/Admin/NewsController.php
+++ b/src/Controllers/Admin/NewsController.php
@@ -39,7 +39,7 @@ class NewsController extends BaseController
         $news = $this->news->find($newsId);
         $isMeeting = (bool) $request->get('meeting', false);
 
-        return $this->showEdit($news, true, $isMeeting);
+        return $this->showEdit($news, !$news, $isMeeting);
     }
 
     protected function showEdit(?News $news, bool $sendNotification = true, bool $isMeetingDefault = false): Response

--- a/src/Controllers/Admin/ShiftTypesController.php
+++ b/src/Controllers/Admin/ShiftTypesController.php
@@ -70,7 +70,7 @@ class ShiftTypesController extends BaseController
 
         return $this->response->withView(
             'admin/shifttypes/view',
-            ['shifttype' => $shiftType]
+            ['shifttype' => $shiftType, 'is_view' => true]
         );
     }
 

--- a/src/Controllers/Admin/UserWorkLogController.php
+++ b/src/Controllers/Admin/UserWorkLogController.php
@@ -131,6 +131,16 @@ class UserWorkLogController extends BaseController
         }
         $worklog->delete();
 
+        $this->log->info(
+            'Deleted worklog for {name} ({id}) at {time} about {hours}h: {text}',
+            [
+                'name' => $worklog->user->name,
+                'id' => $worklog->user->id,
+                'time' => $worklog->worked_at,
+                'hours' => $worklog->hours,
+                'text' => $worklog->comment,
+            ]
+        );
         $this->addNotification('worklog.delete.success');
 
         return $this->redirect->to('/users?action=view&user_id=' . $userId);

--- a/tests/Unit/Controllers/Admin/NewsControllerTest.php
+++ b/tests/Unit/Controllers/Admin/NewsControllerTest.php
@@ -44,7 +44,7 @@ class NewsControllerTest extends ControllerTest
                 $this->assertEquals('pages/news/edit.twig', $view);
 
                 $this->assertNotEmpty($data['news']);
-                $this->assertTrue($data['send_notification']);
+                $this->assertFalse($data['send_notification']);
 
                 return $this->response;
             });

--- a/tests/Unit/Controllers/Admin/UserWorkLogControllerTest.php
+++ b/tests/Unit/Controllers/Admin/UserWorkLogControllerTest.php
@@ -306,6 +306,7 @@ class UserWorkLogControllerTest extends ControllerTest
 
         $this->controller->deleteWorklog($request);
 
+        $this->log->hasInfoThatContains('Deleted worklog');
         $this->assertHasNotification('worklog.delete.success');
         $worklog = Worklog::find($worklog->id);
         $this->assertNull($worklog);


### PR DESCRIPTION
* Use type_bg_class() macro in templates
* Add translations for generic error pages
* Cleanup template styles
* Create log entry on worklog deletion
* Fix voucher calculation when start date not configured
* Make join angeltype message more meaningful for normal angels
* Fix shifts creation to prevent creating empty shifts when copying needed angels from room
* Added edit link on shift type page 
* Cleanup the fix for #1305
* Only preselect "send notification" on new news 