### PR TITLE
Ignore shifts without angels when populating event days

### DIFF
--- a/includes/controller/locations_controller.php
+++ b/includes/controller/locations_controller.php
@@ -24,10 +24,9 @@ function location_controller(): array
     $request = request();
     $location = load_location();
 
-    $all_shifts = $location->shifts->sortBy('start');
+    $days_list = Days_by_Location_id($location->id);
     $days = [];
-    foreach ($all_shifts as $shift) {
-        $day = $shift->start->format('Y-m-d');
+    foreach ($days_list as $day) {
         if (!isset($days[$day])) {
             $days[$day] = dateWithEventDay($day);
         }


### PR DESCRIPTION
resolves #1351 by checking if shifts need any angle types before adding a day to the array.

It is difficult for me to estimate how computationally expensive this is and if it is worth it. ~It will only be checked each day until the first shift which needs angels is found. But since every call to ``NeededAngelTypes_by_shift()`` will trigger three DB queries, there will be atleast three queries for every day on which this location has as any shifts. And if there is a day with many shifts which don't require any angels, this will trigger many additional DB queries.~