### PR TITLE
Fix night shift calculation and smaller fixes

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -350,8 +350,8 @@ return [
     // Goodies must be enabled to use this feature
     'night_shifts'            => [
         'enabled'    => (bool) env('NIGHT_SHIFTS', true), // Disable to weigh every shift the same
-        'start'      => env('NIGHT_SHIFTS_START', 2),
-        'end'        => env('NIGHT_SHIFTS_END', 8),
+        'start'      => env('NIGHT_SHIFTS_START', 2), // Starting from hour
+        'end'        => env('NIGHT_SHIFTS_END', 8), // Ends at (without including) hour
         'multiplier' => env('NIGHT_SHIFTS_MULTIPLIER', 2),
     ],
 

--- a/includes/controller/user_angeltypes_controller.php
+++ b/includes/controller/user_angeltypes_controller.php
@@ -231,8 +231,9 @@ function user_angeltype_delete_controller(): array
     $user_angeltype = UserAngelType::findOrFail($request->input('user_angeltype_id'));
     $angeltype = $user_angeltype->angelType;
     $user_source = $user_angeltype->user;
+    $isOwnAngelType = $user->id == $user_source->id;
     if (
-        $user->id != $user_angeltype->user_id
+        !$isOwnAngelType
         && !$user->isAngelTypeSupporter($angeltype)
         && !auth()->can('admin_user_angeltypes')
     ) {
@@ -243,15 +244,15 @@ function user_angeltype_delete_controller(): array
     if ($request->hasPostData('delete')) {
         $user_angeltype->delete();
 
-        engelsystem_log(sprintf('User %s removed from %s.', User_Nick_render($user_source, true), $angeltype->name));
-        success(sprintf(__('User %s removed from %s.'), $user_source->displayName, $angeltype->name));
+        engelsystem_log(sprintf('User "%s" removed from "%s".', User_Nick_render($user_source, true), $angeltype->name));
+        success(sprintf($isOwnAngelType ? __('You successfully left "%2$s".') : __('User "%s" removed from "%s".'), $user_source->displayName, $angeltype->name));
 
         throw_redirect(url('/angeltypes', ['action' => 'view', 'angeltype_id' => $angeltype->id]));
     }
 
     return [
-        __('Remove angeltype'),
-        UserAngelType_delete_view($user_angeltype, $user_source, $angeltype),
+        __('Leave angeltype'),
+        UserAngelType_delete_view($user_angeltype, $user_source, $angeltype, $isOwnAngelType),
     ];
 }
 

--- a/includes/controller/users_controller.php
+++ b/includes/controller/users_controller.php
@@ -239,10 +239,9 @@ function user_controller()
         auth()->resetApiKey($user_source);
     }
 
+    $tshirt_score = sprintf('%.2f', User_tshirt_score($user_source->id)) . '&nbsp;h';
     if ($user_source->state->force_active && config('enable_force_active')) {
-        $tshirt_score = __('Enough');
-    } else {
-        $tshirt_score = sprintf('%.2f', User_tshirt_score($user_source->id)) . '&nbsp;h';
+        $tshirt_score = '<span title="' . $tshirt_score . '">' . __('Enough') . '</span>';
     }
 
     $worklogs = $user_source->worklogs()

--- a/includes/model/User_model.php
+++ b/includes/model/User_model.php
@@ -123,13 +123,14 @@ function User_get_shifts_sum_query()
         return 'COALESCE(SUM(UNIX_TIMESTAMP(shifts.end) - UNIX_TIMESTAMP(shifts.start)), 0)';
     }
 
+    /* @see \Engelsystem\Helpers\Shifts::isNightShift to keep it in sync */
     return sprintf(
         '
             COALESCE(SUM(
                 (1 + (
-                    (HOUR(shifts.end) > %1$d AND HOUR(shifts.end) < %2$d)
-                    OR (HOUR(shifts.start) > %1$d AND HOUR(shifts.start) < %2$d)
-                    OR (HOUR(shifts.start) <= %1$d AND HOUR(shifts.end) >= %2$d)
+                    HOUR(shifts.start) > %1$d AND HOUR(shifts.start) < %2$d
+                    OR HOUR(shifts.end) > %1$d AND HOUR(shifts.end) < %2$d
+                    OR HOUR(shifts.start) <= %1$d AND HOUR(shifts.end) >= %2$d
                 ))
                 * (UNIX_TIMESTAMP(shifts.end) - UNIX_TIMESTAMP(shifts.start))
                 * (1 - (%3$d + 1) * `shift_entries`.`freeloaded`)

--- a/includes/model/User_model.php
+++ b/includes/model/User_model.php
@@ -128,8 +128,11 @@ function User_get_shifts_sum_query()
         '
             COALESCE(SUM(
                 (1 + (
-                    HOUR(shifts.start) > %1$d AND HOUR(shifts.start) < %2$d
-                    OR HOUR(shifts.end) > %1$d AND HOUR(shifts.end) < %2$d
+                    HOUR(shifts.start) >= %1$d AND HOUR(shifts.start) < %2$d
+                    OR (
+                        HOUR(shifts.end) > %1$d
+                        || HOUR(shifts.end) = %1$d AND MINUTE(shifts.end) > 0
+                    ) AND HOUR(shifts.end) <= %2$d
                     OR HOUR(shifts.start) <= %1$d AND HOUR(shifts.end) >= %2$d
                 ))
                 * (UNIX_TIMESTAMP(shifts.end) - UNIX_TIMESTAMP(shifts.start))

--- a/includes/pages/admin_groups.php
+++ b/includes/pages/admin_groups.php
@@ -43,10 +43,9 @@ function admin_groups()
                         ['action' => 'edit', 'id' => $group->id]
                     ),
                     icon('pencil'),
+                    'btn-sm',
                     '',
-                    '',
-                    __('form.edit'),
-                    'btn-sm'
+                    __('form.edit')
                 ),
             ];
         }
@@ -122,10 +121,9 @@ function admin_groups()
                         . ' edited: ' . join(', ', $privilege_names)
                     );
                     throw_redirect(url('/admin-groups'));
-                } else {
-                    return error('No Group found.', true);
                 }
-                break;
+
+                return error('No Group found.', true);
         }
     }
     return $html;

--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -215,6 +215,12 @@ class ShiftCalendarRenderer
     {
         $time = Carbon::createFromTimestamp($time);
         $class = $label ? 'tick bg-' . theme_type() : 'tick ';
+
+        $diffNow = $time->diffInMinutes(null, false) * 60;
+        if ($diffNow >= 0 && $diffNow < self::SECONDS_PER_ROW) {
+            $class .= ' now';
+        }
+
         if ($time->isStartOfDay()) {
             if (!$label) {
                 return div($class . ' day');

--- a/includes/view/UserAngelTypes_view.php
+++ b/includes/view/UserAngelTypes_view.php
@@ -108,14 +108,15 @@ function UserAngelType_confirm_view(UserAngelType $user_angeltype, User $user, A
  * @param UserAngelType $user_angeltype
  * @param User          $user
  * @param AngelType     $angeltype
+ * @param bool          $isOwnAngelType
  * @return string
  */
-function UserAngelType_delete_view(UserAngelType $user_angeltype, User $user, AngelType $angeltype)
+function UserAngelType_delete_view(UserAngelType $user_angeltype, User $user, AngelType $angeltype, bool $isOwnAngelType)
 {
-    return page_with_title(__('Remove angeltype'), [
+    return page_with_title(__('Leave angeltype'), [
         msg(),
         info(sprintf(
-            __('Do you really want to delete %s from %s?'),
+            $isOwnAngelType ? __('Do you really want to leave "%2$s"?') : __('Do you really want to remove "%s" from "%s"?'),
             $user->displayName,
             $angeltype->name
         ), true),

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -414,7 +414,7 @@ function User_view_myshift(Shift $shift, $user_source, $its_me)
  * @param Shift[]|Collection   $shifts
  * @param User                 $user_source
  * @param bool                 $its_me
- * @param int                  $tshirt_score
+ * @param string               $tshirt_score
  * @param bool                 $tshirt_admin
  * @param Worklog[]|Collection $user_worklogs
  * @param bool                 $admin_user_worklog_privilege
@@ -549,7 +549,7 @@ function User_view_worklog(Worklog $worklog, $admin_user_worklog_privilege)
  * @param Group[]              $user_groups
  * @param Shift[]|Collection   $shifts
  * @param bool                 $its_me
- * @param int                  $tshirt_score
+ * @param string               $tshirt_score
  * @param bool                 $tshirt_admin
  * @param bool                 $admin_user_worklog_privilege
  * @param Worklog[]|Collection $user_worklogs

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -251,6 +251,10 @@ table .border-bottom {
       font-size: 0.9em;
       padding-left: 5px;
     }
+
+    .tick.now {
+      border-top: 2px solid $info;
+    }
   }
 
   .lane.time {

--- a/resources/assets/themes/choices.scss
+++ b/resources/assets/themes/choices.scss
@@ -10,6 +10,7 @@ $choices-bg-color-dropdown: $input-bg;
 $choices-text-color: $input-color;
 
 $es-choices-highlight-color: $choices-text-color !default;
+$choices-bg-color-disabled: $input-disabled-bg;
 
 @import '~choices.js/src/styles/choices.scss';
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -365,14 +365,17 @@ msgstr "Engeltyp für Benutzer bestätigen"
 msgid "You are not allowed to delete this users angeltype."
 msgstr "Du darfst diesen Benutzer nicht von diesem Engeltyp entfernen."
 
-msgid "User %s removed from %s."
-msgstr "Benutzer %s von %s entfernt."
+msgid "User \"%s\" removed from \"%s\"."
+msgstr "Benutzer \"%s\" von \"%s\" entfernt."
 
 msgid "Edit certificates"
 msgstr "Zertifikate bearbeiten"
 
-msgid "Remove angeltype"
-msgstr "Engeltyp löschen"
+msgid "You successfully left \"%2$s\"."
+msgstr "Du hast erfolgreich \"%2$s\" verlassen."
+
+msgid "Leave angeltype"
+msgstr "Engeltyp verlassen"
 
 msgid "You are not allowed to set supporter rights."
 msgstr "Du darfst keine Supporterrechte bearbeiten."
@@ -1129,8 +1132,11 @@ msgstr "Möchtest Du wirklich alle Benutzer als %s bestätigen?"
 msgid "Do you really want to confirm %s for %s?"
 msgstr "Möchtest Du wirklich %s für %s bestätigen?"
 
-msgid "Do you really want to delete %s from %s?"
-msgstr "Möchtest Du wirklich %s von %s entfernen?"
+msgid "Do you really want to remove \"%s\" from \"%s\"?"
+msgstr "Möchtest Du wirklich \"%s\" von \"%s\" entfernen?"
+
+msgid "Do you really want to leave \"%2$s\"?"
+msgstr "Möchtest Du \"%2$s\" wirklich verlassen?"
 
 msgid "Do you really want to add %s to %s?"
 msgstr "Möchtest Du wirklich %s zu %s hinzufügen?"

--- a/resources/views/layouts/app.twig
+++ b/resources/views/layouts/app.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ session_get('locale')|split('_')[0]|escape('html_attr') }}">
+<html lang="{{ session_get('locale')|split('_')[0]|escape('html_attr') }}" class="h-100">
 <head>
     {% block head %}
         <meta charset="utf-8"/>
@@ -23,7 +23,7 @@
 
     {% endblock %}
 </head>
-<body data-theme_type="{{ theme.type }}">
+<body class="d-flex flex-column h-100" data-theme_type="{{ theme.type }}">
 
 {% block body %}
     {% block header %}
@@ -36,11 +36,12 @@
                 {{ content|raw }}
             {% endblock %}
         </div>
-        <div id="footer">
-            {% block footer %}
-                {% include "layouts/parts/footer.twig" %}
-            {% endblock %}
-        </div>
+    </div>
+
+    <div id="footer" class="mt-auto">
+        {% block footer %}
+            {% include "layouts/parts/footer.twig" %}
+        {% endblock %}
     </div>
 
     {% block scripts %}{% endblock %}

--- a/src/Helpers/Shifts.php
+++ b/src/Helpers/Shifts.php
@@ -16,9 +16,11 @@ class Shifts
     {
         $config = config('night_shifts');
 
+        /** @see User_get_shifts_sum_query to keep it in sync */
         return $config['enabled'] && (
-                $start->hour >= $config['start'] && $start->hour < $config['end']
-                || $end->hour >= $config['start'] && $end->hour < $config['end']
+                $start->hour > $config['start'] && $start->hour < $config['end']
+                || $end->hour > $config['start'] && $end->hour < $config['end']
+                || $start->hour <= $config['start'] && $end->hour >= $config['end']
             );
     }
 

--- a/src/Helpers/Shifts.php
+++ b/src/Helpers/Shifts.php
@@ -18,8 +18,11 @@ class Shifts
 
         /** @see User_get_shifts_sum_query to keep it in sync */
         return $config['enabled'] && (
-                $start->hour > $config['start'] && $start->hour < $config['end']
-                || $end->hour > $config['start'] && $end->hour < $config['end']
+                $start->hour >= $config['start'] && $start->hour < $config['end']
+                || (
+                    $end->hour > $config['start']
+                    || $end->hour == $config['start'] && $end->minute > 0
+                ) && $end->hour <= $config['end']
                 || $start->hour <= $config['start'] && $end->hour >= $config['end']
             );
     }

--- a/tests/Unit/Helpers/ShiftsTest.php
+++ b/tests/Unit/Helpers/ShiftsTest.php
@@ -19,7 +19,7 @@ class ShiftsTest extends TestCase
         $config = new Config(['night_shifts' => [
             'enabled'    => false,
             'start'      => 2,
-            'end'        => 6,
+            'end'        => 8,
             'multiplier' => 2,
         ]]);
         $this->app->instance('config', $config);
@@ -40,16 +40,24 @@ class ShiftsTest extends TestCase
         return [
             // Is night shift
             ['2042-01-01 04:00', '2042-01-01 05:00', true],
+            // Is night shift
+            ['2042-01-01 02:00', '2042-01-01 02:15', true],
+            // Is night shift
+            ['2042-01-01 07:45', '2042-01-01 08:00', true],
             // Starts as night shift
-            ['2042-01-01 05:45', '2042-01-01 07:00', true],
+            ['2042-01-01 07:59', '2042-01-01 09:00', true],
             // Ends as night shift
-            ['2042-01-01 00:00', '2042-01-01 03:00', true],
+            ['2042-01-01 00:00', '2042-01-01 02:01', true],
+            // Equals night shift
+            ['2042-01-01 02:00', '2042-01-01 08:00', true],
             // Contains night shift
             ['2042-01-01 01:00', '2042-01-01 09:00', true],
             // Too early
             ['2042-01-01 00:00', '2042-01-01 02:00', false],
             // Too late
-            ['2042-01-01 06:00', '2042-01-01 10:00', false],
+            ['2042-01-01 08:00', '2042-01-01 10:00', false],
+            // Out of range
+            ['2042-01-01 23:00', '2042-01-02 01:00', false],
         ];
     }
 
@@ -62,7 +70,7 @@ class ShiftsTest extends TestCase
         $config = new Config(['night_shifts' => [
             'enabled'    => true,
             'start'      => 2,
-            'end'        => 6,
+            'end'        => 8,
             'multiplier' => 2,
         ]]);
         $this->app->instance('config', $config);
@@ -78,7 +86,7 @@ class ShiftsTest extends TestCase
         $config = new Config(['night_shifts' => [
             'enabled'    => true,
             'start'      => 2,
-            'end'        => 6,
+            'end'        => 8,
             'multiplier' => 2,
         ]]);
         $this->app->instance('config', $config);

--- a/tests/Unit/Helpers/ShiftsTest.php
+++ b/tests/Unit/Helpers/ShiftsTest.php
@@ -32,22 +32,24 @@ class ShiftsTest extends TestCase
     }
 
     /**
-     * @return array{0: Carbon, 1: Carbon, 2: boolean}[]
+     * @return array{0: string, 1: string, 2: boolean}[]
      */
     public function nightShiftData(): array
     {
         // $start, $end, $isNightShift
         return [
             // Is night shift
-            [new Carbon('2042-01-01 04:00'), new Carbon('2042-01-01 05:00'), true],
+            ['2042-01-01 04:00', '2042-01-01 05:00', true],
             // Starts as night shift
-            [new Carbon('2042-01-01 05:45'), new Carbon('2042-01-01 07:00'), true],
+            ['2042-01-01 05:45', '2042-01-01 07:00', true],
             // Ends as night shift
-            [new Carbon('2042-01-01 00:00'), new Carbon('2042-01-01 02:15'), true],
+            ['2042-01-01 00:00', '2042-01-01 03:00', true],
+            // Contains night shift
+            ['2042-01-01 01:00', '2042-01-01 09:00', true],
             // Too early
-            [new Carbon('2042-01-01 00:00'), new Carbon('2042-01-01 01:59'), false],
+            ['2042-01-01 00:00', '2042-01-01 02:00', false],
             // Too late
-            [new Carbon('2042-01-01 06:00'), new Carbon('2042-01-01 09:59'), false],
+            ['2042-01-01 06:00', '2042-01-01 10:00', false],
         ];
     }
 
@@ -55,7 +57,7 @@ class ShiftsTest extends TestCase
      * @covers       \Engelsystem\Helpers\Shifts::isNightShift
      * @dataProvider nightShiftData
      */
-    public function testIsNightShiftEnabled(Carbon $start, Carbon $end, bool $isNightShift): void
+    public function testIsNightShiftEnabled(string $start, string $end, bool $isNightShift): void
     {
         $config = new Config(['night_shifts' => [
             'enabled'    => true,
@@ -65,7 +67,7 @@ class ShiftsTest extends TestCase
         ]]);
         $this->app->instance('config', $config);
 
-        $this->assertEquals($isNightShift, Shifts::isNightShift($start, $end));
+        $this->assertEquals($isNightShift, Shifts::isNightShift(new Carbon($start), new Carbon($end)));
     }
 
     /**


### PR DESCRIPTION
* Fix night shift calculation
  As long as the calculations are now kept in sync they are test covered too :tada:
* add hours as title to "enough" score
* Shifts view: Highlight current time
* Move footer to the bottom on any page
* Make group rights edit buttons clickable again
* Change translations when removing users from angeltype to be less confusing
* Fix disabled choices select color on dark theme