### PR TITLE
dark.scss: Make user-agent stylesheet follow dark theme

### DIFF
--- a/resources/assets/themes/dark.scss
+++ b/resources/assets/themes/dark.scss
@@ -8,11 +8,9 @@ $list-group-form-check-input-border-color: #999;
 
 $es-choices-highlight-color: #000;
 
-$invert-color-value: 1 !default;
-
-/* Invert the clock icon color for Chrome */
-input[type='time']::-webkit-calendar-picker-indicator {
-  filter: invert($invert-color-value);
+/* Make user-agent stylesheet follow dark theme */
+body {
+  color-scheme: dark;
 }
 
 .modal .bg-dark .modal-header .btn-close {


### PR DESCRIPTION
While working on the Easterhegg 2025 Engelsystem theme (separate dark and light theme variants), I discovered that the date-picker icon doesn't correctly follow the theme's color-scheme. The existing fix for chrome's time-picker also didn't account for the date-picker icon (see below).

![Before](https://github.com/user-attachments/assets/a3445191-815d-40b8-b11e-d0cfa15b13e4)

By replacing the fix with instead setting the CSS color-scheme property on the body element, we can ensure that the date- and time-picker icons, as well as input fields and a few other things are forced to use the dark scheme in dark themes.

![After](https://github.com/user-attachments/assets/1aeb60c2-977b-47ec-bbd1-b00fc765ac62)

The property does not need to be set for light-themes, as leaving it unset, all modern browsers default to a light color-scheme anyway.

This works in all browsers which support this property (baseline widely available since 2022) and might also work for #1267, but I did not try and validate using the same system conditions.