### PR TITLE
Add sticky headers to tables

### DIFF
--- a/includes/sys_template.php
+++ b/includes/sys_template.php
@@ -315,7 +315,7 @@ function render_table($columns, $rows, $data = true)
         return info(__('No data found.'), true);
     }
 
-    $html = '<table class="table table-striped' . ($data ? ' data' : '') . '">';
+    $html = '<table class="table table-striped table-sticky-header' . ($data ? ' data' : '') . '">';
     $html .= '<thead><tr>';
     foreach ($columns as $key => $column) {
         $html .= '<th class="column_' . $key . '">' . $column . '</th>';

--- a/resources/assets/js/table-responsive-sticky-header.js
+++ b/resources/assets/js/table-responsive-sticky-header.js
@@ -10,7 +10,7 @@ ready(() => {
     table.className += ' table-sticky-header';
 
     const update = () => {
-      const calcHeight =  navbar.getBoundingClientRect().height - element.getBoundingClientRect().top;
+      const calcHeight = navbar.getBoundingClientRect().height - element.getBoundingClientRect().top;
       header.style.top = `${calcHeight}px`;
     };
 

--- a/resources/assets/js/table-responsive-sticky-header.js
+++ b/resources/assets/js/table-responsive-sticky-header.js
@@ -1,0 +1,24 @@
+import { ready } from './ready';
+
+ready(() => {
+  const navbar = document.querySelector('.navbar');
+
+  document.querySelectorAll('.table-responsive-sticky-header').forEach((element) => {
+    const table = element.querySelector('table');
+    const header = table.querySelector('thead');
+
+    table.className += ' table-sticky-header';
+
+    const update = () => {
+      const calcHeight =  navbar.getBoundingClientRect().height - element.getBoundingClientRect().top;
+      header.style.top = `${calcHeight}px`;
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update);
+
+    const navbarObserver = new MutationObserver(update);
+    navbarObserver.observe(navbar, { attributes: true, subtree: true, attributeFilter: ['class'] });
+  });
+});

--- a/resources/assets/js/vendor.js
+++ b/resources/assets/js/vendor.js
@@ -5,3 +5,4 @@ import './countdown';
 import './dashboard';
 import './design';
 import './voucher';
+import './table-responsive-sticky-header';

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -148,6 +148,13 @@ table .border-bottom {
   padding: 0 2px;
 }
 
+table.table-sticky-header thead {
+  position: sticky;
+  top: 57px;
+  z-index: $zindex-sticky;
+  background-color: var(--es-table-sticky-bg, var(--bs-body-bg));
+}
+
 .stats {
   font-size: 20px;
   height: 150px;

--- a/resources/views/admin/log.twig
+++ b/resources/views/admin/log.twig
@@ -41,39 +41,43 @@
                     </div>
                 {% endif %}
 
-                <table class="table table-striped">
-                    <tr>
-                        <th>{{ __('log.time') }}</th>
-                        <th>{{ __('log.level') }}</th>
-                        <th>{{ __('general.user') }}</th>
-                        <th>{{ __('log.message') }}</th>
-                    </tr>
-                    {% for entry in entries %}
-                        {%- set type = 'default' %}
-                        {%- if entry.level in ['notice', 'info'] %}
-                            {%- set type = 'info' %}
-                        {%- endif %}
-                        {%- if entry.level in ['error', 'warning'] %}
-                            {%- set type = 'warning' %}
-                        {%- endif %}
-                        {%- if entry.level in ['emergency', 'alert', 'critical'] %}
-                            {%- set type = 'danger' %}
-                        {%- endif %}
-
-                        {%- set td_type = '' %}
-                        {%- if type in ['warning', 'danger'] %}
-                            {%- set td_type = type %}
-                        {%- endif %}
-
+                <table class="table table-striped table-sticky-header">
+                    <thead>
                         <tr>
-                            <td class="table-{{ td_type }} text-nowrap">{{ entry.created_at.format(__('general.datetime')) }}</td>
-                            <td class="table-{{ td_type }} text-nowrap">
-                                <span class="badge bg-{{ type }}">{{ entry.level|capitalize }}</span> <!-- //todo bs5 -->
-                            </td>
-                            <td class="text-nowrap">{% if entry.user %}{{ m.user(entry.user) }}{% endif %}</td>
-                            <td>{{ entry.message|nl2br }}</td>
+                            <th>{{ __('log.time') }}</th>
+                            <th>{{ __('log.level') }}</th>
+                            <th>{{ __('general.user') }}</th>
+                            <th>{{ __('log.message') }}</th>
                         </tr>
-                    {% endfor %}
+                    </thead>
+                    <tbody>
+                        {% for entry in entries %}
+                            {%- set type = 'default' %}
+                            {%- if entry.level in ['notice', 'info'] %}
+                                {%- set type = 'info' %}
+                            {%- endif %}
+                            {%- if entry.level in ['error', 'warning'] %}
+                                {%- set type = 'warning' %}
+                            {%- endif %}
+                            {%- if entry.level in ['emergency', 'alert', 'critical'] %}
+                                {%- set type = 'danger' %}
+                            {%- endif %}
+
+                            {%- set td_type = '' %}
+                            {%- if type in ['warning', 'danger'] %}
+                                {%- set td_type = type %}
+                            {%- endif %}
+
+                            <tr>
+                                <td class="table-{{ td_type }} text-nowrap">{{ entry.created_at.format(__('general.datetime')) }}</td>
+                                <td class="table-{{ td_type }} text-nowrap">
+                                    <span class="badge bg-{{ type }}">{{ entry.level|capitalize }}</span> <!-- //todo bs5 -->
+                                </td>
+                                <td class="text-nowrap">{% if entry.user %}{{ m.user(entry.user) }}{% endif %}</td>
+                                <td>{{ entry.message|nl2br }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
                 </table>
             </div>
         </div>

--- a/resources/views/admin/schedule/index.twig
+++ b/resources/views/admin/schedule/index.twig
@@ -21,7 +21,7 @@
                 <div class="col-md-12">
                     <p>{{ __('schedule.import.text') }}</p>
 
-                    <div class="table-responsive">
+                    <div class="table-responsive table-responsive-sticky-header">
                         <table class="table table-striped">
                             <thead>
                             <tr>

--- a/resources/views/admin/schedule/load.twig
+++ b/resources/views/admin/schedule/load.twig
@@ -35,7 +35,7 @@
 
 
 {% macro locationsTable(locations) %}
-    <div class="table-responsive">
+    <div class="table-responsive table-responsive-sticky-header">
         <table class="table table-striped">
             <thead>
             <tr>
@@ -55,7 +55,7 @@
 {% endmacro %}
 
 {% macro shiftsTable(shifts) %}
-    <div class="table-responsive">
+    <div class="table-responsive table-responsive-sticky-header">
         <table class="table table-striped">
             <thead>
             <tr>

--- a/resources/views/admin/shifts/history.twig
+++ b/resources/views/admin/shifts/history.twig
@@ -16,7 +16,7 @@
         <div class="row">
 {% block row_content %}
     <div class="col-md-12">
-        <div class="table-responsive">
+        <div class="table-responsive table-responsive-sticky-header">
             <table class="table table-striped">
                 <thead>
                 <tr>

--- a/resources/views/admin/shifttypes/index.twig
+++ b/resources/views/admin/shifttypes/index.twig
@@ -26,7 +26,7 @@
 
             {% block row_content %}
                 <div class="col-md-12">
-                    <div class="table-responsive">
+                    <div class="table-responsive table-responsive-sticky-header">
                         <table class="table table-striped">
                             <thead>
                             <tr>

--- a/resources/views/pages/design.twig
+++ b/resources/views/pages/design.twig
@@ -72,22 +72,26 @@
             <div class="col-md-6 col-lg-4 mb-4">
                 <span id="tables" class="ref-id"></span>
                 <h3>Tables <a href="#tables" class="ref-link">{{ m.icon('link') }}</a></h3>
-                <table class="table table-striped">
-                    <tr>
-                        <th>Header 1</th>
-                        <th>Header 2</th>
-                        <th>Header 3</th>
-                    </tr>
-                    <tr>
-                        <td>Table content</td>
-                        <td>{{ lipsum }}</td>
-                        <td><span class="text-success">{{ m.icon('check-lg') }}</span></td>
-                    </tr>
-                    <tr>
-                        <td>Another content</td>
-                        <td>Lorem ipsum</td>
-                        <td><span class="text-danger">{{ m.icon('x-lg') }}</span></td>
-                    </tr>
+                <table class="table table-striped table-sticky-header">
+                    <thead>
+                        <tr>
+                            <th>Header 1</th>
+                            <th>Header 2</th>
+                            <th>Header 3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Table content</td>
+                            <td>{{ lipsum }}</td>
+                            <td><span class="text-success">{{ m.icon('check-lg') }}</span></td>
+                        </tr>
+                        <tr>
+                            <td>Another content</td>
+                            <td>Lorem ipsum</td>
+                            <td><span class="text-danger">{{ m.icon('x-lg') }}</span></td>
+                        </tr>
+                    </tbody>
                 </table>
             </div>
             <div class="col-md-6 col-lg-4 mb-4">

--- a/resources/views/pages/locations/index.twig
+++ b/resources/views/pages/locations/index.twig
@@ -26,7 +26,7 @@
 
             {% block row_content %}
                 <div class="col-md-12">
-                    <div class="table-responsive">
+                    <div class="table-responsive table-responsive-sticky-header">
                         <table class="table table-striped">
                             <thead>
                             <tr>

--- a/resources/views/pages/messages/index.twig
+++ b/resources/views/pages/messages/index.twig
@@ -27,7 +27,7 @@
             </div>
         </form>
 
-        <table class="table table-striped data">
+        <table class="table table-striped table-sticky-header data">
             <thead>
             <tr>
                 <th>{{ __('general.angel') }}</th>

--- a/resources/views/pages/settings/oauth.twig
+++ b/resources/views/pages/settings/oauth.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block row_content %}
-<table class="table table-striped">
+<table class="table table-striped table-sticky-header">
     <thead>
         <tr>
             <th>{{ __('settings.oauth.identity-provider') }}</th>

--- a/resources/views/pages/settings/sessions.twig
+++ b/resources/views/pages/settings/sessions.twig
@@ -9,7 +9,7 @@
         <div class="col-md-12">
             {{ m.info(__('settings.sessions.info')) }}
 
-            <div class="table-responsive">
+            <div class="table-responsive table-responsive-sticky-header">
                 <table class="table table-striped">
                     <thead>
                     <tr>

--- a/resources/views/pages/tag/index.twig
+++ b/resources/views/pages/tag/index.twig
@@ -19,33 +19,36 @@
         {% include 'layouts/parts/messages.twig' %}
 
         <div class="row">
-
-            <table class="table table-striped">
-                <tr>
-                    <th>{{ __('general.name') }}</th>
-                    <th></th>
-                </tr>
-
-                {% block row %}
-                    {% for item in items %}
+            <div class="col-md-12">
+                <table class="table table-striped table-sticky-header">
+                    <thead>
                         <tr>
-                            <td>{{ item.name }}</td>
-                            <td>
-                                <div class="d-flex ms-auto">
-                                    {{ m.edit(url('admin/tags/edit/' ~ item.id)) }}
-
-                                    <form method="post" enctype="multipart/form-data" action="{{ url('admin/tags/edit/' ~ item.id) }}" class="ps-1">
-                                        {{ csrf() }}
-                                        {{ f.delete(null, {'size': 'sm', 'confirm_title': __('tag.delete.title', [item.name[:40]|e])}) }}
-                                    </form>
-                                </div>
-                            </td>
+                            <th>{{ __('general.name') }}</th>
+                            <th></th>
                         </tr>
-                    {% endfor %}
-                {% endblock %}
+                    </thead>
 
-            </table>
+                    <tbody>
+                        {% block row %}
+                            {% for item in items %}
+                                <tr>
+                                    <td>{{ item.name }}</td>
+                                    <td>
+                                        <div class="d-flex ms-auto">
+                                            {{ m.edit(url('admin/tags/edit/' ~ item.id)) }}
 
+                                            <form method="post" enctype="multipart/form-data" action="{{ url('admin/tags/edit/' ~ item.id) }}" class="ps-1">
+                                                {{ csrf() }}
+                                                {{ f.delete(null, {'size': 'sm', 'confirm_title': __('tag.delete.title', [item.name[:40]|e])}) }}
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        {% endblock %}
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #289 

This MR introduces sticky headers to tables where possible. The sticky headers will remain visible at the top of the viewport (below the navbar) when scrolling down.

![{354667E2-96D1-4506-A335-4F22FCA5E636}](https://github.com/user-attachments/assets/e27a086b-633c-49b8-ac95-16f2e8448887)
