### PR TITLE
show correct 'Shift ended' text after countdown expires

### DIFF
--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -262,7 +262,7 @@ function User_shift_state_render($user)
             . '</span>';
     }
 
-    return '<span class="text-danger" title="' . $endFormat . '" data-countdown-ts="' . $endTimestamp . '">'
+    return '<span class="text-danger" title="' . $endFormat . '" data-countdown-ts="' . $endTimestamp . '" data-countdown-expired-template="' . htmlspecialchars(__('Shift ended %c'), ENT_QUOTES) . '">'
         . __('Shift ends %c')
         . '</span>';
 }

--- a/resources/assets/js/countdown.js
+++ b/resources/assets/js/countdown.js
@@ -39,9 +39,14 @@ ready(() => {
   document.querySelectorAll('[data-countdown-ts]').forEach((element) => {
     const timestamp = Number(element.dataset.countdownTs);
     const template = element.textContent;
+    const templateExpired = String(element.dataset.countdownExpiredTemplate);
     element.textContent = template.replace('%c', formatFromNow(timestamp));
     setInterval(() => {
-      element.textContent = template.replace('%c', formatFromNow(timestamp));
+      if (templateExpired !== 'undefined' && Date.now() / 1000 >= timestamp) {
+        element.textContent = templateExpired.replace('%c', formatFromNow(timestamp));
+      } else {
+        element.textContent = template.replace('%c', formatFromNow(timestamp));
+      }
     }, 1000);
   });
 });


### PR DESCRIPTION
Resolves #773 by passing the next template into the elements dataset (``data-countdown-expired-template``) and switching to the new template once the countdown expires **without** reloading.

While I agree, that reloading would work as well, I think it could turn out to be quite annoying if the page reloads while using it.