### PR TITLE
Fix autofill, profile page, worklog edit, translations and others

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,6 +239,7 @@ test:
       --coverage-text --coverage-html "${HOMEDIR}/coverage/"
       --log-junit "${HOMEDIR}/unittests.xml"
   after_script:
+    - sed -i 's~/var/www/~~' unittests.xml
     - '"${DOCROOT}/bin/migrate" down'
 
 dump-database:

--- a/includes/controller/angeltypes_controller.php
+++ b/includes/controller/angeltypes_controller.php
@@ -136,7 +136,7 @@ function angeltype_edit_controller()
         if ($valid) {
             $angeltype->save();
 
-            success('Angel type saved.');
+            success(__('Angel type saved.'));
             engelsystem_log(
                 'Saved angeltype: ' . $angeltype->name . ($angeltype->restricted ? ', restricted' : '')
                 . ($angeltype->shift_self_signup ? ', shift_self_signup' : '')

--- a/includes/pages/admin_shifts.php
+++ b/includes/pages/admin_shifts.php
@@ -455,7 +455,7 @@ function admin_shifts()
             );
         }
 
-        success('Shifts created.');
+        success(__('Shifts created.'));
         throw_redirect(url('/admin-shifts'));
     } else {
         $session->remove('admin_shifts_shifts');

--- a/includes/view/Locations_view.php
+++ b/includes/view/Locations_view.php
@@ -56,7 +56,7 @@ function location_view(Location $location, ShiftsFilterRenderer $shiftsFilterRen
     if ($location->map_url) {
         $tabs[__('location.map_url')] = sprintf(
             '<div class="map">'
-            . '<iframe style="width: 100%%; min-height: 400px; border: 0 none;" src="%s"></iframe>'
+            . '<iframe style="width: 100%%; min-height: 75vh; border: 0 none;" src="%s"></iframe>'
             . '</div>',
             htmlspecialchars($location->map_url)
         );

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -803,8 +803,8 @@ function User_view_state_admin($freeloader, $user_source)
     $goodie = GoodieType::from(config('goodie_type'));
     $goodie_enabled = $goodie !== GoodieType::None;
     $goodie_tshirt = $goodie === GoodieType::Tshirt;
-    $password_resets = PasswordReset::whereUserId($user_source->id)
-        ->where('created_at', '>', $user_source->last_login_at)
+    $password_reset = PasswordReset::whereUserId($user_source->id)
+        ->where('created_at', '>', $user_source->last_login_at ?: '')
         ->count();
 
     if ($freeloader) {
@@ -856,8 +856,8 @@ function User_view_state_admin($freeloader, $user_source)
         }
     }
 
-    if ($password_resets > 0) {
-        $state[] = __('Password reset');
+    if ($password_reset) {
+        $state[] = __('Password reset in progress');
     }
 
     return $state;

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -177,6 +177,9 @@ msgstr "Lösche Engeltyp %s"
 msgid "Please check the name. Maybe it already exists."
 msgstr "Bitte überprüfe den Namen. Vielleicht ist er bereits vergeben."
 
+msgid "Angel type saved."
+msgstr "Engeltyp wurde gespeichert."
+
 msgid "Create angeltype"
 msgstr "Engeltyp erstellen"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -2128,8 +2128,8 @@ msgid "shift.sign_out.hint"
 msgstr "Du kannst dich bis %s Stunden vor dem Start der Schicht austragen. "
 "Wenn du nicht zu deiner Schicht kommen kannst, lass dich vom Himmel austragen."
 
-msgid "Password reset"
-msgstr "Passwort zurücksetzen"
+msgid "Password reset in progress"
+msgstr "Passwort zurücksetzen aktiv"
 
 msgid "freeload.info.goodie"
 msgstr "Du warst bei dieser Schicht nicht anwesend. "

--- a/resources/views/admin/user/delete-worklog.twig
+++ b/resources/views/admin/user/delete-worklog.twig
@@ -11,9 +11,9 @@
             {{ csrf() }}
             <div class="row">
                 <div class="col-md-12">
-                    {{ m.alert(__('worklog.delete.info', [m.user(user)]), 'danger', true) }}
+                    {{ m.alert(__('worklog.delete.info', [m.user(userdata)]), 'danger', true) }}
                     {{ m.button(__('form.cancel'),
-                        url('/users?action=view&user_id=' ~ user.id),
+                        url('/users?action=view&user_id=' ~ userdata.id),
                         null,
                         null,
                         null,

--- a/resources/views/admin/user/edit-worklog.twig
+++ b/resources/views/admin/user/edit-worklog.twig
@@ -7,7 +7,7 @@
 {% block content %}
     <div class="container">
         <h1>
-            {{ m.button(m.icon('chevron-left'), url('/users', {action: 'view', user_id: user.id}),
+            {{ m.button(m.icon('chevron-left'), url('/users', {action: 'view', user_id: userdata.id}),
                 null, 'sm', __('general.back')) }}
             {{ block('title') }}
         </h1>
@@ -21,7 +21,7 @@
                     <div>
                         <label class="form-label">{{ __('general.user') }}</label>
                     </div>
-                    {{ m.user(user, {'pronoun': true}) }}
+                    {{ m.user(userdata, {'pronoun': true}) }}
                 </div>
                 <div class="col-12">
                     {{ f.input('work_date', __('worklog.date'), {

--- a/resources/views/pages/settings/profile.twig
+++ b/resources/views/pages/settings/profile.twig
@@ -19,14 +19,14 @@
         <div class="row g-4">
             <div class="col-lg-6">
                 {{ f.input('nick', __('general.nick'), {
-                    'value': user.name,
+                    'value': userdata.name,
                     'disabled': true,
                 }) }}
             </div>
             {% if config('enable_pronoun') %}
                 <div class="col-lg-6">
                     {{ f.input('pronoun', __('settings.profile.pronoun'), {
-                        'value': user.personalData.pronoun,
+                        'value': userdata.personalData.pronoun,
                         'max_length': 15,
                         'required': isPronounRequired,
                         'required_icon': isPronounRequired,
@@ -40,7 +40,7 @@
             <div class="row g-4">
                 <div class="col-sm-6">
                     {{ f.input('first_name', __('settings.profile.firstname'), {
-                        'value': user.personalData.first_name,
+                        'value': userdata.personalData.first_name,
                         'max_length': 64,
                         'required': isFirstnameRequired,
                         'required_icon': isFirstnameRequired,
@@ -48,7 +48,7 @@
                 </div>
                 <div class="col-sm-6">
                     {{ f.input('last_name', __('settings.profile.lastname'), {
-                        'value': user.personalData.last_name,
+                        'value': userdata.personalData.last_name,
                         'max_length': 64,
                         'required': isLastnameRequired,
                         'required_icon': isLastnameRequired,
@@ -60,7 +60,7 @@
         {% if config('enable_planned_arrival') %}
             <div class="row g-4">
                 <div class="col-sm-6">
-                    {% set planned_arrival_date = user.personalData.planned_arrival_date %}
+                    {% set planned_arrival_date = userdata.personalData.planned_arrival_date %}
                     {{ f.input('planned_arrival_date', __('settings.profile.planned_arrival_date'), {
                         'type': 'date',
                         'value': planned_arrival_date ? planned_arrival_date.format('Y-m-d') : '',
@@ -71,7 +71,7 @@
                     }) }}
                 </div>
                 <div class="col-sm-6">
-                    {% set planned_departure_date = user.personalData.planned_departure_date %}
+                    {% set planned_departure_date = userdata.personalData.planned_departure_date %}
                     {{ f.input('planned_departure_date', __('settings.profile.planned_departure_date'), {
                         'type': 'date',
                         'value': planned_departure_date ? planned_departure_date.format('Y-m-d') : '',
@@ -86,7 +86,7 @@
             {% if config('enable_dect') %}
                 <div class="col-md-6">
                     {{ f.input('dect', __('general.dect'), {
-                        'value': user.contact.dect,
+                        'value': userdata.contact.dect,
                         'max_length': 40,
                         'required': isDectRequired,
                         'required_icon': isDectRequired,
@@ -95,14 +95,14 @@
             {% endif %}
             <div class="col-md-6">
                 {{ f.input('mobile', __('settings.profile.mobile'), {
-                    'value': user.contact.mobile,
+                    'value': userdata.contact.mobile,
                     'max_length': 40,
                     'required': isMobileRequired,
                     'required_icon': isMobileRequired,
                 }) }}
                 {% if config('enable_mobile_show') %}
                     {{ f.checkbox('mobile_show', __('settings.profile.mobile_show'), {
-                        'checked': user.settings.mobile_show,
+                        'checked': userdata.settings.mobile_show,
                     }) }}
                 {% endif %}
             </div>
@@ -112,7 +112,7 @@
             <div class="col-md-6">
                 {{ f.input('email', __('general.email'), {
                     'type': 'email',
-                    'value': user.email,
+                    'value': userdata.email,
                     'max_length': 254,
                     'required': true,
                     'required_icon': true,
@@ -122,16 +122,16 @@
             <div class="col-md-6">
                 <label class="form-label">{{ __('settings.profile.email-preferences') }}</label>
                 {{ f.checkbox('email_shiftinfo', __('settings.profile.email_shiftinfo', [config('app_name')]), {
-                    'checked': user.settings.email_shiftinfo,
+                    'checked': userdata.settings.email_shiftinfo,
                 }) }}
                 {{ f.checkbox('email_news', __('settings.profile.email_news'), {
-                    'checked': user.settings.email_news,
+                    'checked': userdata.settings.email_news,
                 }) }}
                 {{ f.checkbox('email_messages', __('settings.profile.email_messages'), {
-                    'checked': user.settings.email_messages,
+                    'checked': userdata.settings.email_messages,
                 }) }}
                 {{ f.checkbox('email_human', __('settings.profile.email_by_human_allowed'), {
-                    'checked': user.settings.email_human,
+                    'checked': userdata.settings.email_human,
                 }) }}
                 {% if goodie_enabled %}
                     {% set privacy_email = config('privacy_email') %}
@@ -139,7 +139,7 @@
                         (privacy_email ? ' ' ~ __('settings.profile.privacy', [privacy_email]) : '')
                     %}
                     {{ f.checkbox('email_goody', email_goody_label, {
-                        'checked': user.settings.email_goody,
+                        'checked': userdata.settings.email_goody,
                         'raw_label': true,
                     }) }}
                 {% endif %}
@@ -150,11 +150,11 @@
             {% if goodie_tshirt %}
                 <div class="col-12">
                     {{ f.select('shirt_size', __('settings.profile.shirt_size'), config('tshirt_sizes'), {
-                        'selected': user.personalData.shirt_size,
+                        'selected': userdata.personalData.shirt_size,
                         'required': isTShirtSizeRequired,
                         'required_icon': isTShirtSizeRequired,
                         'default_option': __('form.select_placeholder'),
-                        'disabled': user.state.got_shirt,
+                        'disabled': userdata.state.got_shirt,
                         'info': __('settings.profile.shirt_size.hint'),
                         'raw_form_text': true,
                         'form_text': (tShirtLink ? m.icon('info-circle')

--- a/src/Controllers/Admin/UserWorkLogController.php
+++ b/src/Controllers/Admin/UserWorkLogController.php
@@ -115,7 +115,7 @@ class UserWorkLogController extends BaseController
 
         return $this->response->withView(
             'admin/user/delete-worklog.twig',
-            ['user' => $user]
+            ['userdata' => $user]
         );
     }
 
@@ -157,7 +157,7 @@ class UserWorkLogController extends BaseController
         return $this->response->withView(
             'admin/user/edit-worklog.twig',
             [
-                'user' => $user,
+                'userdata' => $user,
                 'work_date' => $work_date,
                 'work_hours' => $work_hours,
                 'comment' => $comment,

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -309,8 +309,8 @@ class OAuthController extends BaseController
 
         $this->session->set('form-data-username', $userdata->get($config['username']));
         $this->session->set('form-data-email', $userdata->get($config['email']));
-        $this->session->set('form-data-first_name', $userdata->get($config['first_name']));
-        $this->session->set('form-data-last_name', $userdata->get($config['last_name']));
+        $this->session->set('form-data-firstname', $userdata->get($config['first_name']));
+        $this->session->set('form-data-lastname', $userdata->get($config['last_name']));
 
         $this->session->set('oauth2_groups', $userdata->get($config['groups'], []));
         $this->session->set('oauth2_connect_provider', $providerName);

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -45,7 +45,7 @@ class SettingsController extends BaseController
             'pages/settings/profile',
             [
                 'settings_menu' => $this->settingsMenu(),
-                'user' => $user,
+                'userdata' => $user,
                 'goodie_enabled' => $this->config->get('goodie_type') !== GoodieType::None->value,
                 'goodie_tshirt' => $this->config->get('goodie_type') === GoodieType::Tshirt->value,
                 'tShirtLink' => $this->config->get('tshirt_link'),

--- a/tests/Unit/Controllers/Admin/UserWorkLogControllerTest.php
+++ b/tests/Unit/Controllers/Admin/UserWorkLogControllerTest.php
@@ -50,7 +50,7 @@ class UserWorkLogControllerTest extends ControllerTest
             ->method('withView')
             ->willReturnCallback(function (string $view, array $data) {
                 $this->assertEquals('admin/user/edit-worklog.twig', $view);
-                $this->assertEquals($this->user->id, $data['user']->id);
+                $this->assertEquals($this->user->id, $data['userdata']->id);
                 $this->assertEquals(Carbon::today(), $data['work_date']);
                 $this->assertEquals(0, $data['work_hours']);
                 $this->assertEquals('', $data['comment']);
@@ -96,7 +96,7 @@ class UserWorkLogControllerTest extends ControllerTest
         $this->response->expects($this->once())
             ->method('withView')
             ->willReturnCallback(function (string $view, array $data) {
-                $this->assertEquals($this->user->id, $data['user']->id);
+                $this->assertEquals($this->user->id, $data['userdata']->id);
                 $this->assertEquals(new Carbon('2022-01-01'), $data['work_date']);
                 $this->assertEquals(3.14, $data['work_hours']);
                 $this->assertEquals('a comment', $data['comment']);
@@ -252,7 +252,7 @@ class UserWorkLogControllerTest extends ControllerTest
         $this->response->expects($this->once())
             ->method('withView')
             ->willReturnCallback(function (string $view, array $data) {
-                $this->assertEquals($this->user->id, $data['user']->id);
+                $this->assertEquals($this->user->id, $data['userdata']->id);
                 return $this->response;
             });
         $this->controller->showDeleteWorklog($request);

--- a/tests/Unit/Controllers/OAuthControllerTest.php
+++ b/tests/Unit/Controllers/OAuthControllerTest.php
@@ -461,8 +461,8 @@ class OAuthControllerTest extends TestCase
         $this->assertEquals(null, $this->session->get('oauth2_allow_registration'));
         $this->assertEquals($this->session->get('form-data-username'), 'username');
         $this->assertEquals($this->session->get('form-data-email'), 'foo.bar@localhost');
-        $this->assertEquals($this->session->get('form-data-first_name'), 'Foo');
-        $this->assertEquals($this->session->get('form-data-last_name'), 'Bar');
+        $this->assertEquals($this->session->get('form-data-firstname'), 'Foo');
+        $this->assertEquals($this->session->get('form-data-lastname'), 'Bar');
 
         $this->config->set('registration_enabled', false);
         $this->expectException(HttpNotFound::class);
@@ -541,8 +541,8 @@ class OAuthControllerTest extends TestCase
         $controller->index($request);
         $this->assertEquals($this->session->get('form-data-username'), 'testuser');
         $this->assertEquals($this->session->get('form-data-email'), 'foo.bar@localhost');
-        $this->assertEquals($this->session->get('form-data-first_name'), 'Test');
-        $this->assertEquals($this->session->get('form-data-last_name'), 'Tester');
+        $this->assertEquals($this->session->get('form-data-firstname'), 'Test');
+        $this->assertEquals($this->session->get('form-data-lastname'), 'Tester');
     }
 
 

--- a/tests/Unit/Controllers/SettingsControllerTest.php
+++ b/tests/Unit/Controllers/SettingsControllerTest.php
@@ -96,8 +96,8 @@ class SettingsControllerTest extends ControllerTest
             ->method('withView')
             ->willReturnCallback(function ($view, $data) {
                 $this->assertEquals('pages/settings/profile', $view);
-                $this->assertArrayHasKey('user', $data);
-                $this->assertEquals($this->user, $data['user']);
+                $this->assertArrayHasKey('userdata', $data);
+                $this->assertEquals($this->user, $data['userdata']);
                 return $this->response;
             });
 


### PR DESCRIPTION
* Fix prefilling first and last name on registration page when logging in using oauth
* Show active password resets and fix query resulting in error when not logged in before
* Fix missing translations in confirmations
* Show higher maps on room page
* Fixes #1368: Wrong user name displayed on worklog edit / delete  page
* Fix CI to be able to directly link to covered files