### PR TITLE
Navbar: Allow scrolling on mobile devices

### DIFF
--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -195,7 +195,7 @@ table .border-bottom {
 
 // prevent dropdown-menu from overflowing the view
 .dropdown-menu {
-  max-height: calc(100vh - 300px); // 300px: menu offset
+  max-height: 100dvh;
   overflow: auto;
 
   // Show above shifts headers

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -41,7 +41,7 @@
         >
             <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <div class="collapse navbar-collapse navbar-nav-scroll" id="navbarSupportedContent">
             <ul class="navbar-nav mb-2 mb-lg-0">
                 {% for name,opt in menu() %}
                     {% set url = opt is iterable ? opt[0] : opt %}


### PR DESCRIPTION
Fixes #1298 by applying the bootstrap-inbuilt way from https://getbootstrap.com/docs/5.0/components/navbar/#scrolling . This defaults to limiting the menu to 75% of viewport height, which works quite nicely with the other sizes.

Afterwards noticed the dropdowns in the navbar on my test resolution of 480x320 being quite small, so this also relaxes the height limit of dropdowns (which seems to be the previous fix for navbar-overflowing).

![iPhone 4-1742413036006](https://github.com/user-attachments/assets/588038a0-934e-4be3-8980-2bcdc2c671e2)
