### PR TITLE
Add schedule event guid to shift in api and origin_url to schedule.xml parser

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -150,6 +150,7 @@ $route->addGroup(
                 $route->get('/shifttypes', 'Api\ShiftTypeController@index');
                 $route->get('/shifttypes/{shifttype_id:\d+}/shifts', 'Api\ShiftsController@entriesByShiftType');
 
+                $route->get('/users', 'Api\UsersController@index');
                 $route->get('/users/{user_id:(?:\d+|self)}', 'Api\UsersController@user');
                 $route->get('/users/{user_id:(?:\d+|self)}/angeltypes', 'Api\AngelTypeController@ofUser');
                 $route->get('/users/{user_id:(?:\d+|self)}/shifts', 'Api\ShiftsController@entriesByUser');

--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -663,6 +663,30 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
 
+  /users:
+    get:
+      tags:
+        - user
+      summary: Get a list of all users
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Reference'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+
   /users/{id}:
     parameters:
       - name: id

--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -240,6 +240,11 @@ components:
           $ref: '#/components/schemas/Reference'
         shift_type:
           $ref: '#/components/schemas/Reference'
+        schedule_guid:
+          type: string
+          format: uuid
+          nullable: true
+          description: schedule.xml event guid
         created_at:
           $ref: '#/components/schemas/DateTimeOptional'
         updated_at:
@@ -261,6 +266,7 @@ components:
         - ends_at
         - location
         - shift_type
+        - schedule_guid
         - created_at
         - updated_at
         - needed_angel_types

--- a/src/Controllers/Api/Resources/ShiftResource.php
+++ b/src/Controllers/Api/Resources/ShiftResource.php
@@ -23,6 +23,7 @@ class ShiftResource extends BasicResource
             'ends_at' => $this->model->end,
             'location' => LocationResource::toIdentifierArray($location),
             'shift_type' => ShiftTypeResource::toIdentifierArray($this->model->shiftType),
+            'schedule_guid' => $this->model->scheduleShift?->guid,
             'created_at' => $this->model->created_at,
             'updated_at' => $this->model->updated_at,
             'url' => url('/shifts', ['action' => 'view', 'shift_id' => $this->model->id]),

--- a/src/Controllers/Api/ShiftsController.php
+++ b/src/Controllers/Api/ShiftsController.php
@@ -158,6 +158,7 @@ class ShiftsController extends ApiController
                 'shiftEntries.user.contact',
                 'shiftEntries.user.personalData',
                 'shiftType',
+                'scheduleShift',
                 'schedule.shiftType.neededAngelTypes.angelType',
             ])
             ->orderBy('start')

--- a/src/Controllers/Api/UsersController.php
+++ b/src/Controllers/Api/UsersController.php
@@ -8,10 +8,27 @@ use Engelsystem\Controllers\Api\Resources\UserDetailResource;
 use Engelsystem\Controllers\Api\Resources\UserResource;
 use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
+use Engelsystem\Models\BaseModel;
+use Engelsystem\Models\User\User;
 
 class UsersController extends ApiController
 {
     use UsesAuth;
+
+    public function index(): Response
+    {
+        $models = User::query()
+            ->orderBy('name')
+            ->get();
+
+        $models = $models->map(function (BaseModel $model) {
+            return UserResource::toIdentifierArray($model);
+        });
+
+        $data = ['data' => $models];
+        return $this->response
+            ->withContent(json_encode($data));
+    }
 
     public function user(Request $request): Response
     {

--- a/src/Helpers/Schedule/Event.php
+++ b/src/Helpers/Schedule/Event.php
@@ -48,6 +48,7 @@ class Event extends ScheduleData
         protected ?string $url = null,
         protected ?string $videoDownloadUrl = null,
         protected ?string $feedbackUrl = null,
+        protected ?string $originUrl = null,
     ) {
         $this->endDate = $this->date
             ->copy()
@@ -170,6 +171,11 @@ class Event extends ScheduleData
     public function getFeedbackUrl(): ?string
     {
         return $this->feedbackUrl;
+    }
+
+    public function getOriginUrl(): ?string
+    {
+        return $this->originUrl;
     }
 
     public function getVideoDownloadUrl(): ?string

--- a/src/Helpers/Schedule/XmlParser.php
+++ b/src/Helpers/Schedule/XmlParser.php
@@ -180,6 +180,7 @@ class XmlParser
                 $this->getFirstXpathContent('url', $event) ?: null,
                 $this->getFirstXpathContent('video_download_url', $event) ?: null,
                 $this->getFirstXpathContent('feedback_url', $event) ?: null,
+                $this->getFirstXpathContent('origin_url', $event) ?: null,
             );
         }
 

--- a/src/Models/Shifts/Shift.php
+++ b/src/Models/Shifts/Shift.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -32,6 +33,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  *
  * @property-read Collection|NeededAngelType[] $neededAngelTypes
  * @property-read Schedule                     $schedule
+ * @property-read ScheduleShift                $scheduleShift
  * @property-read Collection|ShiftEntry[]      $shiftEntries
  * @property-read ShiftType                    $shiftType
  * @property-read Location                     $location
@@ -99,6 +101,11 @@ class Shift extends BaseModel
     public function schedule(): HasOneThrough
     {
         return $this->hasOneThrough(Schedule::class, ScheduleShift::class, null, 'id', null, 'schedule_id');
+    }
+
+    public function scheduleShift(): HasOne
+    {
+        return $this->hasOne(ScheduleShift::class);
     }
 
     public function shiftEntries(): HasMany

--- a/tests/Unit/Controllers/Api/ShiftsControllerTest.php
+++ b/tests/Unit/Controllers/Api/ShiftsControllerTest.php
@@ -20,6 +20,7 @@ use Engelsystem\Models\User\Contact;
 use Engelsystem\Models\User\PersonalData;
 use Engelsystem\Models\User\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Str;
 
 class ShiftsControllerTest extends ApiBaseControllerTest
 {
@@ -241,9 +242,17 @@ class ShiftsControllerTest extends ApiBaseControllerTest
             'location_id' => $this->location->id,
         ]);
 
-        (new ScheduleShift(['shift_id' => $this->shiftB->id, 'schedule_id' => $this->schedule1->id, 'guid' => 'a']))
+        (new ScheduleShift([
+            'shift_id' => $this->shiftB->id,
+            'schedule_id' => $this->schedule1->id,
+            'guid' => Str::uuid(),
+        ]))
             ->save();
-        (new ScheduleShift(['shift_id' => $this->shiftC->id, 'schedule_id' => $this->schedule2->id, 'guid' => 'b']))
+        (new ScheduleShift([
+            'shift_id' => $this->shiftC->id,
+            'schedule_id' => $this->schedule2->id,
+            'guid' => Str::uuid(),
+        ]))
             ->save();
 
         // "Empty" entry to be skipped

--- a/tests/Unit/Controllers/Api/UsersControllerTest.php
+++ b/tests/Unit/Controllers/Api/UsersControllerTest.php
@@ -18,6 +18,34 @@ use PHPUnit\Framework\MockObject\MockObject;
 class UsersControllerTest extends ApiBaseControllerTest
 {
     /**
+     * @covers \Engelsystem\Controllers\Api\UsersController::index
+     */
+    public function testIndex(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $controller = new UsersController(new Response());
+
+        $response = $controller->index();
+        $this->validateApiResponse('/users', 'get', $response);
+
+        $this->assertEquals(['application/json'], $response->getHeader('content-type'));
+        $this->assertJson($response->getContent());
+
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertArrayHasKey('data', $data);
+        $this->assertIsArray($data['data']);
+        $this->assertNotEmpty($data['data']);
+
+        $firstUser = $data['data'][0];
+        $this->assertArrayHasKey('id', $firstUser);
+        $this->assertEquals($user->id, $firstUser['id']);
+        $this->assertArrayHasKey('name', $firstUser);
+        $this->assertEquals($user->name, $firstUser['name']);
+    }
+
+    /**
      * @covers \Engelsystem\Controllers\Api\UsersController::user
      * @covers \Engelsystem\Controllers\Api\Resources\UserDetailResource::toArray
      * @covers \Engelsystem\Controllers\Api\Resources\UserResource::toArray

--- a/tests/Unit/Helpers/Schedule/Assets/schedule-extended.xml
+++ b/tests/Unit/Helpers/Schedule/Assets/schedule-extended.xml
@@ -43,6 +43,7 @@
                 <description>Any describing stuff?</description>
                 <url>https://foo.bar/baz/schedule/ipsum</url>
                 <feedback_url>https://foo.bar/baz/schedule/ipsum#feedback</feedback_url>
+                <origin_url>https://some.example/event/ipsum</origin_url>
                 <logo>https://lorem.ipsum/foo/bar.png</logo>
                 <persons>
                     <person id='1234'>Some Person</person>

--- a/tests/Unit/Helpers/Schedule/EventTest.php
+++ b/tests/Unit/Helpers/Schedule/EventTest.php
@@ -38,6 +38,7 @@ class EventTest extends TestCase
      * @covers \Engelsystem\Helpers\Schedule\Event::getAttachments
      * @covers \Engelsystem\Helpers\Schedule\Event::getUrl
      * @covers \Engelsystem\Helpers\Schedule\Event::getFeedbackUrl
+     * @covers \Engelsystem\Helpers\Schedule\Event::getOriginUrl
      * @covers \Engelsystem\Helpers\Schedule\Event::getVideoDownloadUrl
      * @covers \Engelsystem\Helpers\Schedule\Event::getEndDate
      */
@@ -83,6 +84,7 @@ class EventTest extends TestCase
         $this->assertNull($event->getUrl());
         $this->assertNull($event->getVideoDownloadUrl());
         $this->assertNull($event->getFeedbackUrl());
+        $this->assertNull($event->getOriginUrl());
         $this->assertEquals('2020-12-28T20:20:00+00:00', $event->getEndDate()->format(Carbon::RFC3339));
     }
 
@@ -111,6 +113,7 @@ class EventTest extends TestCase
      * @covers \Engelsystem\Helpers\Schedule\Event::getAttachments
      * @covers \Engelsystem\Helpers\Schedule\Event::getUrl
      * @covers \Engelsystem\Helpers\Schedule\Event::getFeedbackUrl
+     * @covers \Engelsystem\Helpers\Schedule\Event::getOriginUrl
      * @covers \Engelsystem\Helpers\Schedule\Event::getVideoDownloadUrl
      */
     public function testCreate(): void
@@ -140,7 +143,8 @@ class EventTest extends TestCase
             $attachments,
             'https://foo.bar/2-lorem',
             'https://videos.orem.ipsum/2-lorem.mp4',
-            'https://videos.orem.ipsum/2-lorem/feedback'
+            'https://videos.orem.ipsum/2-lorem/feedback',
+            'https://some.example/2-lorem/',
         );
 
         $this->assertEquals('/foo/bar.png', $event->getLogo());
@@ -154,6 +158,7 @@ class EventTest extends TestCase
         $this->assertEquals('https://foo.bar/2-lorem', $event->getUrl());
         $this->assertEquals('https://videos.orem.ipsum/2-lorem.mp4', $event->getVideoDownloadUrl());
         $this->assertEquals('https://videos.orem.ipsum/2-lorem/feedback', $event->getFeedbackUrl());
+        $this->assertEquals('https://some.example/2-lorem/', $event->getOriginUrl());
 
         $event->setTitle('Event title');
         $this->assertEquals('Event title', $event->getTitle());

--- a/tests/Unit/Helpers/Schedule/XmlParserTest.php
+++ b/tests/Unit/Helpers/Schedule/XmlParserTest.php
@@ -113,6 +113,7 @@ class XmlParserTest extends TestCase
         $this->assertEquals('Any describing stuff?', $event->getDescription());
         $this->assertEquals('https://foo.bar/baz/schedule/ipsum', $event->getUrl());
         $this->assertEquals('https://foo.bar/baz/schedule/ipsum#feedback', $event->getFeedbackUrl());
+        $this->assertEquals('https://some.example/event/ipsum', $event->getOriginUrl());
         $this->assertEquals('https://lorem.ipsum/foo/bar.png', $event->getLogo());
         $this->assertEquals([1234 => 'Some Person', 1337 => 'Another Person'], $event->getPersons());
         $this->assertEquals([

--- a/tests/Unit/Models/Shifts/ShiftTest.php
+++ b/tests/Unit/Models/Shifts/ShiftTest.php
@@ -100,6 +100,26 @@ class ShiftTest extends ModelTest
     }
 
     /**
+     * @covers \Engelsystem\Models\Shifts\Shift::scheduleShift
+     */
+    public function testScheduleShift(): void
+    {
+        /** @var Schedule $schedule */
+        $schedule = Schedule::factory()->create();
+        /** @var Collection|Shift[] $shifts */
+        $shifts = Shift::factory(4)->create();
+
+        (new ScheduleShift(['shift_id' => $shifts[0]->id, 'schedule_id' => $schedule->id, 'guid' => 'd']))->save();
+        (new ScheduleShift(['shift_id' => $shifts[1]->id, 'schedule_id' => $schedule->id, 'guid' => 'e']))->save();
+        (new ScheduleShift(['shift_id' => $shifts[2]->id, 'schedule_id' => $schedule->id, 'guid' => 'f']))->save();
+
+        $this->assertEquals('d', Shift::find(1)->scheduleShift->guid);
+        $this->assertEquals('e', Shift::find(2)->scheduleShift->guid);
+        $this->assertEquals('f', Shift::find(3)->scheduleShift->guid);
+        $this->assertNull(Shift::find(4)->scheduleShift?->guid);
+    }
+
+    /**
      * @covers \Engelsystem\Models\Shifts\Shift::shiftEntries
      */
     public function testShiftEntries(): void


### PR DESCRIPTION
* Added schedule event guid to api to make translation mapping easier
  ![Screenshot_20250202_182532](https://github.com/user-attachments/assets/72be190e-6fdb-4345-9f6d-4ccc0197e143)
* Schedule: Add new `origin_url` to schedule.xml parser
* API: Add /users endpoint
