### PR TITLE
Schedule: Fixed room patching created duplicates

### DIFF
--- a/src/Controllers/Admin/ScheduleController.php
+++ b/src/Controllers/Admin/ScheduleController.php
@@ -569,7 +569,7 @@ class ScheduleController extends BaseController
 
     protected function patchSchedule(Schedule $schedule): Schedule
     {
-        foreach ($schedule->getRooms() as $room) {
+        foreach ($schedule->getAllRooms() as $room) {
             $room->patch('name', Str::substr($room->getName(), 0, 35));
 
             foreach ($room->getEvents() as $event) {

--- a/src/Helpers/Schedule/Schedule.php
+++ b/src/Helpers/Schedule/Schedule.php
@@ -39,20 +39,36 @@ class Schedule extends ScheduleData
 
     /**
      * @return Room[]
+     *
+     * Returns a list of all rooms for all days
      */
-    public function getRooms(): array
+    public function getAllRooms(): array
     {
         $rooms = [];
         foreach ($this->days as $day) {
             foreach ($day->getRooms() as $room) {
-                $name = $room->getName();
-                $rooms[$name] = $room;
+                $rooms[] = $room;
             }
         }
 
         return $rooms;
     }
 
+    /**
+     * @return Room[]
+     *
+     * Returns a list of rooms unique by name and thus the instance of the last day they are used
+     */
+    public function getRooms(): array
+    {
+        $rooms = [];
+        foreach ($this->getAllRooms() as $room) {
+            $name = $room->getName();
+            $rooms[$name] = $room;
+        }
+
+        return $rooms;
+    }
 
     public function getStartDateTime(): ?Carbon
     {

--- a/tests/Unit/Helpers/Schedule/ScheduleTest.php
+++ b/tests/Unit/Helpers/Schedule/ScheduleTest.php
@@ -37,6 +37,7 @@ class ScheduleTest extends TestCase
     }
 
     /**
+     * @covers \Engelsystem\Helpers\Schedule\Schedule::getAllRooms
      * @covers \Engelsystem\Helpers\Schedule\Schedule::getRooms
      */
     public function testGetRooms(): void
@@ -45,25 +46,28 @@ class ScheduleTest extends TestCase
         $room1 = new Room('Test 1');
         $room2 = new Room('Test 2');
         $room3 = new Room('Test 3');
+        $room4 = new Room('Test 2');
         $days = [
             new Day(
                 '2042-01-01',
                 new Carbon('2042-01-01T00:00:00+00:00'),
                 new Carbon('2042-01-01T23:59:00+00:00'),
                 1,
-                [$room1, $room2]
+                [$room1, $room2],
             ),
             new Day(
                 '2042-01-02',
-                new Carbon('2042-02-01T00:00:00+00:00'),
-                new Carbon('2042-02-01T23:59:00+00:00'),
+                new Carbon('2042-02-02T00:00:00+00:00'),
+                new Carbon('2042-02-02T23:59:00+00:00'),
                 2,
-                [new Room('Test 2'), $room3]
+                [$room4, $room3],
             ),
         ];
         $schedule = new Schedule('Lorem 1.3.3.7', $conference, $days);
 
-        $this->assertEquals(['Test 1' => $room1, 'Test 2' => $room2, 'Test 3' => $room3], $schedule->getRooms());
+        $this->assertEquals(['Test 1' => $room1, 'Test 2' => $room4, 'Test 3' => $room3], $schedule->getRooms());
+        $this->assertEquals([$room1, $room2, $room4, $room3], $schedule->getAllRooms());
+        $this->assertTrue($room4 === $schedule->getRooms()['Test 2']); // Rooms should use last room occurrence
 
         $schedule = new Schedule('Lorem 1.3.3.0', $conference, []);
         $this->assertEquals([], $schedule->getRooms());


### PR DESCRIPTION
The current schedule import logic patches only the last room instance to the new name with previous instances of other days not being changed.
This leads to duplicated room names (full length and shortened)