### PR TITLE
make Docker instructions for Development easier to discover and skim

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,18 +41,20 @@ ln -s ../../bin/pre-commit .git/hooks/pre-commit
 
 ## Docker
 
-We suggest using Docker for the Development local build.
+> [!TIP]
+> We suggest using Docker for the Development local build.  
+> This repo [ships a docker setup](docker/dev) for a quick development start.  
+> If you use another uid/gid than 1000 on your machine you have to adjust it in [docker/dev/.env](docker/dev/.env).
 
-If unspecific issues appear try using Docker version >= 20.10.14.
 
-This repo [ships a docker setup](docker/dev) for a quick development start.
-
-If you use another uid/gid than 1000 on your machine you have to adjust it in [docker/dev/.env](docker/dev/.env).
-
-Run this once
+Make sure you're in the `docker/dev` subfolder: 
 
 ```bash
 cd docker/dev
+```
+
+Then, run
+```bash
 docker compose up
 ```
 
@@ -215,3 +217,11 @@ For some reason *PhpStorm* is unable to detect the server name.
 But without a server name it's impossible to set up path mappings.
 Because of that the docker setup sets the server name *engelsystem*.
 To get Xdebug working you have to create a server with the name *engelsystem* manually.
+
+## Troubleshooting
+
+### Docker version
+If unspecific issues appear try using Docker version >= 20.10.14.
+
+### `service "es_workspace" is not running`
+Make sure you're running your docker commands from the `docker/dev` directory, not from `docker`

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The Engelsystem can now be used.
  * Both Apache and Nginx allow for different VirtualHost configurations.
 
 ### Docker
+
+For instructions on how to build the Docker container for development, please consult the [DEVELOPMENT.md](DEVELOPMENT.md).
+
 #### Build
 To build the `es_server` container:
 ```bash


### PR DESCRIPTION
I had a hard time figuring out what I did 8 months ago to get my Engelsystem dev system up & running. This PR attempts to make the necessary information easier to find and adds a "Troubleshooting" section that would've helped me and may just help someone else in the future.