### PR TITLE
show worked time as duration string

### DIFF
--- a/includes/controller/users_controller.php
+++ b/includes/controller/users_controller.php
@@ -1,6 +1,8 @@
 <?php
 
+use Carbon\CarbonInterval;
 use Engelsystem\Database\Db;
+use Engelsystem\Helpers\Carbon;
 use Engelsystem\Helpers\Goodie;
 use Engelsystem\Models\AngelType;
 use Engelsystem\Models\Shifts\ShiftEntry;
@@ -189,7 +191,10 @@ function user_controller()
         auth()->resetApiKey($user_source);
     }
 
-    $goodie_score = sprintf('%.2f', Goodie::userScore($user_source)) . '&nbsp;h';
+    $goodie_score = Carbon::formatDuration(
+        CarbonInterval::minutes(round(Goodie::userScore($user_source) * 60)),
+        __('general.duration')
+    );
     if ($user_source->state->force_active && config('enable_force_active')) {
         $goodie_score = '<span title="' . $goodie_score . '">' . __('user.goodie_score.enough') . '</span>';
     }

--- a/includes/pages/admin_active.php
+++ b/includes/pages/admin_active.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonInterval;
 use Engelsystem\Config\GoodieType;
 use Engelsystem\Database\Db;
 use Engelsystem\Helpers\Carbon;
@@ -275,9 +276,12 @@ function admin_active()
                 . '"></span></small>'
             );
         }
-        $userData['work_time'] = sprintf('%.2f', round($timeSum / 3600, 2)) . '&nbsp;h';
-        $userData['score'] = round($user['shift_length'] / 60)
-            . ' min (' . sprintf('%.2f', $user['shift_length'] / 3600) . '&nbsp;h)';
+        $duration_format = __('general.duration');
+        $userData['work_time'] = Carbon::formatDuration(CarbonInterval::seconds($timeSum), $duration_format);
+        $userData['score'] =  Carbon::formatDuration(
+            CarbonInterval::seconds((int) $user['shift_length']),
+            $duration_format
+        );
         $userData['active'] = icon_bool($user->state->active);
         $userData['force_active'] = icon_bool($user->state->force_active);
         $userData['force_food'] = icon_bool($user->state->force_food);

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -1,7 +1,8 @@
 <?php
 
-use Carbon\Carbon;
+use Carbon\CarbonInterval;
 use Engelsystem\Config\GoodieType;
+use Engelsystem\Helpers\Carbon;
 use Engelsystem\Helpers\UserVouchers;
 use Engelsystem\Models\AngelType;
 use Engelsystem\Models\Group;
@@ -365,7 +366,7 @@ function User_view_myshift(Shift $shift, $user_source, $its_me, $supporter)
             . icon('clock-history') . $shift->start->format('H:i')
             . ' - '
             . $shift->end->format(__('H:i')),
-        'duration' => sprintf('%.2f', ($shift->end->timestamp - $shift->start->timestamp) / 3600) . '&nbsp;h',
+        'duration' => Carbon::formatDuration(CarbonInterval::diff($shift->start, $shift->end), __('general.duration')),
         'hints' => $night_shift,
         'location' => location_name_render($shift->location),
         'shift_info' => $shift_info,
@@ -504,7 +505,7 @@ function User_view_myshifts(
         if ($show_sum) {
             $myshifts_table[] = [
                 'date' => '<b>' . __('Sum:') . '</b>',
-                'duration' => '<b>' . sprintf('%.2f', round($timeSum / 3600, 2)) . '&nbsp;h</b>',
+                'duration' => '<b>' . Carbon::formatDuration(CarbonInterval::seconds((int) $timeSum), __('general.duration')) . '</b>',
                 'hints' => '',
                 'location' => '',
                 'shift_info' => '',
@@ -568,7 +569,7 @@ function User_view_worklog(Worklog $worklog, $admin_user_worklog_privilege, $its
 
     return [
         'date' => icon('calendar-event') . date(__('general.date'), $worklog->worked_at->timestamp),
-        'duration' => sprintf('%.2f', $worklog->hours) . ' h',
+        'duration' => Carbon::formatDuration(CarbonInterval::minutes(round($worklog->hours * 60)), __('general.duration')),
         'hints' => $night_shift,
         'location' => '',
         'shift_info' => __('Work log entry'),

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -303,8 +303,16 @@ table.table-sticky-header thead {
   }
 }
 
-.column_duration {
+.column_duration,
+.column_work_time,
+.column_score {
   text-align: right;
+}
+
+.column_active,
+.column_force_active,
+.column_tshirt {
+  text-align: center;
 }
 
 .column_shift_info:not(:hover) .table-myshifts-shift-info-limit-height {

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -716,6 +716,9 @@ msgstr "User bearbeiten"
 msgid "general.datetime"
 msgstr "d.m.Y H:i"
 
+msgid "general.duration"
+msgstr "%dh %02dmin"
+
 msgid "API Settings"
 msgstr "API Einstellungen"
 
@@ -1843,9 +1846,6 @@ msgstr "Goodie bearbeiten"
 
 msgid "user.goodie_score.enough"
 msgstr "Genug"
-
-msgid "user.goodie_score.value"
-msgstr "%s h"
 
 msgid "user.goodie_score"
 msgstr "Goodie Score: %s"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -662,9 +662,6 @@ msgstr "Edit goodie"
 msgid "user.goodie_score.enough"
 msgstr "Enough"
 
-msgid "user.goodie_score.value"
-msgstr "%s h"
-
 msgid "user.goodie_score"
 msgstr "Goodie score: %s"
 
@@ -903,6 +900,9 @@ msgstr "Y-m-d H:i"
 
 msgid "general.date"
 msgstr "Y-m-d"
+
+msgid "general.duration"
+msgstr "%dh %02dm"
 
 msgid "general.id"
 msgstr "ID"

--- a/resources/views/admin/user/edit-goodie.twig
+++ b/resources/views/admin/user/edit-goodie.twig
@@ -16,7 +16,7 @@
         {% include 'layouts/parts/messages.twig' %}
 
         <div class="row">
-            {% set score = goodie_score == '~' ? __('user.goodie_score.enough') : __('user.goodie_score.value', [goodie_score])%}
+            {% set score = goodie_score == '~' ? __('user.goodie_score.enough') : goodie_score %}
             <p>{{ __('user.goodie_score', [score]) }}</p>
         </div>
 

--- a/src/Controllers/Admin/UserGoodieController.php
+++ b/src/Controllers/Admin/UserGoodieController.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Admin;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterval;
 use Engelsystem\Config\Config;
 use Engelsystem\Config\GoodieType;
 use Engelsystem\Controllers\BaseController;
 use Engelsystem\Controllers\HasUserNotifications;
 use Engelsystem\Helpers\Authenticator;
+use Engelsystem\Helpers\Carbon;
 use Engelsystem\Helpers\Goodie;
 use Engelsystem\Http\Exceptions\HttpNotFound;
 use Engelsystem\Http\Redirector;
@@ -52,7 +53,11 @@ class UserGoodieController extends BaseController
 
         /** @var User $user */
         $user = $this->user->findOrFail($userId);
-        $goodieScore = $user->state->force_active ? '~' : Goodie::userScore($user);
+        $goodieScore = $user->state->force_active ? '~' :
+            Carbon::formatDuration(
+                CarbonInterval::minutes(round(Goodie::userScore($user) * 60)),
+                __('general.duration')
+            );
 
         return $this->response->withView(
             'admin/user/edit-goodie.twig',

--- a/src/Helpers/Carbon.php
+++ b/src/Helpers/Carbon.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Engelsystem\Helpers;
 
+use Carbon\CarbonInterval;
+
 class Carbon extends \Carbon\Carbon
 {
     public const DATETIME_LOCAL = '!Y-m-d\TH:i';
@@ -30,5 +32,22 @@ class Carbon extends \Carbon\Carbon
         }
 
         return null;
+    }
+
+    /**
+     * Formats a CarbonInterval into a human-readable duration string consisting of hours and minutes.
+     * Format is defined in the localization files under 'general.duration.format'.
+     *
+     * @param CarbonInterval $interval The interval to format
+     * @param string $format The format string, e.g. '%dh %02dm'
+     * @return string The formatted duration string
+     */
+    public static function formatDuration(CarbonInterval $interval, string $format): string
+    {
+        $interval->cascade();
+        $hours = floor($interval->totalHours);
+        $minutes = $interval->minutes;
+
+        return sprintf($format, $hours, $minutes);
     }
 }

--- a/tests/Unit/Controllers/Admin/UserGoodieControllerTest.php
+++ b/tests/Unit/Controllers/Admin/UserGoodieControllerTest.php
@@ -30,6 +30,7 @@ class UserGoodieControllerTest extends ControllerTest
      */
     public function testIndex(): void
     {
+        $this->mockTranslator();
         $this->config->set('goodie_type', GoodieType::Tshirt->value);
         $this->config->set('night_shifts', ['enabled' => false]);
         $request = $this->request->withAttribute('user_id', 1);

--- a/tests/Unit/Helpers/CarbonTest.php
+++ b/tests/Unit/Helpers/CarbonTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Engelsystem\Test\Unit\Helpers;
 
+use Carbon\CarbonInterval;
 use Engelsystem\Helpers\Carbon;
-use PHPUnit\Framework\TestCase;
+use Engelsystem\Test\Unit\TestCase;
 use Traversable;
 
 class CarbonTest extends TestCase
@@ -26,6 +27,14 @@ class CarbonTest extends TestCase
         yield '16.04.2022 11:24' => ['16.04.2022 11:24'];
     }
 
+    public function durations(): Traversable
+    {
+        yield '0h 00m' => [CarbonInterval::seconds(0), '0h 00m'];
+        yield '1h 00m' => [CarbonInterval::minutes(60), '1h 00m'];
+        yield '25h 42m' => [CarbonInterval::days(1)->addHours(1)->addMinutes(42), '25h 42m'];
+        yield '277h 46m' => [CarbonInterval::seconds(1_000_000), '277h 46m'];
+    }
+
     /**
      * @covers \Engelsystem\Helpers\Carbon::createFromDatetime
      * @dataProvider validDates
@@ -44,5 +53,15 @@ class CarbonTest extends TestCase
     {
         $date = Carbon::createFromDatetime($value);
         self::assertNull($date);
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Carbon::formatDuration
+     * @dataProvider durations
+     */
+    public function testFormatDuration(CarbonInterval $value, string $expected): void
+    {
+        $formatted = Carbon::formatDuration($value, '%dh %02dm');
+        self::assertSame($expected, $formatted);
     }
 }


### PR DESCRIPTION
This PR formats the durations on the /user page as duration strings, resolves #1552 

I used CarbonIntervals to format the time, this allows adjusting the format by patching the translations.
I implemented ``%hh %Imin`` (de) and ``%hh %Im`` (en) as defaults as @xuwhite suggested, resulting in:
<img width="623" height="426" alt="grafik" src="https://github.com/user-attachments/assets/57a2224e-3229-4cd5-9a1c-85e51261a9ac" />
<img width="605" height="434" alt="grafik" src="https://github.com/user-attachments/assets/2076cd67-4b5e-4d16-a248-1b76a7eb74cf" />

while still allowing to change the translation to ``%H:%I`` resulting in:
<img width="622" height="429" alt="grafik" src="https://github.com/user-attachments/assets/ac92533b-4d63-4d7b-99b8-357a61da84dd" />

I didn't adjust the Adjust the active angle page, as the format is quite different there, if you want me to adjust it, just let me know.