### PR TITLE
make shift collision message a warning

### DIFF
--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -201,7 +201,7 @@ function Shift_view(
     $content = [msg()];
 
     if ($shift_signup_state->getState() === ShiftSignupStatus::COLLIDES) {
-        $content[] = info(__('This shift collides with one of your shifts.'), true);
+        $content[] = warning(__('This shift collides with one of your shifts.'), true);
     }
 
     if ($shift_signup_state->getState() === ShiftSignupStatus::SIGNED_UP) {


### PR DESCRIPTION
When we were checking shift collisions among our team, we noticed that the note about shift collisions is easy to miss. Imo, this should (at least) be a warning, not an info message, since it's somewhat of a "breaking circumstance": the consequences of overlapping shifts is that you can't sign up for the one you're looking at.
This PR escalates this message to a warning.