### PR TITLE
change MYSQL_RANDOM_ROOT_PASSWORD

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       MYSQL_DATABASE: engelsystem
       MYSQL_USER: engelsystem
       MYSQL_PASSWORD: engelsystem
-      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_RANDOM_ROOT_PASSWORD: "1"
       MYSQL_INITDB_SKIP_TZINFO: "yes"
     volumes:
       - db:/var/lib/mysql


### PR DESCRIPTION
change MYSQL_RANDOM_ROOT_PASSWORD to a non-null string, such that it can be nulled in a docker-compose overwrite. Podman does typechecking and therefore an integer cannot be nulled in an overwrite file.