### PR TITLE
make shift filter selections scrollable

### DIFF
--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -194,7 +194,14 @@ function load_types()
                         NOT `user_angel_type`.`confirm_user_id` IS NULL
                         OR `user_angel_type`.`id` IS NULL
                     )
-                ) AS `enabled`
+                ) AS `enabled`,
+                (
+                    `user_angel_type`.`id` IS NOT NULL
+                    AND (
+                        `angel_types`.`restricted`=0
+                        OR `user_angel_type`.`confirm_user_id` IS NOT NULL
+                    )
+                ) AS `own`
             FROM `angel_types`
             LEFT JOIN `user_angel_type`
                 ON (
@@ -204,7 +211,7 @@ function load_types()
             . ($isShico ? '' :
             'WHERE angel_types.hide_on_shift_view = 0
                 OR user_angel_type.user_id IS NOT NULL ') .
-            'ORDER BY `angel_types`.`name`
+            'ORDER BY `own` DESC, `angel_types`.`name`
         ',
         [
             $user->id,
@@ -411,14 +418,16 @@ function make_select($items, $selected, $name, $title = null, $ownSelect = [])
     $html .= '<div id="selection_' . $name . '" class="mb-3 selection ' . $name . '">' . "\n";
 
     $htmlItems = [];
-    foreach ($items as $i) {
-        $id = $name . '_' . $i['id'];
+    foreach ($items as $i => $item) {
+        $break = isset($item['own'], $items[$i + 1]) &&  $item['own'] && !$items[$i + 1]['own'];
+        $id = $name . '_' . $item['id'];
         $htmlItems[] = '<div class="form-check">'
-            . '<input class="form-check-input" type="checkbox" id="' . $id . '" name="' . $name . '[]" value="' . $i['id'] . '" '
-            . (in_array($i['id'], $selected) ? ' checked="checked"' : '')
-            . '><label class="form-check-label" for="' . $id . '">' . htmlspecialchars($i['name']) . '</label>'
-            . (!isset($i['enabled']) || $i['enabled'] ? '' : icon('mortarboard-fill'))
-            . '</div>';
+            . '<input class="form-check-input" type="checkbox" id="' . $id . '" name="' . $name . '[]" value="' . $item['id'] . '" '
+            . (in_array($item['id'], $selected) ? ' checked="checked"' : '')
+            . '><label class="form-check-label" for="' . $id . '">' . htmlspecialchars($item['name']) . '</label>'
+            . (!isset($item['enabled']) || $item['enabled'] ? '' : icon('mortarboard-fill'))
+            . '</div>'
+            . ($break ? '<hr class="border border-info border-2 opacity-75" id="angel_types_selection_hr">' : '');
     }
     $html .= implode("\n", $htmlItems);
 

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -623,7 +623,6 @@ function User_view(
             $goodie_admin,
             $user_worklogs,
             $admin_user_worklog_privilege,
-            $supported_angeltypes,
         );
         if (count($my_shifts) > 0) {
             $myshifts_table = div('table-responsive', table([

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -215,6 +215,17 @@ table.table-sticky-header thead {
   }
 }
 
+/* make selections scrollable and add a max height of 4.5 entries */
+#collapseShiftsFilterSelect .selection {
+  overflow-y: auto;
+  max-height: ($form-check-min-height + $form-check-margin-bottom) * 4.5;
+}
+
+/* add divider between sorting groups of angel types selection */
+#angel_types_selection_hr {
+  margin: 0;
+}
+
 .selection .checkbox {
   display: block;
 }


### PR DESCRIPTION
* make shifts filter selection scrollable and add max height too in user-shifts
![Screenshot 2025-06-01 at 12 04 01](https://github.com/user-attachments/assets/2c779701-58f9-41d6-ac35-910534a94ddf)
* because @MyIgel wanted it: there now are two sections one with own angel types and one with others, separated with a line 
  * for the record: I hate this sorting and its confusing to me