### PR TITLE
change time format in worklog

### DIFF
--- a/includes/controller/users_controller.php
+++ b/includes/controller/users_controller.php
@@ -188,7 +188,8 @@ function user_controller()
         auth()->resetApiKey($user_source);
     }
 
-    $goodie_score = sprintf('%.2f', Goodie::userScore($user_source)) . '&nbsp;h';
+    $goodie_score_raw = Goodie::userScore($user_source);
+    $goodie_score = sprintf("%02d:%02d", floor($goodie_score_raw / 3600), floor(($goodie_score_raw % 3600) / 60));
     if ($user_source->state->force_active && config('enable_force_active')) {
         $goodie_score = '<span title="' . $goodie_score . '">' . __('user.goodie_score.enough') . '</span>';
     }

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -490,7 +490,7 @@ function User_view_myshifts(
         if ($show_sum) {
             $myshifts_table[] = [
                 'date' => '<b>' . __('Sum:') . '</b>',
-                'duration' => '<b>' . sprintf('%.2f', round($timeSum / 3600, 2)) . '&nbsp;h</b>',
+                'duration' => '<b>' . sprintf("%02d:%02d", floor($timeSum / 3600), floor(($timeSum % 3600) / 60)) . '</b>',
                 'hints' => '',
                 'location' => '',
                 'shift_info' => '',
@@ -546,7 +546,7 @@ function User_view_worklog(Worklog $worklog, $admin_user_worklog_privilege, $its
 
     return [
         'date' => icon('calendar-event') . date(__('general.date'), $worklog->worked_at->timestamp),
-        'duration' => sprintf('%.2f', $worklog->hours) . ' h',
+        'duration' => sprintf("%02d:%02d", floor($worklog->hours), floor($worklog->hours * 60) % 60),
         'hints' => '',
         'location' => '',
         'shift_info' => __('Work log entry'),


### PR DESCRIPTION
Changes as requested in #1552 
Set format to hh:mm at:

- goodie score in worklog
- worklog sum
- worklog entries