### PR TITLE
Use confirmation dialog and redirect back when deleting shifts

### DIFF
--- a/includes/sys_form.php
+++ b/includes/sys_form.php
@@ -141,11 +141,23 @@ function form_info($label, $text = '')
  * @param string $class
  * @param bool   $wrapForm
  * @param string $buttonType
+ * @param array $dataAttributes
  * @return string
  */
-function form_submit($name, $label, $class = '', $wrapForm = true, $buttonType = 'primary', $title = '')
-{
-    $button = '<button class="btn btn-' . $buttonType . ($class ? ' ' . $class : '') . '" type="submit" name="' . $name . '" title="' . $title . '">'
+function form_submit(
+    $name,
+    $label,
+    $class = '',
+    $wrapForm = true,
+    $buttonType = 'primary',
+    $title = '',
+    array $dataAttributes = []
+) {
+    $add = '';
+    foreach ($dataAttributes as $dataType => $dataValue) {
+        $add .= ' data-' . $dataType . '="'. htmlspecialchars($dataValue) .'"';
+    }
+    $button = '<button class="btn btn-' . $buttonType . ($class ? ' ' . $class : '') . '" type="submit" name="' . $name . '" title="' . $title . '"' . $add . '>'
         . $label
         . '</button>';
 

--- a/includes/view/ShiftCalendarShiftRenderer.php
+++ b/includes/view/ShiftCalendarShiftRenderer.php
@@ -245,7 +245,7 @@ class ShiftCalendarShiftRenderer
     {
         $header_buttons = '';
         if (auth()->can('admin_shifts')) {
-            $header_buttons = '<div class="ms-auto d-print-none">' . table_buttons([
+            $header_buttons = div('ms-auto d-print-none d-flex', [
                     button(
                         url('/user-shifts', ['edit_shift' => $shift->id]),
                         icon('pencil'),
@@ -253,14 +253,26 @@ class ShiftCalendarShiftRenderer
                         '',
                         __('form.edit')
                     ),
-                    button(
-                        url('/user-shifts', ['delete_shift' => $shift->id]),
-                        icon('trash'),
-                        'btn-' . $class . ' btn-sm border-light text-white',
-                        '',
-                        __('form.delete')
-                    ),
-                ]) . '</div>';
+                    form([
+                        form_hidden('delete_shift', $shift->id),
+                        form_submit(
+                            'delete',
+                            icon('trash'),
+                            'btn-' . $class . ' btn-sm border-light text-white ms-1',
+                            false,
+                            'danger',
+                            __('form.delete'),
+                            [
+                                'confirm_submit_title' => __('Do you want to delete the shift "%s" from %s to %s?', [
+                                    $shift->shiftType->name,
+                                    $shift->start->format(__('general.datetime')),
+                                    $shift->end->format(__('H:i'))
+                                ]),
+                                'confirm_button_text' => icon('trash') . __('form.delete'),
+                            ]
+                        ),
+                    ], url('/user-shifts', ['delete_shift' => $shift->id])),
+                ]);
         }
         $shift_heading = $shift->start->format('H:i') . ' &dash; '
             . $shift->end->format('H:i') . ' &mdash; '

--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -180,7 +180,25 @@ function Shift_view(
     if ($shift_admin || $admin_shifttypes || $admin_locations) {
         $buttons = [
             $shift_admin ? button(shift_edit_link($shift), icon('pencil'), '', '', __('form.edit')) : '',
-            $shift_admin ? button(shift_delete_link($shift), icon('trash'), 'btn-danger', '', __('form.delete')) : '',
+            $shift_admin ? form([
+                form_hidden('delete_shift', $shift->id),
+                form_submit(
+                    'delete',
+                    icon('trash'),
+                    '',
+                    false,
+                    'danger',
+                    __('form.delete'),
+                    [
+                        'confirm_submit_title' => __('Do you want to delete the shift "%s" from %s to %s?', [
+                            $shift->shiftType->name,
+                            $shift->start->format(__('general.datetime')),
+                            $shift->end->format(__('H:i'))
+                        ]),
+                        'confirm_button_text' => icon('trash') . __('form.delete'),
+                    ]
+                ),
+            ], url('/user-shifts', ['delete_shift' => $shift->id])): '',
             $admin_shifttypes
                 ? button(url('/admin/shifttypes/' . $shifttype->id), htmlspecialchars($shifttype->name))
                 : '',

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -321,8 +321,8 @@ msgstr "Benötigte Engel"
 msgid "Shift deleted."
 msgstr "Schicht gelöscht."
 
-msgid "Do you want to delete the shift %s from %s to %s?"
-msgstr "Möchtest Du die Schicht %s von %s bis %s löschen?"
+msgid "Do you want to delete the shift \"%s\" from %s to %s?"
+msgstr "Möchtest Du die Schicht \"%s\" von %s bis %s löschen?"
 
 msgid "Shift could not be found."
 msgstr "Schicht konnte nicht gefunden werden."


### PR DESCRIPTION
This fixes #1342 by allowing back redirects as the referrer is known when sending the form using a modal for the confirmation dialog.