### PR TITLE
Add own shifts filter to shift calendar view

### DIFF
--- a/includes/controller/users_controller.php
+++ b/includes/controller/users_controller.php
@@ -433,6 +433,11 @@ function shiftCalendarRendererByShiftFilter(ShiftsFilter $shiftsFilter)
         return new ShiftCalendarRenderer($shifts, $needed_angeltypes, $shift_entries, $shiftsFilter);
     }
 
+    $own_shift_ids = [];
+    if (in_array(ShiftsFilter::FILLED_OWN, $shiftsFilter->getFilled())) {
+        $own_shift_ids = Shifts_by_user(auth()->user()->id, false)->pluck('id')->toArray();
+    }
+
     $filtered_shifts = [];
     foreach ($shifts as $shift) {
         $needed_angels_count = 0;
@@ -463,11 +468,20 @@ function shiftCalendarRendererByShiftFilter(ShiftsFilter $shiftsFilter)
             && $needed_angels_count > 0
         ) {
             $filtered_shifts[] = $shift;
+            continue;
         }
 
         if (
             in_array(ShiftsFilter::FILLED_FILLED, $shiftsFilter->getFilled())
             && $needed_angels_count == 0
+        ) {
+            $filtered_shifts[] = $shift;
+            continue;
+        }
+
+        if (
+            in_array(ShiftsFilter::FILLED_OWN, $shiftsFilter->getFilled())
+            && in_array($shift->id, $own_shift_ids)
         ) {
             $filtered_shifts[] = $shift;
         }

--- a/includes/model/ShiftsFilter.php
+++ b/includes/model/ShiftsFilter.php
@@ -22,6 +22,11 @@ class ShiftsFilter
     public const FILLED_FREE = 0;
 
     /**
+     * Always include own shifts.
+     */
+    public const FILLED_OWN = 2;
+
+    /**
      * Has the user "user shifts admin" privilege?
      *
      * @var boolean

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -280,6 +280,10 @@ function view_user_shifts()
             'id'   => '0',
             'name' => __('free'),
         ],
+        [
+            'id'   => '2',
+            'name' => __('own'),
+        ],
     ];
     $start_day = $shiftsFilter->getStart()->format('Y-m-d');
     $start_time = $shiftsFilter->getStart()->format('H:i');

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -762,6 +762,9 @@ msgstr "belegt"
 msgid "free"
 msgstr "frei"
 
+msgid "own"
+msgstr "eigene"
+
 msgid "Own"
 msgstr "Eigene"
 


### PR DESCRIPTION
This adds the feature requested in #1482 by adding a new occupancy filter to the calendar view called "own" like this:

![image](https://github.com/user-attachments/assets/49633943-60f0-44fa-a92e-1ccea7475cca)

