### PR TITLE
Smaller fixes and updates

### DIFF
--- a/includes/controller/shift_entries_controller.php
+++ b/includes/controller/shift_entries_controller.php
@@ -113,12 +113,15 @@ function shift_entry_create_controller_admin(Shift $shift, ?AngelType $angeltype
     }
 
     /** @var User[]|Collection $users */
-    $users = User::with('userAngelTypes')->orderBy('name')->get();
+    $users = User::with(['userAngelTypes', 'shiftEntries'])->orderBy('name')->get();
     $users_select = [];
     foreach ($users as $user) {
         $name = $user->displayName;
         if ($user->userAngelTypes->where('id', $angeltype->id)->isEmpty()) {
             $name = __('%s (not "%s")', [$name, $angeltype->name]);
+        }
+        if ($user->shiftEntries->where('shift_id', $shift->id)->isNotEmpty()) {
+            $name = __('%s (already in shift)', [$name]);
         }
         $users_select[$user->id] = $name;
     }

--- a/includes/controller/shifts_controller.php
+++ b/includes/controller/shifts_controller.php
@@ -107,14 +107,14 @@ function shift_edit_controller()
             error(__('Please select a shift type.'));
         }
 
-        if ($request->has('start') && $tmp = DateTime::createFromFormat('Y-m-d H:i', $request->input('start'))) {
+        if ($request->has('start') && $tmp = DateTime::createFromFormat('Y-m-d\TH:i', $request->input('start'))) {
             $start = $tmp;
         } else {
             $valid = false;
             error(__('Please enter a valid starting time for the shifts.'));
         }
 
-        if ($request->has('end') && $tmp = DateTime::createFromFormat('Y-m-d H:i', $request->input('end'))) {
+        if ($request->has('end') && $tmp = DateTime::createFromFormat('Y-m-d\TH:i', $request->input('end'))) {
             $end = $tmp;
         } else {
             $valid = false;
@@ -190,13 +190,16 @@ function shift_edit_controller()
 
     $angel_types_spinner = '';
     foreach ($angeltypes as $angeltype_id => $angeltype_name) {
-        $angel_types_spinner .= form_spinner(
-            'angeltype_count_' . $angeltype_id,
-            htmlspecialchars($angeltype_name),
-            $needed_angel_types[$angeltype_id],
-            [],
-            (bool) ScheduleShift::whereShiftId($shift->id)->first(),
-        );
+        $angel_types_spinner .=
+            '<div class="col-sm-6 col-md-8 col-lg-6 col-xl-4 col-xxl-3">'
+            . form_spinner(
+                'angeltype_count_' . $angeltype_id,
+                htmlspecialchars($angeltype_name),
+                $needed_angel_types[$angeltype_id],
+                [],
+                (bool) ScheduleShift::whereShiftId($shift->id)->first(),
+            )
+            . '</div>';
     }
 
     $link = button(url('/shifts', ['action' => 'view', 'shift_id' => $shift_id]), icon('chevron-left'), 'btn-sm', '', __('general.back'));
@@ -208,18 +211,38 @@ function shift_edit_controller()
             . info(__('This page is much more comfortable with javascript.'), true)
             . '</noscript>',
             form([
-                form_select('shifttype_id', __('Shift type'), $shifttypes, $shifttype_id),
-                form_text('title', __('title.title'), $title),
-                form_select('rid', __('Location:'), $locations, $rid),
-                form_text('start', __('Start:'), $start->format('Y-m-d H:i')),
-                form_text('end', __('End:'), $end->format('Y-m-d H:i')),
-                form_textarea('description', __('Additional description'), $description),
-                form_info(
-                    '',
-                    __('This description is for single shifts, otherwise please use the description in shift type.')
-                ),
-                '<h2>' . __('Needed angels') . '</h2>',
-                $angel_types_spinner,
+                div('row', [
+                    div('col-md-6 col-xl-5', [
+                        form_select('shifttype_id', __('Shift type'), $shifttypes, $shifttype_id),
+                        form_text('title', __('title.title'), $title),
+                        form_select('rid', __('Location'), $locations, $rid),
+                    ]),
+                    div('col-md-6 col-xl-7', [
+                        form_textarea('description', __('Additional description'), $description),
+                        form_info(
+                            '',
+                            __('This description is for single shifts, otherwise please use the description in shift type.')
+                        ),
+                    ]),
+                ]),
+                div('row', [
+                    div('col-md-6 col-xl-5', [
+                        div('row', [
+                            div('col-lg-6', [
+                                form_datetime('start', __('shifts.start'), $start),
+                            ]),
+                            div('col-lg-6', [
+                                form_datetime('end', __('shifts.end'), $end),
+                            ]),
+                        ]),
+                    ]),
+                    div('col-md-6 col-xl-7', [
+                        '<h4>' . __('Needed angels') . '</h4>',
+                        div('row', [
+                            $angel_types_spinner,
+                        ]),
+                    ]),
+                ]),
                 form_submit('submit', icon('save') . __('form.save')),
             ]),
         ]

--- a/includes/controller/user_angeltypes_controller.php
+++ b/includes/controller/user_angeltypes_controller.php
@@ -367,7 +367,20 @@ function user_angeltype_add_controller(): array
             ));
             success(sprintf(__('User %s added to %s.'), $user_source->displayName, $angeltype->name));
 
-            if ($request->hasPostData('auto_confirm_user')) {
+            $setSupporter = $request->hasPostData('set_supporter')
+                && (auth()->can('admin_angel_types') || config('supporters_can_promote'));
+            if ($setSupporter) {
+                $userAngelType->supporter = true;
+                $userAngelType->save();
+
+                engelsystem_log(sprintf(
+                    'User %s set as supporter for %s.',
+                    User_Nick_render($user_source, true),
+                    AngelType_name_render($angeltype, true)
+                ));
+            }
+
+            if ($request->hasPostData('auto_confirm_user') || $setSupporter) {
                 $userAngelType->confirmUser()->associate($user_source);
                 $userAngelType->save();
 

--- a/includes/pages/admin_shifts.php
+++ b/includes/pages/admin_shifts.php
@@ -76,13 +76,13 @@ function admin_shifts()
             error(__('Please select a shift type.'));
         }
 
-        // Name/Bezeichnung der Schicht, darf leer sein
+        // Name/designation of the shift, may be empty
         $title = substr(strip_request_item('title'), 0, 255);
 
-        // Beschreibung der Schicht, darf leer sein
+        // Description of the shift, may be empty
         $description = strip_request_item_nl('description');
 
-        // Auswahl der sichtbaren Locations für die Schichten
+        // Selection of the visible locations for the layers
         if (
             $request->has('lid')
             && preg_match('/^\d+$/', $request->input('lid'))
@@ -138,7 +138,7 @@ function admin_shifts()
                         'trim',
                         explode(',', $request->input('change_hours'))
                     );
-                    // Fehlende Minutenangaben ergänzen, 24 Uhr -> 00 Uhr
+                    // Add missing minutes, 24:00 -> 00:00
                     array_walk($change_hours, function (&$value) use ($valid) {
                         // Add minutes
                         if (!preg_match('/^(\d{1,2}):\d{2}$/', $value)) {
@@ -209,12 +209,12 @@ function admin_shifts()
             error(__('Please select needed angels.'));
         }
 
-        // Beim Zurück-Knopf das Formular zeigen
+        // Show the form when you press the back button
         if ($request->has('back')) {
             $valid = false;
         }
 
-        // Alle Eingaben in Ordnung
+        // All entries OK
         if ($valid) {
             if ($angelmode == 'shift_type') {
                 $needed_angel_types = NeededAngelType::whereShiftTypeId($shifttype_id)

--- a/includes/view/AngelTypes_view.php
+++ b/includes/view/AngelTypes_view.php
@@ -130,60 +130,69 @@ function AngelType_edit_view(AngelType $angeltype, bool $supporter_mode)
                 ]) : '',
             msg(),
             form([
-                $supporter_mode
-                    ? form_info(__('general.name'), htmlspecialchars($angeltype->name))
-                    : form_text('name', __('general.name'), $angeltype->name, false, 255),
-                $supporter_mode
-                    ? form_info(__('angeltypes.restricted'), $angeltype->restricted ? __('Yes') : __('No'))
-                    : form_checkbox(
-                        'restricted',
-                        __('angeltypes.restricted') .
-                        ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
-                        __('angeltypes.restricted.info') . '"></span>',
-                        $angeltype->restricted
-                    ),
-                $supporter_mode
-                    ? form_info(__('shift.self_signup'), $angeltype->shift_self_signup ? __('Yes') : __('No'))
-                    : form_checkbox(
-                        'shift_self_signup',
-                        __('shift.self_signup') .
-                        ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
-                        __('angeltypes.shift.self_signup.info') . '"></span>',
-                        $angeltype->shift_self_signup
-                    ),
-                $requires_driving_license,
-                $requires_ifsg,
-                $supporter_mode
-                    ? form_info(__('Show on dashboard'), $angeltype->show_on_dashboard ? __('Yes') : __('No'))
-                    : form_checkbox('show_on_dashboard', __('Show on dashboard'), $angeltype->show_on_dashboard),
-                $supporter_mode
-                    ? form_info(__('Hide at Registration'), $angeltype->hide_register ? __('Yes') : __('No'))
-                    : form_checkbox('hide_register', __('Hide at Registration'), $angeltype->hide_register),
-                $supporter_mode
-                    ? form_info(
-                        __('angeltypes.hide_on_shift_view'),
-                        $angeltype->hide_on_shift_view ? __('Yes') : __('No')
-                    )
-                    : form_checkbox(
-                        'hide_on_shift_view',
-                        __('angeltypes.hide_on_shift_view') .
-                        ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
-                        __('angeltypes.hide_on_shift_view.info') . '"></span>',
-                        $angeltype->hide_on_shift_view
-                    ),
-                form_textarea('description', __('general.description'), $angeltype->description),
-                form_info('', __('Please use markdown for the description.')),
-                heading(__('Contact'), 3),
-                form_info(
-                    '',
-                    __('Primary contact person/desk for user questions.')
-                ),
-                form_text('contact_name', __('general.name'), $angeltype->contact_name),
-                config('enable_dect') ? form_text('contact_dect', __('general.dect'), $angeltype->contact_dect) : '',
-                form_text('contact_email', __('general.email'), $angeltype->contact_email),
+                div('row', [
+                    div('col-md-9', [
+                        $supporter_mode
+                            ? form_info(__('general.name'), htmlspecialchars($angeltype->name))
+                            : form_text('name', __('general.name'), $angeltype->name, false, 255),
+                        form_textarea('description', __('general.description'), $angeltype->description),
+                        form_info('', __('Please use markdown for the description.')),
+                        heading(__('Contact'), 3),
+                        form_info(
+                            '',
+                            __('Primary contact person/desk for user questions.')
+                        ),
+                        form_text('contact_name', __('general.name'), $angeltype->contact_name),
+                        config('enable_dect') ? form_text('contact_dect', __('general.dect'), $angeltype->contact_dect) : '',
+                        form_text('contact_email', __('general.email'), $angeltype->contact_email),
+                    ]),
+
+                    div('col-md-3', [
+                        heading(__('State'), 3),
+                        $supporter_mode
+                            ? form_info(__('angeltypes.restricted'), $angeltype->restricted ? __('Yes') : __('No'))
+                            : form_checkbox(
+                                'restricted',
+                                __('angeltypes.restricted') .
+                                ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
+                                __('angeltypes.restricted.info') . '"></span>',
+                                $angeltype->restricted
+                            ),
+                        $supporter_mode
+                            ? form_info(__('shift.self_signup'), $angeltype->shift_self_signup ? __('Yes') : __('No'))
+                            : form_checkbox(
+                                'shift_self_signup',
+                                __('shift.self_signup') .
+                                ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
+                                __('angeltypes.shift.self_signup.info') . '"></span>',
+                                $angeltype->shift_self_signup
+                            ),
+                        $requires_driving_license,
+                        $requires_ifsg,
+                        $supporter_mode
+                            ? form_info(__('Show on dashboard'), $angeltype->show_on_dashboard ? __('Yes') : __('No'))
+                            : form_checkbox('show_on_dashboard', __('Show on dashboard'), $angeltype->show_on_dashboard),
+                        $supporter_mode
+                            ? form_info(__('Hide at Registration'), $angeltype->hide_register ? __('Yes') : __('No'))
+                            : form_checkbox('hide_register', __('Hide at Registration'), $angeltype->hide_register),
+                        $supporter_mode
+                            ? form_info(
+                                __('angeltypes.hide_on_shift_view'),
+                                $angeltype->hide_on_shift_view ? __('Yes') : __('No')
+                            )
+                            : form_checkbox(
+                                'hide_on_shift_view',
+                                __('angeltypes.hide_on_shift_view') .
+                                ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
+                                __('angeltypes.hide_on_shift_view.info') . '"></span>',
+                                $angeltype->hide_on_shift_view
+                            ),
+                    ]),
+                ]),
                 form_submit('submit', icon('save') . __('form.save')),
             ]),
-        ]
+        ],
+        true
     );
 }
 

--- a/includes/view/UserAngelTypes_view.php
+++ b/includes/view/UserAngelTypes_view.php
@@ -151,6 +151,9 @@ function UserAngelType_add_view(AngelType $angeltype, $users_select, $user_id)
             $angeltype->restricted
                 ? form_checkbox('auto_confirm_user', __('Confirm user'), true)
                 : '',
+            auth()->can('admin_angel_types') || config('supporters_can_promote')
+                ? form_checkbox('set_supporter', __('Supporter'), false)
+                : '',
             form_select('user_id', __('general.user'), $users_select, $user_id),
             form_submit('submit', icon('plus-lg') . __('general.add')),
         ]),

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1914,7 +1914,8 @@ msgid "angeltypes.about"
 msgstr "Teams-/Aufgabenbeschreibung"
 
 msgid "angeltypes.about.text"
-msgstr "Hier findest Du die Liste der Teams und ihrer Aufgaben. Wenn Du weitere Fragen hast, schaue in den FAQ nach."
+msgstr "Hier findest Du die Liste der Teams und ihrer Aufgaben. Wenn Du weitere Fragen hast, "
+"schaue in den <a href=\"%s\">FAQ</a> nach."
 
 msgid "angeltypes.restricted.hint"
 msgstr "Dieser Engeltyp benötigt eine Einweisung bei einem Einführungstreffen. "

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -282,12 +282,6 @@ msgstr "Titel"
 msgid "Location:"
 msgstr "Ort:"
 
-msgid "Start:"
-msgstr "Start:"
-
-msgid "End:"
-msgstr "Ende:"
-
 msgid "Needed angels"
 msgstr "Benötigte Engel"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -974,7 +974,7 @@ msgid "ended"
 msgstr "vorbei"
 
 msgid "please arrive for signup"
-msgstr "Ankommen zum Eintragen"
+msgstr "Komme an um dich einzutragen"
 
 msgid "not yet possible"
 msgstr "noch nicht möglich"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -54,7 +54,7 @@ msgid "page.419.title"
 msgstr "Autorisierung ist abgelaufen"
 
 msgid "page.419.text"
-msgstr "Das angegebene CSRF Token ist ungültig oder abgelaufen"
+msgstr "Das angegebene CSRF Token ist ungültig oder abgelaufen. Bitte versuche es erneut."
 
 msgid "general.date"
 msgstr "d.m.Y"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -192,6 +192,9 @@ msgstr "Team %s"
 msgid "%s (not \"%s\")"
 msgstr "%s (kein \"%s\")"
 
+msgid "%s (already in shift)"
+msgstr "%s (bereits eingetragen)"
+
 msgid "form.view"
 msgstr "Ansehen"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1987,6 +1987,11 @@ msgstr "Eventdaten"
 msgid "registration.what_todo"
 msgstr "Was möchtest Du machen?"
 
+msgid "registration.jobs"
+msgstr ""
+"Weitere Informationen wie Du uns helfen kannst findest du in der "
+"<a href=\"%s\" target=\"_blank\">Teams-/Aufgabenbeschreibung</a>."
+
 msgid "registration.register"
 msgstr "Registrieren"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -527,6 +527,9 @@ msgstr "T-Shirt Statistik"
 msgid "Given T-shirts"
 msgstr "Ausgegebene T-Shirts"
 
+msgid "Configured T-shirts"
+msgstr "Konfigurierte T-Shirts"
+
 msgid "Arrive angels"
 msgstr "Ankommende Engel"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -738,9 +738,6 @@ msgid "angeltypes.hide_on_shift_view.info"
 msgstr "If checked only admins and members of the angel type "
 "can see the filter option for this angel type on the shifts page"
 
-msgid "registration.register"
-msgstr "Register"
-
 msgid "location.location"
 msgstr "Location"
 
@@ -803,6 +800,13 @@ msgstr "Event data"
 
 msgid "registration.what_todo"
 msgstr "What do you want to do?"
+
+msgid "registration.jobs"
+msgstr "You can find more information about how to help us in the "
+"<a href=\"%s\" target=\"_blank\">Teams-/Job description</a>."
+
+msgid "registration.register"
+msgstr "Register"
 
 msgid "tshirt.required.hint"
 msgstr "Please specify a T-shirt size in your settings!"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -705,7 +705,8 @@ msgid "angeltypes.about"
 msgstr "Teams-/Job description"
 
 msgid "angeltypes.about.text"
-msgstr "Here you can find the list of teams and their tasks. If you have further questions, have a look at the FAQ."
+msgstr "Here you can find the list of teams and their tasks. If you have further questions, "
+"have a look at the <a href=\"%s\">FAQ</a>."
 
 msgid "angeltypes.restricted"
 msgstr "Requires introduction"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -73,7 +73,7 @@ msgid "page.419.title"
 msgstr "Authentication expired"
 
 msgid "page.419.text"
-msgstr "The provided CSRF token is invalid or has expired"
+msgstr "The provided CSRF token is invalid or has expired. Please try again."
 
 msgid "credits.credit"
 msgstr ""

--- a/resources/views/admin/locations/edit.twig
+++ b/resources/views/admin/locations/edit.twig
@@ -25,6 +25,7 @@
                     'type': 'url',
                     'value': f.formData('map_url', location ? location.map_url : ''),
                     'info': __('location.map_url.info'),
+                    'max_length': 300,
                 }) }}
 
                 {{ f.textarea('description', __('general.description'), {

--- a/resources/views/admin/schedule/edit.twig
+++ b/resources/views/admin/schedule/edit.twig
@@ -23,32 +23,32 @@
             <div class="col-md-6">
                 {{ f.input('name', __('schedule.name'), {
                     'required': true,
-                    'value': schedule.name,
+                    'value': f.formData('name', schedule.name),
                     'max_length': 255,
                 }) }}
                 {{ f.input('url', __('schedule.url'), {
                     'type': 'url',
                     'required': true,
-                    'value': schedule.url
+                    'value': f.formData('url', schedule.url)
                 }) }}
 
                 {{ f.select('shift_type', __('schedule.shift-type'), shift_types|default([]), {
-                    'selected': schedule.shift_type,
+                    'selected': f.formData('shift_type', schedule.shift_type) ~ '',
                 }) }}
 
                 {{ f.checkbox('needed_from_shift_type', __('schedule.needed-from-shift-type'), {
-                    'checked': schedule.needed_from_shift_type,
+                    'checked': f.formData('needed_from_shift_type', schedule.needed_from_shift_type),
                 }) }}
 
                 {{ f.input('minutes_before', __('schedule.minutes-before'), {
                     'type': 'number',
                     'required': true,
-                    'value': schedule.id ? schedule.minutes_before : 15
+                    'value': f.formData('minutes_before', schedule.id ? schedule.minutes_before : 15)
                 }) }}
                 {{ f.input('minutes_after', __('schedule.minutes-after'), {
                     'type': 'number',
                     'required': true,
-                    'value': schedule.id ? schedule.minutes_after : 15
+                    'value': f.formData('minutes_after', schedule.id ? schedule.minutes_after : 15)
                 }) }}
 
                 {{ f.save(__('form.save')) }}
@@ -68,7 +68,7 @@
                             {{ f.checkbox(
                                 'location_' ~ id,
                                 name,
-                                {'checked': schedule.id and id in schedule.activeLocations.pluck('id')}
+                                {'checked': f.formData('location_' ~ id, id in schedule.activeLocations.pluck('id'))}
                             ) }}
                         </div>
                     {% endfor %}

--- a/resources/views/pages/angeltypes/about.twig
+++ b/resources/views/pages/angeltypes/about.twig
@@ -39,7 +39,7 @@
         </div>
 
         <div class="col-md-12">
-            <p>{{ __('angeltypes.about.text') }}</p>
+            <p>{{ __('angeltypes.about.text', [url('/faq')])|raw }}</p>
         </div>
 
         <div class="row">

--- a/resources/views/pages/registration.twig
+++ b/resources/views/pages/registration.twig
@@ -274,6 +274,9 @@
 
         <div class="mb-5">
             <h2>{{ __('registration.what_todo') }}</h2>
+            <div class="row">
+                <p>{{ __('registration.jobs', [url('/angeltypes/about')])|raw }}</p>
+            </div>
             <div class="row mb-3">
                 {% for angelType in angelTypes %}
                     <div class="col-sm-6 col-md-4 col-lg-3 col-xl-2">

--- a/resources/views/pages/settings/oauth.twig
+++ b/resources/views/pages/settings/oauth.twig
@@ -20,7 +20,7 @@
     </thead>
     <tbody>
     {% for name,config in providers %}
-        <tr{% if config.hidden|default(false) %} class="d-none"{% endif %}>
+        <tr{% if config.hidden|default(false) and not user.oauth.contains('provider', name) %} class="d-none"{% endif %}>
             <td>
                 {% if config.url|default %}
                     <a href="{{ config.url }}" target="_blank" rel="noopener">

--- a/src/Controllers/Admin/LocationsController.php
+++ b/src/Controllers/Admin/LocationsController.php
@@ -85,7 +85,7 @@ class LocationsController extends BaseController
                 'name'        => 'required|max:35',
                 'description' => 'optional',
                 'dect'        => 'optional',
-                'map_url'     => 'optional|url',
+                'map_url'     => 'optional|url|max:300',
             ] + $validation
         );
 

--- a/src/Controllers/Metrics/Stats.php
+++ b/src/Controllers/Metrics/Stats.php
@@ -216,8 +216,8 @@ class Stats
 
         if (!is_null($freeloaded)) {
             $freeloaded
-                ? $query->whereNull('freeloaded_by')
-                : $query->whereNotNull('freeloaded_by');
+                ? $query->whereNotNull('freeloaded_by')
+                : $query->whereNull('freeloaded_by');
         }
 
         if (!is_null($done)) {

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -423,8 +423,9 @@ class SettingsController extends BaseController
 
     protected function checkOauthHidden(): bool
     {
-        foreach (config('oauth') as $config) {
-            if (empty($config['hidden'])) {
+        $userServices = $this->auth->user()->oauth;
+        foreach (config('oauth') as $name => $config) {
+            if (empty($config['hidden']) || $userServices->contains('provider', $name)) {
                 return false;
             }
         }

--- a/src/Models/AngelType.php
+++ b/src/Models/AngelType.php
@@ -57,7 +57,7 @@ class AngelType extends BaseModel
         'contact_name'              => '',
         'contact_dect'              => '',
         'contact_email'             => '',
-        'restricted'                => false,
+        'restricted'                => true,
         'requires_driver_license'   => false,
         'requires_ifsg_certificate' => false,
         'shift_self_signup'         => true,

--- a/tests/Feature/Controllers/RegistrationControllerTest.php
+++ b/tests/Feature/Controllers/RegistrationControllerTest.php
@@ -213,6 +213,7 @@ final class RegistrationControllerTest extends ApplicationFeatureTest
     {
         $angelType1 = AngelType::create([
             'name' => 'Test angel type 1',
+            'restricted' => false,
         ]);
 
         $angelType2 = AngelType::create([
@@ -228,6 +229,7 @@ final class RegistrationControllerTest extends ApplicationFeatureTest
         $angelType4 = AngelType::create([
             'name' => 'Test angel type 4',
             'hide_register' => true,
+            'restricted' => false,
         ]);
 
         $this->modelsToBeDeleted[] = $angelType1;

--- a/tests/Unit/Controllers/Api/ShiftsControllerTest.php
+++ b/tests/Unit/Controllers/Api/ShiftsControllerTest.php
@@ -279,16 +279,18 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         ShiftEntry::factory(2)->create([
             'shift_id' => $this->shiftB->id,
             'angel_type_id' => $byLocation->angel_type_id,
+            'freeloaded_by' => null,
         ]);
 
         // By shift type via schedule
         ShiftEntry::factory(3)->create([
             'shift_id' => $this->shiftC->id,
             'angel_type_id' => $byShiftType->angel_type_id,
+            'freeloaded_by' => null,
         ]);
 
         // Additional (not required by shift nor location)
-        ShiftEntry::factory(5)->create(['shift_id' => $this->shiftA->id]);
+        ShiftEntry::factory(5)->create(['shift_id' => $this->shiftA->id, 'freeloaded_by' => null]);
 
         foreach (User::all() as $user) {
             // Generate user data

--- a/tests/Unit/Controllers/Metrics/StatsTest.php
+++ b/tests/Unit/Controllers/Metrics/StatsTest.php
@@ -216,9 +216,9 @@ class StatsTest extends TestCase
     public function testAngelTypes(): void
     {
         (new AngelType(['id' => 1, 'name' => 'AngelType 1', 'restricted' => true]))->save();
-        (new AngelType(['id' => 2, 'name' => 'Second AngelType']))->save();
+        (new AngelType(['id' => 2, 'name' => 'Second AngelType', 'restricted' => false]))->save();
         (new AngelType(['id' => 3, 'name' => 'Another AngelType', 'restricted' => true]))->save();
-        (new AngelType(['id' => 4, 'name' => 'Old AngelType']))->save();
+        (new AngelType(['id' => 4, 'name' => 'Old AngelType', 'restricted' => false]))->save();
         UserAngelType::factory()->create(['angel_type_id' => 1, 'confirm_user_id' => 1, 'supporter' => true]);
         UserAngelType::factory()->create(['angel_type_id' => 1, 'confirm_user_id' => null, 'supporter' => false]);
         UserAngelType::factory()->create(['angel_type_id' => 1, 'confirm_user_id' => 1, 'supporter' => false]);

--- a/tests/Unit/Controllers/SettingsControllerTest.php
+++ b/tests/Unit/Controllers/SettingsControllerTest.php
@@ -17,6 +17,7 @@ use Engelsystem\Http\Response;
 use Engelsystem\Http\UrlGenerator;
 use Engelsystem\Http\Validation\Validator;
 use Engelsystem\Models\AngelType;
+use Engelsystem\Models\OAuth;
 use Engelsystem\Models\Session as SessionModel;
 use Engelsystem\Models\User\License;
 use Engelsystem\Models\User\Settings;
@@ -998,6 +999,22 @@ class SettingsControllerTest extends ControllerTest
         $menu = $this->controller->settingsMenu();
         $this->assertArrayHasKey('http://localhost/settings/oauth', $menu);
         $this->assertEquals(['title' => 'settings.oauth', 'hidden' => true], $menu['http://localhost/settings/oauth']);
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\SettingsController::checkOauthHidden
+     */
+    public function testSettingsMenuWithOAuthShownWhenConnected(): void
+    {
+        // Provider configured as hidden
+        $providersHidden = ['foo' => ['lorem' => 'ipsum', 'hidden' => true]];
+        config(['oauth' => $providersHidden]);
+
+        OAuth::factory()->create(['provider' => 'foo', 'user_id' => $this->user->id]);
+
+        $menu = $this->controller->settingsMenu();
+        $this->assertArrayHasKey('http://localhost/settings/oauth', $menu);
+        $this->assertEquals(['title' => 'settings.oauth', 'hidden' => false], $menu['http://localhost/settings/oauth']);
     }
 
     /**


### PR DESCRIPTION
* Default angel types to restricted, fixes  #1471
* Move checkboxes on edit angel type page to the right, fixes #1470
* Update shift edit to match creation, fixes #1465
* Show link to team/angel type description on registration, fixes #1463
* Allow adding angels as supporter for angel type when adding, fixes #1464
* Ported comment fixes made by @chipuni (happy to have more input if you need some other stuff that can be added here)
* Updated translation of message that angel user needs to arrive
* Fixed freeload metrics & flaky tests
* Show SSO menu and entries in profile settings when entered, even if they are normally hidden
* Schedule creation: Show form content on validation errors
* Show total configured t-shirts/goodies on active page
* Show info that user is already in a shift when adding, fixes #1480
* Link FAQ on angeltypes about page
