### PR TITLE
active_angels.php, default.po: fix typo

### DIFF
--- a/includes/pages/admin_active.php
+++ b/includes/pages/admin_active.php
@@ -342,7 +342,7 @@ function admin_active()
             form_submit('submit', icon('search') . __('form.search')),
         ], url('/admin-active')),
         $set_active == '' ? form([
-            form_text('count', __('How much angels should be active?'), $count ?: $forced_count),
+            form_text('count', __('How many angels should be active?'), $count ?: $forced_count),
             form_submit('set_active', icon('eye') .  __('form.preview'), 'btn-info'),
         ]) : $set_active,
         $msg . msg(),

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -518,7 +518,7 @@ msgstr "Suche Engel:"
 msgid "Show all shifts"
 msgstr "Alle Schichten anzeigen"
 
-msgid "How much angels should be active?"
+msgid "How many angels should be active?"
 msgstr "Wie viele Engel sollten aktiv sein?"
 
 msgid "Size"


### PR DESCRIPTION
From my understanding, it should be "how many angels" instead of "how much". This PR fixes this.