### PR TITLE
replace user state 'arrived' with 'arrival_date NOT NULL'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,7 +45,7 @@ indent_size = 4
 [*.sh]
 indent_size = 2
 
-[{db/*.sql,includes/**}]
+[{db/*.sql,includes/**,*.json}]
 max_line_length = unset
 
 [*.{yml,yaml}]

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         ],
         "phpstan": "phpstan",
         "phpunit": "phpunit",
-        "phpunit:coverage": "phpunit --coverage-text --coverage-html ./public/coverage/"
+        "phpunit:coverage": "php -d memory_limit=-1 vendor/bin/phpunit --coverage-text --coverage-html ./public/coverage/"
     },
     "require": {
         "php": ">=8.2.0",

--- a/db/factories/User/StateFactory.php
+++ b/db/factories/User/StateFactory.php
@@ -20,7 +20,6 @@ class StateFactory extends Factory
 
         return [
             'user_id'      => User::factory(),
-            'arrived'      => (bool) $arrival,
             'arrival_date' => $arrival ? Carbon::instance($arrival) : null,
             'user_info'    => $this->faker->optional(.1)->text(),
             'active'       => $this->faker->boolean(.3),
@@ -39,7 +38,6 @@ class StateFactory extends Factory
         return $this->state(
             function (array $attributes) {
                 return [
-                    'arrived'      => true,
                     'arrival_date' => Carbon::instance($this->faker->dateTimeThisMonth()),
                 ];
             }

--- a/db/migrations/2025_10_19_000000_remove_user_arrived_state.php
+++ b/db/migrations/2025_10_19_000000_remove_user_arrived_state.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder as SchemaBuilder;
+
+class RemoveUserArrivedState extends Migration
+{
+    protected Connection $db;
+
+    public function __construct(SchemaBuilder $schema)
+    {
+        parent::__construct($schema);
+        $this->db = $this->schema->getConnection();
+    }
+
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        $this->schema->table('users_state', function (Blueprint $table): void {
+            $table->dropColumn('arrived');
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        $this->schema->table('users_state', function (Blueprint $table): void {
+            $table->boolean('arrived')->default(false)->after('user_id');
+        });
+        $this->db->table('users_state')
+            ->whereNotNull('arrival_date')
+            ->update(['arrived' => true]);
+    }
+}

--- a/includes/pages/admin_active.php
+++ b/includes/pages/admin_active.php
@@ -83,9 +83,9 @@ function admin_active()
                 ->leftJoin('shift_entries', 'users.id', '=', 'shift_entries.user_id')
                 ->leftJoin('shifts', 'shift_entries.shift_id', '=', 'shifts.id')
                 ->leftJoin('users_state', 'users.id', '=', 'users_state.user_id')
-                ->where('users_state.arrived', '=', true)
+                ->whereNotNull('users_state.arrival_date')
                 ->orWhere(function (EloquentBuilder $userinfo) {
-                    $userinfo->where('users_state.arrived', '=', false)
+                    $userinfo->whereNull('users_state.arrival_date')
                         ->whereNotNull('users_state.user_info')
                         ->whereNot('users_state.user_info', '');
                 })
@@ -209,9 +209,9 @@ function admin_active()
             }
         })
         ->leftJoin('users_state', 'users.id', '=', 'users_state.user_id')
-        ->where('users_state.arrived', '=', true)
+        ->whereNotNull('users_state.arrival_date')
         ->orWhere(function (EloquentBuilder $userinfo) {
-            $userinfo->where('users_state.arrived', '=', false)
+            $userinfo->whereNull('users_state.arrival_date')
                 ->whereNotNull('users_state.user_info')
                 ->whereNot('users_state.user_info', '');
         })

--- a/includes/pages/admin_arrive.php
+++ b/includes/pages/admin_arrive.php
@@ -38,7 +38,6 @@ function admin_arrive()
             $user_id = $request->input('user');
             $user_source = User::find($user_id);
             if ($user_source) {
-                $user_source->state->arrived = false;
                 $user_source->state->arrival_date = null;
                 $user_source->state->save();
 
@@ -57,7 +56,6 @@ function admin_arrive()
             $user_id = $request->input('user');
             $user_source = User::find($user_id);
             if ($user_source) {
-                $user_source->state->arrived = true;
                 $user_source->state->arrival_date = new Carbon\Carbon();
                 $user_source->state->save();
 

--- a/includes/pages/admin_free.php
+++ b/includes/pages/admin_free.php
@@ -50,7 +50,7 @@ function admin_free()
                     ->where('shifts.start', '<', Carbon::now())
                     ->where('shifts.end', '>', Carbon::now());
             })
-            ->where('users_state.arrived', '=', 1)
+            ->whereNotNull('users_state.arrival_date')
             ->whereNull('shifts.id')
             ->orderBy('users.name')
             ->groupBy('users.id');

--- a/includes/pages/admin_user.php
+++ b/includes/pages/admin_user.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Engelsystem\Config\GoodieType;
 use Engelsystem\Http\Validation\Rules\Username;
 use Engelsystem\Models\Group;
@@ -348,7 +349,13 @@ function admin_user()
                     $user_source->state->user_info = $request->postData('userInfo');
                 }
                 if ($admin_arrive) {
-                    $user_source->state->arrived = $request->postData('arrive');
+                    if ($user_source->state->arrived != $request->postData('arrive')) {
+                        if ($request->postData('arrive')) {
+                            $user_source->state->arrival_date = new Carbon();
+                        } else {
+                            $user_source->state->arrival_date = null;
+                        }
+                    }
                 }
 
                 if ($user_goodie_edit) {

--- a/src/Controllers/Admin/UserGoodieController.php
+++ b/src/Controllers/Admin/UserGoodieController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Engelsystem\Controllers\Admin;
 
+use Carbon\Carbon;
 use Engelsystem\Config\Config;
 use Engelsystem\Config\GoodieType;
 use Engelsystem\Controllers\BaseController;
@@ -84,7 +85,13 @@ class UserGoodieController extends BaseController
         }
 
         if ($this->auth->can('admin_arrive')) {
-            $user->state->arrived = (bool) $data['arrived'];
+            if ($user->state->arrived != (bool) $data['arrived']) {
+                if ((bool) $data['arrived']) {
+                    $user->state->arrival_date = new Carbon();
+                } else {
+                    $user->state->arrival_date = null;
+                }
+            }
         }
 
         $user->state->active = (bool) $data['active'];

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -260,7 +260,6 @@ class OAuthController extends BaseController
             return;
         }
 
-        $userState->arrived = true;
         $userState->arrival_date = new Carbon();
         $userState->save();
 

--- a/src/Factories/User.php
+++ b/src/Factories/User.php
@@ -275,7 +275,6 @@ class User
         $state = new State([]);
 
         if ($this->config->get('autoarrive')) {
-            $state->arrived = true;
             $state->arrival_date = CarbonImmutable::now();
         }
 

--- a/src/Models/User/State.php
+++ b/src/Models/User/State.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Engelsystem\Models\User;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
- * @property bool        $arrived
+ * @property-read bool   $arrived
  * @property Carbon|null $arrival_date
  * @property string|null $user_info
  * @property bool        $active
@@ -36,7 +37,6 @@ class State extends HasUserModel
 
     /** @var array<string, bool|int|null> Default attributes */
     protected $attributes = [ // phpcs:ignore
-        'arrived'      => false,
         'arrival_date' => null,
         'user_info'    => null,
         'active'       => false,
@@ -49,7 +49,6 @@ class State extends HasUserModel
     /** @var array<string, string> */
     protected $casts = [ // phpcs:ignore
         'user_id'      => 'integer',
-        'arrived'      => 'boolean',
         'arrival_date' => 'datetime',
         'active'       => 'boolean',
         'force_active' => 'boolean',
@@ -65,7 +64,6 @@ class State extends HasUserModel
      */
     protected $fillable = [ // phpcs:ignore
         'user_id',
-        'arrived',
         'arrival_date',
         'user_info',
         'active',
@@ -74,4 +72,23 @@ class State extends HasUserModel
         'got_goodie',
         'got_voucher',
     ];
+
+    /**
+     * Accessor: for arrived property
+     * Derived from arrival_date being not null
+     */
+    public function getArrivedAttribute(): bool
+    {
+        return $this->arrival_date !== null;
+    }
+
+    /**
+     * provide WhereArrived query scope
+     */
+    public static function scopeWhereArrived(Builder $query, bool $value): Builder
+    {
+        return $value
+            ? $query->whereNotNull('arrival_date')
+            : $query->whereNull('arrival_date');
+    }
 }

--- a/tests/Unit/Controllers/Admin/UserGoodieControllerTest.php
+++ b/tests/Unit/Controllers/Admin/UserGoodieControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Engelsystem\Test\Unit\Controllers\Admin;
 
+use Carbon\Carbon;
 use Engelsystem\Config\GoodieType;
 use Engelsystem\Controllers\Admin\UserGoodieController;
 use Engelsystem\Helpers\Authenticator;
@@ -125,11 +126,11 @@ class UserGoodieControllerTest extends ControllerTest
             ->create();
 
         $auth
-            ->expects($this->exactly(5))
+            ->expects($this->exactly(6))
             ->method('can')
             ->with('admin_arrive')
-            ->willReturnOnConsecutiveCalls(true, true, false, false, true);
-        $this->setExpects($redirector, 'back', null, $this->response, $this->exactly(5));
+            ->willReturnOnConsecutiveCalls(true, true, false, false, true, true);
+        $this->setExpects($redirector, 'back', null, $this->response, $this->exactly(6));
 
         $controller = new UserGoodieController(
             $auth,
@@ -191,7 +192,7 @@ class UserGoodieControllerTest extends ControllerTest
                 'arrived'    => '1',
             ]);
 
-        $user->state->arrived = false;
+        $user->state->arrival_date = null;
         $user->state->save();
         $this->assertFalse($user->state->arrived);
         $controller->saveGoodie($request);
@@ -219,6 +220,19 @@ class UserGoodieControllerTest extends ControllerTest
         $controller->saveGoodie($request);
         $user = User::find(1);
         $this->assertEquals('XS', $user->personalData->shirt_size);
+
+        // remove arrived
+        $user->state->arrival_date = Carbon::now();
+        $user->state->save();
+        $request = $request
+            ->withParsedBody([
+                'shirt_size' => 'XS',
+                'arrived'    => '',
+            ]);
+
+        $controller->saveGoodie($request);
+        $user = User::find(1);
+        $this->assertFalse($user->state->arrived);
     }
 
     /**

--- a/tests/Unit/Controllers/Metrics/StatsTest.php
+++ b/tests/Unit/Controllers/Metrics/StatsTest.php
@@ -581,17 +581,29 @@ class StatsTest extends TestCase
     {
         $this->addUser();
         $this->addUser([], ['shirt_size' => 'L'], ['email_human' => true, 'email_shiftinfo' => true]);
-        $this->addUser(['arrived' => 1], [], ['email_human' => true, 'email_goodie' => true, 'email_news' => true]);
-        $this->addUser(['arrived' => 1], ['pronoun' => 'unicorn'], ['language' => 'lo_RM', 'email_shiftinfo' => true]);
-        $this->addUser(['arrived' => 1, 'got_voucher' => 2], ['shirt_size' => 'XXL'], ['language' => 'lo_RM']);
         $this->addUser(
-            ['arrived' => 1, 'got_voucher' => 9, 'force_active' => true, 'user_info' => 'Info'],
+            ['arrival_date' => Carbon::now()],
+            [],
+            ['email_human' => true, 'email_goodie' => true, 'email_news' => true]
+        );
+        $this->addUser(
+            ['arrival_date' => Carbon::now()],
+            ['pronoun' => 'unicorn'],
+            ['language' => 'lo_RM', 'email_shiftinfo' => true]
+        );
+        $this->addUser(
+            ['arrival_date' => Carbon::now(), 'got_voucher' => 2],
+            ['shirt_size' => 'XXL'],
+            ['language' => 'lo_RM']
+        );
+        $this->addUser(
+            ['arrival_date' => Carbon::now(), 'got_voucher' => 9, 'force_active' => true, 'user_info' => 'Info'],
             [],
             ['theme' => 1],
             ['drive_car' => true, 'drive_12t' => true, 'drive_confirmed' => true, 'ifsg_certificate_light' => true]
         );
         $this->addUser(
-            ['arrived' => 1, 'got_voucher' => 3, 'force_food' => true],
+            ['arrival_date' => Carbon::now(), 'got_voucher' => 3, 'force_food' => true],
             ['pronoun' => 'per'],
             ['theme' => 1, 'email_human' => true],
             [
@@ -602,9 +614,9 @@ class StatsTest extends TestCase
                 'ifsg_confirmed' => true,
             ]
         );
-        $this->addUser(['arrived' => 1, 'active' => 1, 'got_goodie' => true, 'force_active' => true]);
+        $this->addUser(['arrival_date' => Carbon::now(), 'active' => 1, 'got_goodie' => true, 'force_active' => true]);
         $this->addUser(
-            ['arrived' => 1, 'active' => 1, 'got_goodie' => true, 'force_food' => true],
+            ['arrival_date' => Carbon::now(), 'active' => 1, 'got_goodie' => true, 'force_food' => true],
             ['shirt_size' => 'L'],
             ['theme' => 4]
         );

--- a/tests/Unit/Models/User/UserStateTest.php
+++ b/tests/Unit/Models/User/UserStateTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Models\User;
+
+use Carbon\Carbon;
+use Engelsystem\Models\User\State;
+use Engelsystem\Test\Unit\Models\ModelTest;
+
+class UserStateTest extends ModelTest
+{
+    /**
+     * @covers \Engelsystem\Models\User\State::getArrivedAttribute
+     */
+    public function testGetArrivedAttribute(): void
+    {
+        $state = new State();
+        $this->assertFalse($state->arrived);
+
+        $state->arrival_date = Carbon::now();
+        $this->assertTrue($state->arrived);
+    }
+
+    /**
+     * @covers \Engelsystem\Models\User\State::scopeWhereArrived
+     */
+    public function testScopeWhereArrived(): void
+    {
+        $state = State::factory()->create([
+            'arrival_date' => null,
+        ]);
+        $this->assertCount(0, State::whereArrived(true)->get());
+        $this->assertCount(1, State::whereArrived(false)->get());
+
+        $state->arrival_date = Carbon::now();
+        $state->save();
+        $this->assertCount(1, State::whereArrived(true)->get());
+        $this->assertCount(0, State::whereArrived(false)->get());
+    }
+}


### PR DESCRIPTION
resolves #1560 by removing ``arrived`` column from ``users_state`` table and adding readonly property ``arrived`` to the model class to keep read access intact.
I also removed all write accesses to the property and replace them with ``arrival_date`` where needed.

I added ``UserStateTest`` to cover the two new functions in the ``State`` class and keep coverage at 100%