### PR TITLE
README: make it clearer that you have to run `migrate` on fresh installs too

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ cd docker
 docker compose up -d
 ```
 
-#### Migrate
-Import database changes to migrate it to the newest version
+#### Set Up / Migrate Database
+Create the Database Schema (on a fresh install) or import database changes to migrate it to the newest version
 ```bash
 cd docker
 docker compose exec es_server bin/migrate


### PR DESCRIPTION
During setup, it was not immediately clear to me from the README that I'd have to run `docker compose exec es_server bin/migrate` too even though I didn't have an old database to be migrated yet.
This PR aims to prevent this hickup for the next new person.