### PR TITLE
translate "Ask the Heaven" menu item in additional.po

### DIFF
--- a/includes/sys_menu.php
+++ b/includes/sys_menu.php
@@ -48,7 +48,7 @@ function make_navigation(): array
         'user_shifts'    => 'general.shifts',
         'angeltypes'     => 'angeltypes.angeltypes',
         'locations'      => ['location.locations', 'locations.view'],
-        'questions'      => ['Ask the Heaven', 'question.add'],
+        'questions'      => ['question.menu', 'question.add'],
     ];
 
     foreach ($pages as $menu_page => $options) {

--- a/resources/lang/de_DE/additional.po
+++ b/resources/lang/de_DE/additional.po
@@ -192,6 +192,9 @@ msgstr "FAQ Eintrag erfolgreich gelöscht."
 msgid "faq.edit.success"
 msgstr "FAQ Eintrag erfolgreich aktualisiert."
 
+msgid "question.menu"
+msgstr "Frag den Himmel"
+
 msgid "question.delete.success"
 msgstr "Frage erfolgreich gelöscht."
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -716,9 +716,6 @@ msgstr "Gib bitte einen Schwänz-Kommentar ein!"
 msgid "Shift saved."
 msgstr "Schicht gespeichert."
 
-msgid "Ask the Heaven"
-msgstr "Frag den Himmel"
-
 msgid "The administration has not configured any locations yet."
 msgstr "Die Administratoren habe noch keine Orte eingerichtet."
 

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -191,6 +191,9 @@ msgstr "FAQ entry successfully deleted."
 msgid "faq.edit.success"
 msgstr "FAQ entry successfully updated."
 
+msgid "question.menu"
+msgstr "Ask the Heaven"
+
 msgid "question.delete.success"
 msgstr "Question deleted successfully."
 


### PR DESCRIPTION
resolves #1556 by replacing the reference with ``question.menu`` and adding ''Ask the Heaven" to en and de ``additional.po``

I moved the translation to ``additional.po`` as the string is **not** auto-detected and, from my understanding (which might be very wrong), does therefore not belong in the ``default.po``, where it was until now in the german translation.