### PR TITLE
WIP: limit consecutive working time

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -388,6 +388,18 @@ return [
     # Instruction only onsite in accordance with § 43 Para. 1 of the German Infection Protection Act (IfSG)
     'ifsg_light_enabled'           => env('IFSG_LIGHT_ENABLED', false) && env('IFSG_ENABLED', false),
 
+    // Prevent Angles from overworking themselves by working too many consecutive shifts
+    'maximum_working_time' => [
+        // enable to enforce work time limit / disable to allow unlimited consecutive work
+        'enabled' => (bool) env('MAX_WORKING_TIME_ENABLED', false),
+        // maximum hours of work before a rest period is required
+        'max_working_hours' => env('MAX_WORKING_TIME_WORK_HOURS', 10),
+        // length of required rest period
+        'min_rest_hours' => env('MAX_WORKING_TIME_REST_HOURS', 11),
+        // enforce one rest period every 24h, even if max_working_hours limit is not reached
+        'enforce_daily_rest' => env('MAX_WORKING_TIME_ENFORCE_DAILY_REST', true),
+    ],
+
     // Available locales in /resources/lang/
     // To disable a locale in config.php, you can set its value to null
     'locales'                 => [

--- a/includes/controller/shift_entries_controller.php
+++ b/includes/controller/shift_entries_controller.php
@@ -196,6 +196,7 @@ function shift_entry_error_message(ShiftSignupState $shift_signup_state)
         ShiftSignupStatus::NOT_ARRIVED => error(__('You are not marked as arrived.')),
         ShiftSignupStatus::NOT_YET     => error(__('You are not allowed to sign up yet.')),
         ShiftSignupStatus::SIGNED_UP   => error(__('You are signed up for this shift.')),
+        ShiftSignupStatus::OVERWORKED  => error(__('This Shift exceeds your maximum working time. Please get some rest.')),
         default => null, // ShiftSignupStatus::FREE|ShiftSignupStatus::ADMIN
     };
 }

--- a/includes/model/ShiftSignupState.php
+++ b/includes/model/ShiftSignupState.php
@@ -45,7 +45,7 @@ class ShiftSignupState
     private function valueForState(ShiftSignupStatus $state)
     {
         return match ($state) {
-            ShiftSignupStatus::NOT_ARRIVED, ShiftSignupStatus::NOT_YET, ShiftSignupStatus::SHIFT_ENDED => 100,
+            ShiftSignupStatus::NOT_ARRIVED, ShiftSignupStatus::NOT_YET, ShiftSignupStatus::SHIFT_ENDED, ShiftSignupStatus::OVERWORKED => 100,
             ShiftSignupStatus::SIGNED_UP => 90,
             ShiftSignupStatus::FREE      => 80,
             ShiftSignupStatus::ANGELTYPE, ShiftSignupStatus::COLLIDES => 70,

--- a/includes/view/ShiftCalendarShiftRenderer.php
+++ b/includes/view/ShiftCalendarShiftRenderer.php
@@ -74,7 +74,7 @@ class ShiftCalendarShiftRenderer
         return match ($shiftSignupState->getState()) {
             ShiftSignupStatus::ADMIN, ShiftSignupStatus::OCCUPIED => 'success',
             ShiftSignupStatus::SIGNED_UP => 'primary',
-            ShiftSignupStatus::NOT_ARRIVED, ShiftSignupStatus::NOT_YET, ShiftSignupStatus::SHIFT_ENDED => 'secondary',
+            ShiftSignupStatus::NOT_ARRIVED, ShiftSignupStatus::NOT_YET, ShiftSignupStatus::SHIFT_ENDED, ShiftSignupStatus::OVERWORKED => 'secondary',
             ShiftSignupStatus::ANGELTYPE, ShiftSignupStatus::COLLIDES => 'warning',
             ShiftSignupStatus::FREE => 'danger',
             default => 'light',
@@ -212,6 +212,7 @@ class ShiftCalendarShiftRenderer
                 ),
             // Shift collides or user is already signed up: No signup allowed
             ShiftSignupStatus::COLLIDES, ShiftSignupStatus::SIGNED_UP => $inner_text,
+            ShiftSignupStatus::OVERWORKED => $inner_text . ' (' . __('rest period') . ')',
             // Shift is full
             ShiftSignupStatus::OCCUPIED => null,
             default => null,

--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -206,6 +206,10 @@ function Shift_view(
                 : ''), true);
     }
 
+    if ($shift_signup_state->getState() === ShiftSignupStatus::OVERWORKED) {
+        $content[] = info(__('This Shift exceeds your maximum working time. Please get some rest.'), true);
+    }
+
     $signupAdvanceSeconds = ($shift->shiftType->signup_advance_hours ?: config('signup_advance_hours')) * 3600;
     if ($signupAdvanceSeconds && $shift->start->timestamp > time() + $signupAdvanceSeconds) {
         $content[] = info(sprintf(

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -234,6 +234,9 @@ msgstr "Du bist nicht als angekommen markiert."
 msgid "You are not allowed to sign up yet."
 msgstr "Du darfst dich noch nicht anmelden."
 
+msgid "This Shift exceeds your maximum working time. Please get some rest."
+msgstr "Diese Schicht überschreitet deinen maximale Arbeitszeit. Bitte mach eine Pause."
+
 msgid "You are signed up for this shift."
 msgstr "Du bist für diese Schicht eingetragen."
 
@@ -984,6 +987,9 @@ msgstr "Komme an um dich einzutragen"
 
 msgid "not yet possible"
 msgstr "noch nicht möglich"
+
+msgid "rest period"
+msgstr "Ruhezeit"
 
 msgid "m-d"
 msgstr "d.m."

--- a/src/Models/Shifts/ShiftSignupStatus.php
+++ b/src/Models/Shifts/ShiftSignupStatus.php
@@ -50,4 +50,9 @@ enum ShiftSignupStatus: string
      * User has to be arrived
      */
     case NOT_ARRIVED = 'NOT_ARRIVED';
+
+    /**
+     * User exceeds or would exceed maximum working time
+     */
+    case OVERWORKED = 'OVERWORKED';
 }


### PR DESCRIPTION
This PR implements #565 and has the goal to prevent angels from overworking themselfs by limiting consecutive work to configured hours before requiring a rest.

- [ ] Basic Implementation
    - [x] Global Config: feature enabled, max working time, rest period, toggle for daily rest
    - [x] Limit consecutive working time
    - [x] Enforce daily rest period
    - [ ] Finalize user-facing messages and visualization (shift calendar)
- [ ] Demanding Work implementation
    - [ ] Global Config: max demanding working time
    - [ ] Shift Type Config: is shift type demanding
    - [ ] Limit consecutive demanding work
    - [ ] Finalize user-facing messages and visualization (shift calendar)
- [ ] Unit Tests