### PR TITLE
add ability to mark work log as nightshift

### DIFF
--- a/db/factories/WorklogFactory.php
+++ b/db/factories/WorklogFactory.php
@@ -16,11 +16,12 @@ class WorklogFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id'    => User::factory(),
-            'creator_id' => User::factory(),
-            'hours'      => $this->faker->randomFloat(2, 0.01, 10),
-            'comment'    => $this->faker->text(30),
-            'worked_at'  => $this->faker->dateTimeThisMonth(),
+            'user_id'     => User::factory(),
+            'creator_id'  => User::factory(),
+            'hours'       => $this->faker->randomFloat(2, 0.01, 10),
+            'comment'     => $this->faker->text(30),
+            'worked_at'   => $this->faker->dateTimeThisMonth(),
+            'night_shift' => $this->faker->boolean(),
         ];
     }
 }

--- a/db/migrations/2025_01_16_000000_add_worklog_nightshift.php
+++ b/db/migrations/2025_01_16_000000_add_worklog_nightshift.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddWorklogNightshift extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        $this->schema->table('worklogs', function (Blueprint $table): void {
+            $table->boolean('night_shift')->default(false)->after('worked_at');
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        $this->schema->table('worklogs', function (Blueprint $table): void {
+            $table->dropColumn('night_shift');
+        });
+    }
+}

--- a/includes/pages/admin_active.php
+++ b/includes/pages/admin_active.php
@@ -26,6 +26,7 @@ function admin_active()
 {
     $tshirt_sizes = config('tshirt_sizes');
     $shift_sum_formula = Goodie::shiftScoreQuery()->getValue(Db::connection()->getQueryGrammar());
+    $worklog_sum_formula = Goodie::worklogScoreQuery()->getValue(Db::connection()->getQueryGrammar());
     $request = request();
     $goodie = GoodieType::from(config('goodie_type'));
     $goodie_enabled = $goodie !== GoodieType::None;
@@ -70,12 +71,13 @@ function admin_active()
                             users.*,
                             COUNT(shift_entries.id) AS shift_count,
                                 (%s + (
-                                    SELECT COALESCE(SUM(`hours`) * 3600, 0)
+                                    SELECT %s * 3600
                                     FROM `worklogs` WHERE `user_id`=`users`.`id`
                                     AND `worked_at` <= NOW()
                                 )) AS `shift_length`
                         ',
-                        $shift_sum_formula
+                        $shift_sum_formula,
+                        $worklog_sum_formula
                     )
                 )
                 ->leftJoin('shift_entries', 'users.id', '=', 'shift_entries.user_id')
@@ -185,12 +187,13 @@ function admin_active()
                     users.*,
                     COUNT(shift_entries.id) AS shift_count,
                         (%s + (
-                            SELECT COALESCE(SUM(`hours`) * 3600, 0)
+                            SELECT %s * 3600
                             FROM `worklogs` WHERE `user_id`=`users`.`id`
                             AND `worked_at` <= NOW()
                         )) AS `shift_length`
                 ',
-                $shift_sum_formula
+                $shift_sum_formula,
+                $worklog_sum_formula
             )
         )
         ->leftJoin('shift_entries', 'users.id', '=', 'shift_entries.user_id')

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -337,13 +337,7 @@ function User_view_myshift(Shift $shift, $user_source, $its_me, $supporter)
 
     $night_shift = '';
     if ($shift->isNightShift() && $goodie_enabled) {
-        $night_shift = ' <span class="bi bi-moon-stars text-info" data-bs-toggle="tooltip" title="'
-            . __('Night shifts between %d and %d am are multiplied by %d for the goodie score.', [
-                $nightShiftsConfig['start'],
-                $nightShiftsConfig['end'],
-                $nightShiftsConfig['multiplier'],
-            ])
-            . '"></span>';
+        $night_shift = render_night_shift_hint($nightShiftsConfig);
     }
     $myshift = [
         'date' => icon('calendar-event')
@@ -524,6 +518,9 @@ function User_view_worklog(Worklog $worklog, $admin_user_worklog_privilege, $its
 {
     $actions = '';
     $self_worklog = config('enable_self_worklog') || !$its_me;
+    $nightShiftsConfig = config('night_shifts');
+    $goodie = GoodieType::from(config('goodie_type'));
+    $goodie_enabled = $goodie !== GoodieType::None;
 
     if ($admin_user_worklog_privilege && $self_worklog) {
         $actions = '<div class="text-end">' . table_buttons([
@@ -544,10 +541,15 @@ function User_view_worklog(Worklog $worklog, $admin_user_worklog_privilege, $its
         ]) . '</div>';
     }
 
+    $night_shift = '';
+    if ($worklog->night_shift && $goodie_enabled && $nightShiftsConfig['enabled']) {
+        $night_shift = render_night_shift_hint($nightShiftsConfig);
+    }
+
     return [
         'date' => icon('calendar-event') . date(__('general.date'), $worklog->worked_at->timestamp),
         'duration' => sprintf('%.2f', $worklog->hours) . ' h',
-        'hints' => '',
+        'hints' => $night_shift,
         'location' => '',
         'shift_info' => __('Work log entry'),
         'comment' => htmlspecialchars($worklog->comment) . '<br>'
@@ -1165,4 +1167,15 @@ function render_user_mobile_hint()
     }
 
     return null;
+}
+
+function render_night_shift_hint(mixed $nightShiftsConfig): string
+{
+    return ' <span class="bi bi-moon-stars text-info" data-bs-toggle="tooltip" title="'
+        . __('Night shifts between %d and %d am are multiplied by %d for the goodie score.', [
+            $nightShiftsConfig['start'],
+            $nightShiftsConfig['end'],
+            $nightShiftsConfig['multiplier'],
+        ])
+        . '"></span>';
 }

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1880,6 +1880,9 @@ msgstr "Arbeitsstunden"
 msgid "worklog.comment"
 msgstr "Kommentar"
 
+msgid "worklog.night_shift"
+msgstr "Arbeitseinsatz ist eine Nachtschicht"
+
 msgid "worklog.delete"
 msgstr "Arbeitseinsatz löschen"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -707,6 +707,9 @@ msgstr "Work hours"
 msgid "worklog.comment"
 msgstr "Comment"
 
+msgid "worklog.night_shift"
+msgstr "Work log is a night shift"
+
 msgid "worklog.delete"
 msgstr "Delete work log"
 

--- a/resources/views/admin/user/edit-worklog.twig
+++ b/resources/views/admin/user/edit-worklog.twig
@@ -40,6 +40,11 @@
                         'required': true,
                         'max_length': 200,
                     }) }}
+                    {% if attribute(config('night_shifts'), 'enabled') %}
+                        {{ f.checkbox('night_shift', __('worklog.night_shift'), {
+                            'checked': night_shift,
+                        }) }}
+                    {% endif %}
                     {{ f.submit(__('form.save'), {'icon_left': 'save'}) }}
                 </div>
             </div>

--- a/src/Models/Worklog.php
+++ b/src/Models/Worklog.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property float       $hours
  * @property string      $comment
  * @property Carbon      $worked_at
+ * @property bool        $night_shift
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  *
@@ -38,10 +39,11 @@ class Worklog extends BaseModel
 
     /** @var array<string, string> */
     protected $casts = [ // phpcs:ignore
-        'user_id'    => 'integer',
-        'creator_id' => 'integer',
-        'hours'      => 'float',
-        'worked_at'  => 'datetime',
+        'user_id'     => 'integer',
+        'creator_id'  => 'integer',
+        'hours'       => 'float',
+        'worked_at'   => 'datetime',
+        'night_shift' => 'boolean',
     ];
 
     /**
@@ -55,6 +57,7 @@ class Worklog extends BaseModel
         'hours',
         'comment',
         'worked_at',
+        'night_shift',
     ];
 
     public function creator(): BelongsTo

--- a/tests/Unit/Controllers/Admin/UserGoodieControllerTest.php
+++ b/tests/Unit/Controllers/Admin/UserGoodieControllerTest.php
@@ -30,6 +30,7 @@ class UserGoodieControllerTest extends ControllerTest
     public function testIndex(): void
     {
         $this->config->set('goodie_type', GoodieType::Tshirt->value);
+        $this->config->set('night_shifts', ['enabled' => false]);
         $request = $this->request->withAttribute('user_id', 1);
         /** @var Authenticator|MockObject $auth */
         $auth = $this->createMock(Authenticator::class);

--- a/tests/Unit/Controllers/Admin/UserWorklogControllerTest.php
+++ b/tests/Unit/Controllers/Admin/UserWorklogControllerTest.php
@@ -68,6 +68,7 @@ class UserWorklogControllerTest extends ControllerTest
                 $this->assertEquals(Carbon::today(), $data['work_date']);
                 $this->assertEquals(0, $data['work_hours']);
                 $this->assertEquals('', $data['comment']);
+                $this->assertFalse($data['night_shift']);
                 $this->assertFalse($data['is_edit']);
                 return $this->response;
             });
@@ -102,6 +103,7 @@ class UserWorklogControllerTest extends ControllerTest
             'worked_at' => new Carbon('2022-01-01'),
             'hours' => 3.14,
             'comment' => 'a comment',
+            'night_shift' => true,
         ])->create();
 
         $request = $this->request
@@ -114,6 +116,7 @@ class UserWorklogControllerTest extends ControllerTest
                 $this->assertEquals(new Carbon('2022-01-01'), $data['work_date']);
                 $this->assertEquals(3.14, $data['work_hours']);
                 $this->assertEquals('a comment', $data['comment']);
+                $this->assertTrue($data['night_shift']);
                 $this->assertTrue($data['is_edit']);
                 return $this->response;
             });
@@ -151,7 +154,9 @@ class UserWorklogControllerTest extends ControllerTest
         $work_date = Carbon::today()->format('Y-m-d');
         $work_hours = 3.14;
         $comment = str_repeat('X', 200);
-        $body = ['work_date' => $work_date, 'work_hours' => $work_hours, 'comment' => $comment];
+        $night_shift = true;
+        $body = ['work_date' => $work_date, 'work_hours' => $work_hours, 'comment' => $comment,
+            'night_shift' => $night_shift];
         $request = $this->request->withAttribute('user_id', $this->user->id)->withParsedBody($body);
         $this->setExpects($this->auth, 'user', null, $this->user, $this->any());
         $this->redirect->expects($this->once())
@@ -170,6 +175,7 @@ class UserWorklogControllerTest extends ControllerTest
         $this->assertEquals($work_date, $new_worklog->worked_at->format('Y-m-d'));
         $this->assertEquals($work_hours, $new_worklog->hours);
         $this->assertEquals($comment, $new_worklog->comment);
+        $this->assertEquals($night_shift, $new_worklog->night_shift);
     }
 
     /**
@@ -216,7 +222,9 @@ class UserWorklogControllerTest extends ControllerTest
         $work_date = Carbon::today()->format('Y-m-d');
         $work_hours = 3.14;
         $comment = str_repeat('X', 200);
-        $body = ['work_date' => $work_date, 'work_hours' => $work_hours, 'comment' => $comment];
+        $night_shift = true;
+        $body = ['work_date' => $work_date, 'work_hours' => $work_hours, 'comment' => $comment,
+            'night_shift' => $night_shift];
 
         $request = $this->request
             ->withAttribute('user_id', $this->user->id)
@@ -235,6 +243,7 @@ class UserWorklogControllerTest extends ControllerTest
         $this->assertEquals($work_date, $worklog->worked_at->format('Y-m-d'));
         $this->assertEquals($work_hours, $worklog->hours);
         $this->assertEquals($comment, $worklog->comment);
+        $this->assertEquals($night_shift, $worklog->night_shift);
     }
 
     /**

--- a/tests/Unit/Helpers/GoodieTest.php
+++ b/tests/Unit/Helpers/GoodieTest.php
@@ -45,6 +45,6 @@ class GoodieTest extends TestCase
         parent::setUp();
 
         $this->initDatabase();
-        $this->app->instance('config', new Config(['night_shifts' => []]));
+        $this->app->instance('config', new Config(['night_shifts' => ['enabled' => false]]));
     }
 }

--- a/tests/Unit/Models/WorklogTest.php
+++ b/tests/Unit/Models/WorklogTest.php
@@ -24,6 +24,7 @@ class WorklogTest extends ModelTest
         $worklog->hours = 4.2;
         $worklog->comment = 'Lorem ipsum';
         $worklog->worked_at = new Carbon();
+        $worklog->night_shift = false;
         $worklog->save();
 
         $savedWorklog = Worklog::first();


### PR DESCRIPTION
This PR adds the ability to mark work logs as night shifts to apply the night bonus multiplier, implementing #710.
- added db column "night_shift" to worklogs table
- added night shift checkbox to edit-worklog view
- nightshift-work logs multiplied with nighshift muliplier in User_model
- nightshift info text (moon) added to User_view

This is my first PR for the engelsystem and I'm not fully familiar with the codebase. Please let me know if I can improve anything. Unit tests and the pre-commit hook ran successfully.

Please find screenshots of the adjusted views below:
## User_view
![grafik](https://github.com/user-attachments/assets/e576a244-bc78-4cc5-81de-975f496ae8ca)

## edit-worklog
![grafik](https://github.com/user-attachments/assets/cb180c56-931c-4eda-9413-f54cb31347e1)
