### PR TITLE
API: Use references in shifts list, added shift types endpoints

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -146,6 +146,9 @@ $route->addGroup(
 
                 $route->get('/news', 'Api\NewsController@index');
 
+                $route->get('/shifttypes', 'Api\ShiftTypeController@index');
+                $route->get('/shifttypes/{shifttype_id:\d+}/shifts', 'Api\ShiftsController@entriesByShiftType');
+
                 $route->get('/users/{user_id:(?:\d+|self)}', 'Api\UsersController@user');
                 $route->get('/users/{user_id:(?:\d+|self)}/angeltypes', 'Api\AngelTypeController@ofUser');
                 $route->get('/users/{user_id:(?:\d+|self)}/shifts', 'Api\ShiftsController@entriesByUser');

--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 0.0.1-beta
+  version: 0.1.0-beta
   title: Engelsystem
   description: >
     This API is as stable as a **beta** version might be.
@@ -17,14 +17,17 @@ info:
 servers:
   - url: /api/v0-beta
     description: This server
-  - url: http://localhost:5080/api/v0-beta
-    description: Your local dev instance
+  - url: '{host}/api/v0-beta'
+    description: Engelsystem instance to use
+    variables:
+      host:
+        default: http://localhost:5080
 
 tags:
   - name: api
     description: API related
   - name: angeltype
-    description: Angeltypes
+    description: Angel types
   - name: event
     description: Event information
   - name: location
@@ -33,8 +36,10 @@ tags:
     description: News and meeting announcements
   - name: shift
     description: Event shifts
+  - name: shifttype
+    description: Shift types
   - name: user
-    description: User information
+    description: Users
 
 security:
   - bearer-auth: [ ]
@@ -89,11 +94,11 @@ components:
           example: Angel
         description:
           type: string
-          example: Meta-Group of all registered Angels
+          example: Standard angel type, without further requirements
         url:
           type: string
           example: https://example.com/angeltype/42
-          description: Link to the page of the given angeltype.
+          description: Link to the page of the given angel type.
       required:
         - id
         - name
@@ -109,11 +114,11 @@ components:
               example: true
               description: >
                 If the user is confirmed
-                (either by the angeltype not requiring confirmation, being a supporter or being confirmed by one).
+                (either by the angel type not requiring confirmation, being a supporter or being confirmed by one).
             supporter:
               type: boolean
               example: false
-              description: If the user is a supporter of the angeltype.
+              description: If the user is a supporter of the angel type.
           required:
             - confirmed
             - supporter
@@ -123,9 +128,10 @@ components:
         id:
           type: integer
           example: 42
-        title:
+        name:
           type: string
           example: First helper introduction
+          description: Title of the news
         text:
           type: string
           example: |
@@ -156,7 +162,7 @@ components:
           description: Direct link to the news page
       required:
         - id
-        - title
+        - name
         - text
         - is_meeting
         - is_pinned
@@ -187,9 +193,10 @@ components:
         id:
           type: integer
           example: 42
-        title:
+        name:
           type: string
           example: Cleanup the venue
+          description: Title of the shift
         description:
           type: string
           example: You clean up the venue after the event. Its fun, we promise!
@@ -201,9 +208,9 @@ components:
         ends_at:
           $ref: '#/components/schemas/DateTime'
         location:
-          $ref: '#/components/schemas/Location'
+          $ref: '#/components/schemas/Reference'
         shift_type:
-          $ref: '#/components/schemas/ShiftType'
+          $ref: '#/components/schemas/Reference'
         created_at:
           $ref: '#/components/schemas/DateTimeOptional'
         updated_at:
@@ -219,7 +226,7 @@ components:
           description: Direct link to the shift
       required:
         - id
-        - title
+        - name
         - description
         - starts_at
         - ends_at
@@ -235,9 +242,9 @@ components:
         users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
-        type:
-          $ref: '#/components/schemas/AngelType'
+            $ref: '#/components/schemas/Reference'
+        angeltype:
+          $ref: '#/components/schemas/Reference'
         needs:
           type: integer
           description: >
@@ -247,7 +254,7 @@ components:
           example: 3
       required:
         - users
-        - type
+        - angeltype
         - needs
     ShiftType:
       type: object
@@ -428,13 +435,28 @@ components:
         - buildup
         - event
         - teardown
+    Reference:
+      type: object
+      description: Reference to other resources
+      properties:
+        id:
+          type: integer
+          example: 42
+          description: The ID of the related resource
+        name:
+          type: string
+          nullable: true
+          example: Foo
+          description: A name of the related resource, should only be used for reference
+      required:
+        - id
 
 paths:
   /angeltypes:
     get:
       tags:
         - angeltype
-      summary: Get a list of angeltypes
+      summary: Get a list of angel types
       responses:
         '200':
           description: Ok
@@ -457,7 +479,7 @@ paths:
       - name: id
         in: path
         required: true
-        description: The angeltype identifier
+        description: The angel type identifier
         example: 42
         schema:
           type: integer
@@ -465,7 +487,7 @@ paths:
       tags:
         - angeltype
         - shift
-      summary: Get all shifts of the requested angeltype
+      summary: Get all shifts of the requested angel type
       responses:
         '200':
           description: Ok
@@ -537,6 +559,61 @@ paths:
         - location
         - shift
       summary: Get all shifts in the requested location
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Shift'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+
+  /shifttypes:
+    get:
+      tags:
+        - shifttype
+      summary: Get a list of shift types
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ShiftType'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+
+  /shifttypes/{id}/shifts:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The shift types identifier
+        example: 42
+        schema:
+          type: integer
+    get:
+      tags:
+        - shifttype
+        - shift
+      summary: Get all shifts of the requested shift type
       responses:
         '200':
           description: Ok

--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -26,7 +26,7 @@ servers:
 tags:
   - name: api
     description: API related
-  - name: angeltype
+  - name: angel type
     description: Angel types
   - name: event
     description: Event information
@@ -36,7 +36,7 @@ tags:
     description: News and meeting announcements
   - name: shift
     description: Event shifts
-  - name: shifttype
+  - name: shift type
     description: Shift types
   - name: user
     description: Users
@@ -199,18 +199,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ShiftEntry'
-        angeltype:
+        angel_type:
           $ref: '#/components/schemas/Reference'
         needs:
           type: integer
           description: >
-            Number of users needed for the shift of the given type.
-            Will be more than users count when not full, less when overbooked
+            Number of users needed for the shift of the given angel type.
+            Will be greater than users count when not full, less when overbooked
             or 0 when only additional users with given type have been added.
           example: 3
       required:
         - entries
-        - angeltype
+        - angel_type
         - needs
     Shift:
       type: object
@@ -240,7 +240,7 @@ components:
           $ref: '#/components/schemas/DateTimeOptional'
         updated_at:
           $ref: '#/components/schemas/DateTimeOptional'
-        angeltypes:
+        needed_angel_types:
           type: array
           description: Needed angel types and user entries, can be empty (for example on Schedule import of unused room)
           items:
@@ -259,7 +259,7 @@ components:
         - shift_type
         - created_at
         - updated_at
-        - angeltypes
+        - needed_angel_types
         - url
     ShiftEntry:
       type: object
@@ -269,7 +269,7 @@ components:
         freeloaded:
           type: boolean
           example: false
-          description: True if the user did not arrive to the shift
+          description: True if the user was marked as freeloaded for not arriving to the shift
       required:
         - user
         - freeloaded
@@ -472,7 +472,7 @@ paths:
   /angeltypes:
     get:
       tags:
-        - angeltype
+        - angel type
       summary: Get a list of angel types
       responses:
         '200':
@@ -502,7 +502,7 @@ paths:
           type: integer
     get:
       tags:
-        - angeltype
+        - angel type
         - shift
       summary: Get all shifts of the requested angel type
       responses:
@@ -598,7 +598,7 @@ paths:
   /shifttypes:
     get:
       tags:
-        - shifttype
+        - shift type
       summary: Get a list of shift types
       responses:
         '200':
@@ -628,7 +628,7 @@ paths:
           type: integer
     get:
       tags:
-        - shifttype
+        - shift type
         - shift
       summary: Get all shifts of the requested shift type
       responses:
@@ -697,7 +697,7 @@ paths:
             - type: integer
     get:
       tags:
-        - angeltype
+        - angel type
         - user
       summary: Get the users angel types
       responses:

--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -95,6 +95,10 @@ components:
         description:
           type: string
           example: Standard angel type, without further requirements
+        restricted:
+          type: boolean
+          example: false
+          description: True if the angel type requires an introduction
         url:
           type: string
           example: https://example.com/angeltype/42

--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -192,6 +192,26 @@ components:
         - name
         - description
         - url
+    NeededAngelType:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ShiftEntry'
+        angeltype:
+          $ref: '#/components/schemas/Reference'
+        needs:
+          type: integer
+          description: >
+            Number of users needed for the shift of the given type.
+            Will be more than users count when not full, less when overbooked
+            or 0 when only additional users with given type have been added.
+          example: 3
+      required:
+        - entries
+        - angeltype
+        - needs
     Shift:
       type: object
       properties:
@@ -220,11 +240,11 @@ components:
           $ref: '#/components/schemas/DateTimeOptional'
         updated_at:
           $ref: '#/components/schemas/DateTimeOptional'
-        entries:
+        angeltypes:
           type: array
-          description: Can be empty (for example on Schedule import of unused room)
+          description: Needed angel types and user entries, can be empty (for example on Schedule import of unused room)
           items:
-            $ref: '#/components/schemas/ShiftEntry'
+            $ref: '#/components/schemas/NeededAngelType'
         url:
           type: string
           example: https://example.com/shifts/42
@@ -239,28 +259,20 @@ components:
         - shift_type
         - created_at
         - updated_at
-        - entries
+        - angeltypes
         - url
     ShiftEntry:
       type: object
       properties:
-        users:
-          type: array
-          items:
-            $ref: '#/components/schemas/Reference'
-        angeltype:
+        user:
           $ref: '#/components/schemas/Reference'
-        needs:
-          type: integer
-          description: >
-            Number of users needed for the shift of the given type.
-            Will be more than users count when not full, less when overbooked
-            or 0 when only additional users with given type have been added.
-          example: 3
+        freeloaded:
+          type: boolean
+          example: false
+          description: True if the user did not arrive to the shift
       required:
-        - users
-        - angeltype
-        - needs
+        - user
+        - freeloaded
     ShiftType:
       type: object
       properties:

--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -179,6 +179,10 @@ components:
         name:
           type: string
           example: Heaven
+        description:
+          type: string
+          example: Located behind room 42
+          description: Description of the room
         url:
           type: string
           example: https://example.com/location/42
@@ -186,6 +190,7 @@ components:
       required:
         - id
         - name
+        - description
         - url
     Shift:
       type: object
@@ -326,7 +331,7 @@ components:
             email:
               type: string
               example: user@example.com
-            tshirt:
+            tshirt_size:
               type: string
               nullable: true
               example: XL
@@ -355,7 +360,7 @@ components:
               example: true
       required:
         - email
-        - tshirt
+        - tshirt_size
         - dates
         - language
         - arrived

--- a/src/Controllers/Api/Resources/AngelTypeResource.php
+++ b/src/Controllers/Api/Resources/AngelTypeResource.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Api\Resources;
 
+use Engelsystem\Models\AngelType;
+use Engelsystem\Models\BaseModel;
+use Illuminate\Support\Collection;
+
 class AngelTypeResource extends BasicResource
 {
+    protected Collection | BaseModel | AngelType $model;
+
     public function toArray(): array
     {
         return [

--- a/src/Controllers/Api/Resources/AngelTypeResource.php
+++ b/src/Controllers/Api/Resources/AngelTypeResource.php
@@ -18,6 +18,7 @@ class AngelTypeResource extends BasicResource
             'id' => $this->model->id,
             'name' => $this->model->name,
             'description' => $this->model->description,
+            'restricted' => $this->model->restricted,
             'url' => url('/angeltypes', ['action' => 'view', 'angeltype_id' => $this->model->id]),
         ];
     }

--- a/src/Controllers/Api/Resources/BasicResource.php
+++ b/src/Controllers/Api/Resources/BasicResource.php
@@ -13,7 +13,7 @@ use Stringable;
 /** @phpstan-consistent-constructor */
 abstract class BasicResource implements Arrayable, Jsonable, Stringable
 {
-    public function __construct(protected BaseModel|Collection $model)
+    public function __construct(protected BaseModel | Collection $model)
     {
     }
 
@@ -32,6 +32,16 @@ abstract class BasicResource implements Arrayable, Jsonable, Stringable
     public function toArray(): array
     {
         return $this->model->toArray();
+    }
+
+    public static function toIdentifierArray(array | Arrayable $data): array
+    {
+        $data = $data instanceof Arrayable ? $data->toArray() : $data;
+        $identifier = ['id' => $data['id']];
+        if (array_key_exists('name', $data)) {
+            $identifier['name'] = $data['name'];
+        }
+        return $identifier;
     }
 
     /**

--- a/src/Controllers/Api/Resources/LocationResource.php
+++ b/src/Controllers/Api/Resources/LocationResource.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Api\Resources;
 
+use Engelsystem\Models\BaseModel;
+use Engelsystem\Models\Location;
+use Illuminate\Support\Collection;
+
 class LocationResource extends BasicResource
 {
+    protected Collection | BaseModel | Location $model;
+
     public function toArray(): array
     {
         return [
             'id' => $this->model->id,
             'name' => $this->model->name,
+            'description' => $this->model->description ?: '',
             'url' => url('/locations', ['action' => 'view', 'location_id' => $this->model->id]),
         ];
     }

--- a/src/Controllers/Api/Resources/NewsResource.php
+++ b/src/Controllers/Api/Resources/NewsResource.php
@@ -10,7 +10,7 @@ class NewsResource extends BasicResource
     {
         return [
             'id' => $this->model->id,
-            'title' => $this->model->title,
+            'name' => $this->model->title,
             'text' => $this->model->text,
             'is_meeting' => $this->model->is_meeting,
             'is_pinned' => $this->model->is_pinned,

--- a/src/Controllers/Api/Resources/NewsResource.php
+++ b/src/Controllers/Api/Resources/NewsResource.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Api\Resources;
 
+use Engelsystem\Models\BaseModel;
+use Engelsystem\Models\News;
+use Illuminate\Support\Collection;
+
 class NewsResource extends BasicResource
 {
+    protected Collection | BaseModel | News $model;
+
     public function toArray(): array
     {
         return [

--- a/src/Controllers/Api/Resources/ShiftResource.php
+++ b/src/Controllers/Api/Resources/ShiftResource.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Api\Resources;
 
+use Engelsystem\Models\BaseModel;
+use Engelsystem\Models\Shifts\Shift;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
 
 class ShiftResource extends BasicResource
 {
-    public function toArray(array|Arrayable $location = []): array
+    protected Collection | BaseModel | Shift $model;
+
+    public function toArray(array | Arrayable $location = []): array
     {
         return [
             'id' => $this->model->id,

--- a/src/Controllers/Api/Resources/ShiftResource.php
+++ b/src/Controllers/Api/Resources/ShiftResource.php
@@ -12,12 +12,12 @@ class ShiftResource extends BasicResource
     {
         return [
             'id' => $this->model->id,
-            'title' => $this->model->title,
+            'name' => $this->model->title,
             'description' => $this->model->description,
             'starts_at' => $this->model->start,
             'ends_at' => $this->model->end,
-            'location' => $location instanceof Arrayable ? $location->toArray() : $location,
-            'shift_type' => (new ShiftTypeResource($this->model->shiftType))->toArray(),
+            'location' => LocationResource::toIdentifierArray($location),
+            'shift_type' => ShiftTypeResource::toIdentifierArray($this->model->shiftType),
             'created_at' => $this->model->created_at,
             'updated_at' => $this->model->updated_at,
             'url' => url('/shifts', ['action' => 'view', 'shift_id' => $this->model->id]),

--- a/src/Controllers/Api/Resources/ShiftTypeResource.php
+++ b/src/Controllers/Api/Resources/ShiftTypeResource.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Api\Resources;
 
+use Engelsystem\Models\BaseModel;
+use Engelsystem\Models\Shifts\ShiftType;
+use Illuminate\Support\Collection;
+
 class ShiftTypeResource extends BasicResource
 {
+    protected Collection | BaseModel | ShiftType $model;
+
     public function toArray(): array
     {
         return [

--- a/src/Controllers/Api/Resources/ShiftWithEntriesResource.php
+++ b/src/Controllers/Api/Resources/ShiftWithEntriesResource.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class ShiftWithEntriesResource extends ShiftResource
 {
-    public function toArray(array|Arrayable $location = [], array|Arrayable $entries = []): array
+    public function toArray(array | Arrayable $location = [], array | Arrayable $entries = []): array
     {
         return [
             ...parent::toArray($location),

--- a/src/Controllers/Api/Resources/ShiftWithEntriesResource.php
+++ b/src/Controllers/Api/Resources/ShiftWithEntriesResource.php
@@ -8,11 +8,11 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class ShiftWithEntriesResource extends ShiftResource
 {
-    public function toArray(array | Arrayable $location = [], array | Arrayable $entries = []): array
+    public function toArray(array | Arrayable $location = [], array | Arrayable $angelTypes = []): array
     {
         return [
             ...parent::toArray($location),
-            'entries' => $entries instanceof Arrayable ? $entries->toArray() : $entries,
+            'angeltypes' => $angelTypes instanceof Arrayable ? $angelTypes->toArray() : $angelTypes,
         ];
     }
 }

--- a/src/Controllers/Api/Resources/ShiftWithEntriesResource.php
+++ b/src/Controllers/Api/Resources/ShiftWithEntriesResource.php
@@ -12,7 +12,7 @@ class ShiftWithEntriesResource extends ShiftResource
     {
         return [
             ...parent::toArray($location),
-            'angeltypes' => $angelTypes instanceof Arrayable ? $angelTypes->toArray() : $angelTypes,
+            'needed_angel_types' => $angelTypes instanceof Arrayable ? $angelTypes->toArray() : $angelTypes,
         ];
     }
 }

--- a/src/Controllers/Api/Resources/UserDetailResource.php
+++ b/src/Controllers/Api/Resources/UserDetailResource.php
@@ -10,7 +10,7 @@ class UserDetailResource extends UserResource
     {
         return array_merge(parent::toArray(), [
             'email' => $this->model->contact->email ?: $this->model->email,
-            'tshirt' => $this->model->personalData->shirt_size,
+            'tshirt_size' => $this->model->personalData->shirt_size,
             'language' => $this->model->settings->language,
             'arrived' => $this->model->state->arrived,
             'dates' => [

--- a/src/Controllers/Api/Resources/UserResource.php
+++ b/src/Controllers/Api/Resources/UserResource.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Api\Resources;
 
+use Engelsystem\Models\BaseModel;
+use Engelsystem\Models\User\User;
+use Illuminate\Support\Collection;
+
 class UserResource extends BasicResource
 {
+    protected Collection | BaseModel | User $model;
+
     public function toArray(): array
     {
         return [

--- a/src/Controllers/Api/ShiftTypeController.php
+++ b/src/Controllers/Api/ShiftTypeController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers\Api;
+
+use Engelsystem\Controllers\Api\Resources\ShiftTypeResource;
+use Engelsystem\Http\Response;
+use Engelsystem\Models\Shifts\ShiftType;
+
+class ShiftTypeController extends ApiController
+{
+    use UsesAuth;
+
+    public function index(): Response
+    {
+        $models = ShiftType::query()
+            ->orderBy('name')
+            ->get();
+
+        $data = ['data' => ShiftTypeResource::collection($models)];
+        return $this->response
+            ->withContent(json_encode($data));
+    }
+}

--- a/src/Controllers/Api/ShiftsController.php
+++ b/src/Controllers/Api/ShiftsController.php
@@ -147,7 +147,7 @@ class ShiftsController extends ApiController
                 ]);
                 $angelTypeData = AngelTypeResource::toIdentifierArray($neededAngelType->angelType);
                 $angelTypes[] = new Collection([
-                    'angeltype' => $angelTypeData,
+                    'angel_type' => $angelTypeData,
                     'needs' => $neededAngelType->count,
                     'entries' => $entries,
                 ]);
@@ -163,7 +163,7 @@ class ShiftsController extends ApiController
     }
 
     /**
-     * Collect all needed angeltypes
+     * Collect all needed angel types
      */
     protected function getNeededAngelTypes(Shift $shift): Collection
     {
@@ -179,7 +179,7 @@ class ShiftsController extends ApiController
             $neededAngelTypes = $shift->location->neededAngelTypes;
         }
 
-        // Add needed angeltypes from additionally added users
+        // Add needed angel types from additionally added users
         foreach ($shift->shiftEntries as $entry) {
             $neededAngelType = $neededAngelTypes->where('angel_type_id', $entry->angelType->id)->first();
             if (!$neededAngelType) {
@@ -191,7 +191,7 @@ class ShiftsController extends ApiController
                 $neededAngelTypes[] = $neededAngelType;
             }
 
-            // Add entries to needed angeltype
+            // Add entries to needed angel type
             $neededAngelType->entries = isset($neededAngelType->entries)
                 ? $neededAngelType->entries
                 : new Collection();

--- a/src/Models/AngelType.php
+++ b/src/Models/AngelType.php
@@ -53,12 +53,17 @@ class AngelType extends BaseModel
 
     /** @var array Default attributes */
     protected $attributes = [ // phpcs:ignore
+        'description'               => '',
+        'contact_name'              => '',
+        'contact_dect'              => '',
+        'contact_email'             => '',
         'restricted'                => false,
         'requires_driver_license'   => false,
         'requires_ifsg_certificate' => false,
-        'shift_self_signup'         => true,
-        'show_on_dashboard'         => false,
+        'shift_self_signup'         => false,
+        'show_on_dashboard'         => true,
         'hide_register'             => false,
+        'hide_on_shift_view'        => false,
     ];
 
     /**

--- a/src/Models/EventConfig.php
+++ b/src/Models/EventConfig.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 /**
  * @property string $name
  * @property string $value
- * @property Carbon $created_at
- * @property Carbon $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  *
  * @method static QueryBuilder|EventConfig[] whereName($value)
  * @method static QueryBuilder|EventConfig[] whereValue($value)

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property int                               $id
  * @property string                            $name
  * @property string                            $map_url
- * @property string                            $description
+ * @property string|null                       $description
  * @property string                            $dect
  * @property Carbon|null                       $created_at
  * @property Carbon|null                       $updated_at

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -17,9 +17,9 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 /**
  * @property int                               $id
  * @property string                            $name
- * @property string                            $map_url
+ * @property string|null                       $map_url
  * @property string|null                       $description
- * @property string                            $dect
+ * @property string|null                       $dect
  * @property Carbon|null                       $created_at
  * @property Carbon|null                       $updated_at
  *

--- a/src/Models/LogEntry.php
+++ b/src/Models/LogEntry.php
@@ -14,9 +14,12 @@ use Illuminate\Support\Collection as SupportCollection;
 
 /**
  * @property int         $id
+ * @property int|null    $user_id
  * @property string      $level
  * @property string      $message
  * @property Carbon|null $created_at
+ *
+ * @property-read User|null $user
  *
  * @method static QueryBuilder|LogEntry[] whereId($value)
  * @method static QueryBuilder|LogEntry[] whereLevel($value)
@@ -32,6 +35,11 @@ class LogEntry extends BaseModel
 
     /** @var null Disable updated_at */
     public const UPDATED_AT = null;
+
+    /** @var array Default attributes */
+    protected $attributes = [ // phpcs:ignore
+        'user_id' => null,
+    ];
 
     /** @var array<string, string> */
     protected $casts = [ // phpcs:ignore

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -20,8 +20,10 @@ use Illuminate\Support\Carbon;
  * @property string      $text
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ *
  * @property-read User   $sender
  * @property-read User   $receiver
+ *
  * @method static Builder|Message whereId($value)
  * @method static Builder|Message whereUserId($value)
  * @method static Builder|Message whereReceiverId($value)

--- a/src/Models/OAuth.php
+++ b/src/Models/OAuth.php
@@ -13,8 +13,8 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property int         $id
  * @property string      $provider
  * @property string      $identifier
- * @property string      $access_token
- * @property string      $refresh_token
+ * @property string|null $access_token
+ * @property string|null $refresh_token
  * @property Carbon|null $expires_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at

--- a/src/Models/Question.php
+++ b/src/Models/Question.php
@@ -15,13 +15,13 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 /**
  * @property int         $id
  * @property string      $text
- * @property string      $answer
- * @property int         $answerer_id
+ * @property string|null $answer
+ * @property int|null    $answerer_id
  * @property Carbon|null $answered_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  *
- * @property-read User   $answerer
+ * @property-read User|null $answerer
  *
  * @method static Builder|Question whereAnswer($value)
  * @method static Builder|Question whereAnswererId($value)

--- a/src/Models/Shifts/NeededAngelType.php
+++ b/src/Models/Shifts/NeededAngelType.php
@@ -51,6 +51,15 @@ class NeededAngelType extends BaseModel
         'count',
     ];
 
+    /** @var array<string, string> */
+    protected $casts = [ // phpcs:ignore
+        'location_id' => 'integer',
+        'shift_id' => 'integer',
+        'shift_type_id' => 'integer',
+        'angel_type_id' => 'integer',
+        'count' => 'integer',
+    ];
+
     public function location(): BelongsTo
     {
         return $this->belongsTo(Location::class);

--- a/src/Models/Shifts/Schedule.php
+++ b/src/Models/Shifts/Schedule.php
@@ -23,8 +23,8 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property bool                                         $needed_from_shift_type
  * @property int                                          $minutes_before
  * @property int                                          $minutes_after
- * @property Carbon                                       $created_at
- * @property Carbon                                       $updated_at
+ * @property Carbon|null                                  $created_at
+ * @property Carbon|null                                  $updated_at
  *
  * @property-read QueryBuilder|Location[]                 $activeLocations
  * @property-read QueryBuilder|Collection|Shift[]         $shifts
@@ -47,6 +47,11 @@ class Schedule extends BaseModel
 
     /** @var bool enable timestamps */
     public $timestamps = true; // phpcs:ignore
+
+    /** @var array Default attributes */
+    protected $attributes = [ // phpcs:ignore
+        'needed_from_shift_type' => false,
+    ];
 
     /** @var array<string> */
     protected $casts = [ // phpcs:ignore

--- a/src/Models/Shifts/Shift.php
+++ b/src/Models/Shifts/Shift.php
@@ -24,7 +24,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property Carbon                            $end
  * @property int                               $shift_type_id
  * @property int                               $location_id
- * @property string                            $transaction_id
+ * @property string|null                       $transaction_id
  * @property int                               $created_by
  * @property int|null                          $updated_by
  * @property Carbon|null                       $created_at

--- a/src/Models/Shifts/ShiftEntry.php
+++ b/src/Models/Shifts/ShiftEntry.php
@@ -53,6 +53,9 @@ class ShiftEntry extends BaseModel
 
     /** @var array<string, string> */
     protected $casts = [ // phpcs:ignore
+        'shift_id' => 'integer',
+        'angel_type_id' => 'integer',
+        'user_id' => 'integer',
         'freeloaded' => 'bool',
     ];
 

--- a/src/Models/User/License.php
+++ b/src/Models/User/License.php
@@ -72,6 +72,7 @@ class License extends HasUserModel
 
     /** @var array<string> */
     protected $casts = [ // phpcs:ignore
+        'user_id' => 'integer',
         'has_car' => 'boolean',
         'drive_forklift' => 'boolean',
         'drive_car' => 'boolean',

--- a/src/Models/User/PersonalData.php
+++ b/src/Models/User/PersonalData.php
@@ -42,6 +42,7 @@ class PersonalData extends HasUserModel
 
     /** @var array<string, string> */
     protected $casts = [ // phpcs:ignore
+        'user_id'                => 'integer',
         'planned_arrival_date'   => 'datetime',
         'planned_departure_date' => 'datetime',
     ];

--- a/src/Models/User/Settings.php
+++ b/src/Models/User/Settings.php
@@ -37,7 +37,7 @@ class Settings extends HasUserModel
     protected $attributes = [ // phpcs:ignore
         'email_human'     => false,
         'email_messages'  => false,
-        'email_goodie'     => false,
+        'email_goodie'    => false,
         'email_shiftinfo' => false,
         'email_news'      => false,
         'mobile_show'     => false,
@@ -66,7 +66,7 @@ class Settings extends HasUserModel
         'theme'           => 'integer',
         'email_human'     => 'boolean',
         'email_messages'  => 'boolean',
-        'email_goodie'     => 'boolean',
+        'email_goodie'    => 'boolean',
         'email_shiftinfo' => 'boolean',
         'email_news'      => 'boolean',
         'mobile_show'     => 'boolean',

--- a/src/Models/User/State.php
+++ b/src/Models/User/State.php
@@ -47,11 +47,11 @@ class State extends HasUserModel
     protected $casts = [ // phpcs:ignore
         'user_id'      => 'integer',
         'arrived'      => 'boolean',
+        'arrival_date' => 'datetime',
         'active'       => 'boolean',
         'force_active' => 'boolean',
         'got_goodie'   => 'boolean',
         'got_voucher'  => 'integer',
-        'arrival_date' => 'datetime',
     ];
 
     /**

--- a/src/Models/User/User.php
+++ b/src/Models/User/User.php
@@ -35,8 +35,8 @@ use Illuminate\Support\Collection as SupportCollection;
  * @property string                             $password
  * @property string                             $api_key
  * @property Carbon|null                        $last_login_at
- * @property Carbon                             $created_at
- * @property Carbon                             $updated_at
+ * @property Carbon|null                        $created_at
+ * @property Carbon|null                        $updated_at
  *
  * @property-read QueryBuilder|Contact          $contact
  * @property-read QueryBuilder|License          $license

--- a/src/Models/UserAngelType.php
+++ b/src/Models/UserAngelType.php
@@ -17,11 +17,11 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  *
  * @property int            $id
  * @property int            $angel_type_id
- * @property int            $confirm_user_id
+ * @property int|null       $confirm_user_id
  * @property bool           $supporter
  *
  * @property-read AngelType $angelType
- * @property-read User      $confirmUser
+ * @property-read User|null $confirmUser
  *
  * @method static QueryBuilder|UserAngelType[] whereId($value)
  * @method static QueryBuilder|UserAngelType[] whereAngelTypeId($value)

--- a/tests/Unit/Controllers/Api/AngelTypeControllerTest.php
+++ b/tests/Unit/Controllers/Api/AngelTypeControllerTest.php
@@ -17,6 +17,7 @@ class AngelTypeControllerTest extends ApiBaseControllerTest
 {
     /**
      * @covers \Engelsystem\Controllers\Api\AngelTypeController::index
+     * @covers \Engelsystem\Controllers\Api\Resources\AngelTypeResource::toArray
      */
     public function testIndex(): void
     {
@@ -37,6 +38,7 @@ class AngelTypeControllerTest extends ApiBaseControllerTest
             return $item['name'] == $items->first()->getAttribute('name');
         }));
     }
+
     /**
      * @covers \Engelsystem\Controllers\Api\AngelTypeController::ofUser
      * @covers \Engelsystem\Controllers\Api\Resources\UserAngelTypeResource::toArray

--- a/tests/Unit/Controllers/Api/AngelTypeControllerTest.php
+++ b/tests/Unit/Controllers/Api/AngelTypeControllerTest.php
@@ -35,7 +35,10 @@ class AngelTypeControllerTest extends ApiBaseControllerTest
         $this->assertArrayHasKey('data', $data);
         $this->assertCount(3, $data['data']);
         $this->assertCount(1, collect($data['data'])->filter(function ($item) use ($items) {
-            return $item['name'] == $items->first()->getAttribute('name');
+            $first = $items->first();
+            return $item['name'] == $first->getAttribute('name')
+                && $item['description'] == $first->getAttribute('description')
+                && $item['restricted'] == $first->getAttribute('restricted');
         }));
     }
 

--- a/tests/Unit/Controllers/Api/ApiBaseControllerTest.php
+++ b/tests/Unit/Controllers/Api/ApiBaseControllerTest.php
@@ -6,6 +6,8 @@ namespace Engelsystem\Test\Unit\Controllers\Api;
 
 use Engelsystem\Http\UrlGeneratorInterface;
 use Engelsystem\Test\Unit\Controllers\ControllerTest as TestCase;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
 use League\OpenAPIValidation\PSR7\OperationAddress as OpenApiAddress;
 use League\OpenAPIValidation\PSR7\ResponseValidator as OpenApiResponseValidator;
 use League\OpenAPIValidation\PSR7\ValidatorBuilder as OpenApiValidatorBuilder;
@@ -19,7 +21,12 @@ abstract class ApiBaseControllerTest extends TestCase
     protected function validateApiResponse(string $path, string $method, ResponseInterface $response): void
     {
         $operation = new OpenApiAddress($path, $method);
-        $this->validator->validate($operation, $response);
+        try {
+            $this->validator->validate($operation, $response);
+        } catch (InvalidBody $e) {
+            $newMessage = $e->getMessage() . ': ' . $e->getPrevious()?->getMessage();
+            throw new ValidationFailed($newMessage, $e->getCode(), $e);
+        }
     }
 
     public function setUp(): void

--- a/tests/Unit/Controllers/Api/Resources/BasicResourceTest.php
+++ b/tests/Unit/Controllers/Api/Resources/BasicResourceTest.php
@@ -28,6 +28,22 @@ class BasicResourceTest extends TestCase
     }
 
     /**
+     * @covers \Engelsystem\Controllers\Api\Resources\BasicResource::toIdentifierArray
+     */
+    public function testToIdentifierArray(): void
+    {
+        $model = $this->getModel()->setAttribute('id', 42);
+        $resource = $this->getResource($model);
+
+        $this->assertEquals(['id' => 42], $resource->toIdentifierArray($model));
+
+        $model = $model->setAttribute('name', 'test');
+        $resource = $this->getResource($model);
+
+        $this->assertEquals(['id' => 42, 'name' => 'test'], $resource->toIdentifierArray($model));
+    }
+
+    /**
      * @covers \Engelsystem\Controllers\Api\Resources\BasicResource::toJson
      */
     public function testToJson(): void

--- a/tests/Unit/Controllers/Api/ShiftTypeControllerTest.php
+++ b/tests/Unit/Controllers/Api/ShiftTypeControllerTest.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 
 namespace Engelsystem\Test\Unit\Controllers\Api;
 
-use Engelsystem\Controllers\Api\NewsController;
+use Engelsystem\Controllers\Api\ShiftTypeController;
 use Engelsystem\Http\Response;
-use Engelsystem\Models\News;
+use Engelsystem\Models\Shifts\ShiftType;
 
-class NewsControllerTest extends ApiBaseControllerTest
+class ShiftTypeControllerTest extends ApiBaseControllerTest
 {
     /**
-     * @covers \Engelsystem\Controllers\Api\NewsController::index
-     * @covers \Engelsystem\Controllers\Api\Resources\NewsResource::toArray
+     * @covers \Engelsystem\Controllers\Api\ShiftTypeController::index
+     * @covers \Engelsystem\Controllers\Api\Resources\ShiftTypeResource::toArray
      */
     public function testIndex(): void
     {
-        $items = News::factory(3)->create();
+        $items = ShiftType::factory(3)->create();
 
-        $controller = new NewsController(new Response());
+        $controller = new ShiftTypeController(new Response());
 
         $response = $controller->index();
-        $this->validateApiResponse('/news', 'get', $response);
+        $this->validateApiResponse('/shifttypes', 'get', $response);
 
         $this->assertEquals(['application/json'], $response->getHeader('content-type'));
         $this->assertJson($response->getContent());
@@ -29,9 +29,8 @@ class NewsControllerTest extends ApiBaseControllerTest
         $data = json_decode($response->getContent(), true);
         $this->assertArrayHasKey('data', $data);
         $this->assertCount(3, $data['data']);
-
         $this->assertCount(1, collect($data['data'])->filter(function ($item) use ($items) {
-            return $item['name'] == $items->first()->getAttribute('title');
+            return $item['name'] == $items->first()->getAttribute('name');
         }));
     }
 }

--- a/tests/Unit/Controllers/Api/ShiftsControllerTest.php
+++ b/tests/Unit/Controllers/Api/ShiftsControllerTest.php
@@ -57,9 +57,9 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertEquals($this->shiftA->title, $shiftAData['name'], 'Title is equal');
         $this->assertEquals($this->location->id, $shiftAData['location']['id'], 'Same location');
         $this->assertEquals($this->shiftA->shiftType->id, $shiftAData['shift_type']['id'], 'Shift type equals');
-        $this->assertCount(4, $shiftAData['angeltypes']);
+        $this->assertCount(4, $shiftAData['needed_angel_types']);
         // Has users
-        $entriesA = collect($shiftAData['angeltypes'])->sortBy('angeltype.id');
+        $entriesA = collect($shiftAData['needed_angel_types'])->sortBy('angeltype.id');
         $entry = $entriesA[0];
         $this->assertCount(2, $entry['entries']);
         $this->assertEquals(2, $entry['needs']);
@@ -76,9 +76,9 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertEquals($this->shiftB->title, $shiftBData['name'], 'Title is equal');
         $this->assertEquals($this->location->id, $shiftBData['location']['id'], 'Same location');
         $this->assertEquals($this->shiftB->shiftType->id, $shiftBData['shift_type']['id'], 'Shift type equals');
-        $this->assertCount(3, $shiftBData['angeltypes']);
+        $this->assertCount(3, $shiftBData['needed_angel_types']);
         // No users
-        $entriesB = collect($shiftBData['angeltypes'])->sortBy('angeltype.id');
+        $entriesB = collect($shiftBData['needed_angel_types'])->sortBy('angeltype.id');
         $this->assertCount(0, $entriesB[0]['entries']);
     }
 
@@ -110,7 +110,7 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertCount(5, $data['data']);
 
         $shift = $data['data'][0];
-        $this->assertTrue(count($shift['angeltypes']) >= 1);
+        $this->assertTrue(count($shift['needed_angel_types']) >= 1);
     }
 
     /**
@@ -137,7 +137,7 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertCount(1, $data['data']);
 
         $shift = $data['data'][0];
-        $this->assertTrue(count($shift['angeltypes']) >= 1);
+        $this->assertTrue(count($shift['needed_angel_types']) >= 1);
     }
 
     /**
@@ -164,7 +164,7 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertCount(1, $data['data']);
 
         $shift = $data['data'][0];
-        $this->assertTrue(count($shift['angeltypes']) >= 1);
+        $this->assertTrue(count($shift['needed_angel_types']) >= 1);
     }
 
     /**

--- a/tests/Unit/Controllers/Api/ShiftsControllerTest.php
+++ b/tests/Unit/Controllers/Api/ShiftsControllerTest.php
@@ -33,7 +33,6 @@ class ShiftsControllerTest extends ApiBaseControllerTest
      * @covers \Engelsystem\Controllers\Api\Resources\ShiftResource::toArray
      * @covers \Engelsystem\Controllers\Api\Resources\ShiftTypeResource::toArray
      * @covers \Engelsystem\Controllers\Api\Resources\ShiftWithEntriesResource::toArray
-     * @covers \Engelsystem\Controllers\Api\Resources\UserResource::toArray
      * @covers \Engelsystem\Controllers\Api\ShiftsController::getNeededAngelTypes
      */
     public function testEntriesByLocation(): void
@@ -58,29 +57,29 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertEquals($this->shiftA->title, $shiftAData['name'], 'Title is equal');
         $this->assertEquals($this->location->id, $shiftAData['location']['id'], 'Same location');
         $this->assertEquals($this->shiftA->shiftType->id, $shiftAData['shift_type']['id'], 'Shift type equals');
-        $this->assertCount(4, $shiftAData['entries']);
+        $this->assertCount(4, $shiftAData['angeltypes']);
         // Has users
-        $entriesA = collect($shiftAData['entries'])->sortBy('type.id');
+        $entriesA = collect($shiftAData['angeltypes'])->sortBy('angeltype.id');
         $entry = $entriesA[0];
-        $this->assertCount(2, $entry['users']);
+        $this->assertCount(2, $entry['entries']);
         $this->assertEquals(2, $entry['needs']);
-        $user = $entry['users'][0];
+        $user = $entry['entries'][0]['user'];
         $this->assertArrayHasKey('id', $user);
         $this->assertArrayHasKey('name', $user);
         $this->assertArrayNotHasKey('email', $user);
-        $this->assertCount(0, $entriesA[1]['users']);
-        $this->assertCount(1, $entriesA[2]['users']);
-        $this->assertCount(1, $entriesA[3]['users']);
+        $this->assertCount(0, $entriesA[1]['entries']);
+        $this->assertCount(1, $entriesA[2]['entries']);
+        $this->assertCount(1, $entriesA[3]['entries']);
 
         // Second (empty) shift
         $shiftBData = $data['data'][1];
         $this->assertEquals($this->shiftB->title, $shiftBData['name'], 'Title is equal');
         $this->assertEquals($this->location->id, $shiftBData['location']['id'], 'Same location');
         $this->assertEquals($this->shiftB->shiftType->id, $shiftBData['shift_type']['id'], 'Shift type equals');
-        $this->assertCount(3, $shiftBData['entries']);
+        $this->assertCount(3, $shiftBData['angeltypes']);
         // No users
-        $entriesB = collect($shiftBData['entries'])->sortBy('type.id');
-        $this->assertCount(0, $entriesB[0]['users']);
+        $entriesB = collect($shiftBData['angeltypes'])->sortBy('angeltype.id');
+        $this->assertCount(0, $entriesB[0]['entries']);
     }
 
     /**
@@ -111,7 +110,7 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertCount(5, $data['data']);
 
         $shift = $data['data'][0];
-        $this->assertTrue(count($shift['entries']) >= 1);
+        $this->assertTrue(count($shift['angeltypes']) >= 1);
     }
 
     /**
@@ -138,7 +137,7 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertCount(1, $data['data']);
 
         $shift = $data['data'][0];
-        $this->assertTrue(count($shift['entries']) >= 1);
+        $this->assertTrue(count($shift['angeltypes']) >= 1);
     }
 
     /**
@@ -165,7 +164,7 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $this->assertCount(1, $data['data']);
 
         $shift = $data['data'][0];
-        $this->assertTrue(count($shift['entries']) >= 1);
+        $this->assertTrue(count($shift['angeltypes']) >= 1);
     }
 
     /**

--- a/tests/Unit/Controllers/Api/UsersControllerTest.php
+++ b/tests/Unit/Controllers/Api/UsersControllerTest.php
@@ -20,6 +20,7 @@ class UsersControllerTest extends ApiBaseControllerTest
     /**
      * @covers \Engelsystem\Controllers\Api\UsersController::user
      * @covers \Engelsystem\Controllers\Api\Resources\UserDetailResource::toArray
+     * @covers \Engelsystem\Controllers\Api\Resources\UserResource::toArray
      */
     public function testUser(): void
     {
@@ -50,7 +51,11 @@ class UsersControllerTest extends ApiBaseControllerTest
         $this->assertArrayHasKey('data', $data);
         $this->assertArrayHasKey('id', $data['data']);
         $this->assertEquals($user->id, $data['data']['id']);
+        $this->assertArrayHasKey('name', $data['data']);
+        $this->assertEquals($user->name, $data['data']['name']);
+        $this->assertArrayHasKey('email', $data['data']);
         $this->assertArrayHasKey('dates', $data['data']);
+        $this->assertArrayHasKey('contact', $data['data']);
     }
 
     /**


### PR DESCRIPTION
* Use references in shifts list instead of always returning full data sets (**breaking** change in beta API)
  This change is definitely needed to improve the file size for example for room shift endpoints as they are currently too big with tons of redundant datasets
* Group entries by angeltypes to show additional states like freeloaded (**breaking** response structure change)
* Renamed users `tshirt` to `tshirt_size` (**breaking** response structure)
* Added shift types endpoints (list and shifts by shift type) to retrieve them
* Added description to location
* Fixed model nullable, casts and default values
* Improved api tests error messages when response does not match the spec