### PR TITLE
composer: set memory_limit=-1 for phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
             "phpcbf -p"
         ],
         "phpstan": "phpstan",
-        "phpunit": "phpunit",
+        "phpunit": "php -d memory_limit=-1 vendor/bin/phpunit",
         "phpunit:coverage": "php -d memory_limit=-1 vendor/bin/phpunit --coverage-text --coverage-html ./public/coverage/"
     },
     "require": {


### PR DESCRIPTION
I ran into the same memory problem with ``phpunit`` as with ``phpunit:coverage``

This resolves the issue.