### PR TITLE
trigger password reset mail from admin_user.php

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -58,6 +58,7 @@ $route->addGroup(
             $route->get('/certificates', 'Admin\\UserSettingsController@certificate');
             $route->post('/certificates/ifsg', 'Admin\\UserSettingsController@saveIfsgCertificate');
             $route->post('/certificates/driving', 'Admin\\UserSettingsController@saveDrivingLicense');
+            $route->post('/password/reset', 'PasswordResetController@postResetByUserId');
     }
 );
 

--- a/includes/pages/admin_user.php
+++ b/includes/pages/admin_user.php
@@ -197,9 +197,23 @@ function admin_user()
             . '</td></tr>' . "\n";
 
         $html .= '</table>' . "\n" . '<br>' . "\n";
-        $html .= '<button type="submit" class="btn btn-primary">'
-            . icon('save') . __('form.save') . '</button>' . "\n";
         $html .= '</form>';
+
+        $html .= '<div class="row justify-content-start">';
+        $html .= '<div class="col-sm-auto">';
+        $html .= '<button type="submit" form="change_password" class="btn btn-primary">'
+            . icon('save') . __('form.save') . '</button>' . "\n";
+        $html .= '</div>';
+        $html .= '<form class="col-sm-auto" action="'
+            . url('/users/' . $user_id . '/password/reset')
+            . '" method="post">' . "\n";
+        $html .= form_csrf();
+        $html .= '<button type="submit" class="btn btn-warning">'
+            . icon('envelope-at')
+            . __('password.recovery.send')
+            . '</button>';
+        $html .= '</form>';
+        $html .= '</div>';
 
         $html .= '<hr>';
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -149,12 +149,18 @@ msgstr "Informiere Dich über die Tätigkeiten bei denen Du uns helfen kannst."
 msgid "login.cookies"
 msgstr "Hinweis: Cookies müssen aktiviert sein!"
 
+msgid "password.recovery.send"
+msgstr "Passwort-zurücksetzen E-mail senden"
+
 msgid "password.reset.confirm"
 msgstr "Passwort wiederholen"
 
 msgid "password.recovery.success"
 msgstr ""
 "Wir haben dir eine E-Mail mit einem Link zum Passwort-zurücksetzen geschickt."
+
+msgid "password.recovery.success.admin"
+msgstr "Passwort-zurücksetzen E-mail versendet."
 
 msgid "password.reset.title"
 msgstr "Passwort wiederherstellen"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -1093,11 +1093,17 @@ msgstr "Angel"
 msgid "title.date"
 msgstr "Date"
 
+msgid "password.recovery.send"
+msgstr "Send password recovery e-mail"
+
 msgid "password.reset.confirm"
 msgstr "Confirm password"
 
 msgid "password.recovery.success"
 msgstr "We sent you an e-mail containing your password recovery link."
+
+msgid "password.recovery.success.admin"
+msgstr "Password recovery e-mail sent."
 
 msgid "password.reset.title"
 msgstr "Password recovery"

--- a/src/Controllers/PasswordResetController.php
+++ b/src/Controllers/PasswordResetController.php
@@ -11,6 +11,7 @@ use Engelsystem\Mail\EngelsystemMailer;
 use Engelsystem\Models\User\PasswordReset;
 use Engelsystem\Models\User\User;
 use Psr\Log\LoggerInterface;
+use Random\RandomException;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class PasswordResetController extends BaseController
@@ -23,6 +24,7 @@ class PasswordResetController extends BaseController
         'postReset'         => 'login',
         'resetPassword'     => 'login',
         'postResetPassword' => 'login',
+        'postResetByUserId' => 'admin_user',
     ];
 
     public function __construct(
@@ -47,22 +49,7 @@ class PasswordResetController extends BaseController
         /** @var User $user */
         $user = User::whereEmail($data['email'])->first();
         if ($user) {
-            $reset = (new PasswordReset())->findOrNew($user->id);
-            $reset->user_id = $user->id;
-            $reset->token = bin2hex(random_bytes(16));
-            $reset->save();
-
-            $this->log->info(
-                sprintf('Password recovery for %s (%u)', $user->name, $user->id),
-                ['user' => $user->toJson()]
-            );
-
-            $this->mail->sendViewTranslated(
-                $user,
-                'Password recovery',
-                'emails/password-reset',
-                ['username' => $user->displayName, 'reset' => $reset]
-            );
+            $this->triggerPasswordReset($user);
         }
 
         return $this->showView('pages/password/reset-success', ['type' => 'email']);
@@ -118,5 +105,40 @@ class PasswordResetController extends BaseController
         }
 
         return $reset;
+    }
+
+    public function postResetByUserId(Request $request): Response
+    {
+        $userId = $request->getAttribute('user_id');
+        $requestUser = User::findOrFail($userId);
+        $this->triggerPasswordReset($requestUser);
+        $this->addNotification(__('password.recovery.success.admin'), NotificationType::INFORMATION);
+        return back();
+    }
+
+    /**
+     * Trigger a password reset for the given user. This will email the user!
+     *
+     * @param User $user The user to trigger the password reset for.
+     * @throws RandomException
+     */
+    private function triggerPasswordReset(User $user): void
+    {
+        $reset = (new PasswordReset())->findOrNew($user->id);
+        $reset->user_id = $user->id;
+        $reset->token = bin2hex(random_bytes(16));
+        $reset->save();
+
+        $this->log->info(
+            sprintf('Password recovery for %s (%u)', $user->name, $user->id),
+            ['user' => $user->toJson()]
+        );
+
+        $this->mail->sendViewTranslated(
+            $user,
+            'password.reset.title',
+            'emails/password-reset',
+            ['username' => $user->displayName, 'reset' => $reset]
+        );
     }
 }

--- a/tests/Unit/Controllers/PasswordResetControllerTest.php
+++ b/tests/Unit/Controllers/PasswordResetControllerTest.php
@@ -10,6 +10,7 @@ use Engelsystem\Controllers\PasswordResetController;
 use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Exceptions\HttpNotFound;
 use Engelsystem\Http\Exceptions\ValidationException;
+use Engelsystem\Http\Redirector;
 use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
 use Engelsystem\Http\Validation\Validator;
@@ -22,6 +23,7 @@ use Engelsystem\Test\Unit\HasDatabase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Psr\Log\Test\TestLogger;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -33,6 +35,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 #[CoversMethod(PasswordResetController::class, 'requireToken')]
 #[CoversMethod(PasswordResetController::class, 'postResetPassword')]
 #[CoversMethod(PasswordResetController::class, 'showView')]
+#[CoversMethod(PasswordResetController::class, 'postResetByUserId')]
+#[CoversMethod(PasswordResetController::class, 'triggerPasswordReset')]
 #[AllowMockObjectsWithoutExpectations]
 class PasswordResetControllerTest extends ControllerTestCase
 {
@@ -60,7 +64,10 @@ class PasswordResetControllerTest extends ControllerTestCase
         );
         /** @var TestLogger $log */
         $log = $this->args['log'];
+        $this->app->instance(LoggerInterface::class, $log);
+        /** @var EngelsystemMailer|MockObject $mailer */
         $mailer = $this->args['mailer'];
+        $this->app->instance(EngelsystemMailer::class, $mailer);
         $this->setExpects($mailer, 'sendViewTranslated');
 
         $controller->postReset($request);
@@ -173,6 +180,32 @@ class PasswordResetControllerTest extends ControllerTestCase
 
         $controller->postResetPassword($request);
         $this->assertHasNotification('validation.password.confirmed', NotificationType::ERROR);
+    }
+
+    public function testPostResetByUserId(): void
+    {
+        $this->initDatabase();
+        $this->stubTranslator();
+        $redirect = $this->createMock(Redirector::class);
+        $this->app->instance('redirect', $redirect);
+
+        $user = $this->createUser();
+        $request = new Request([], [], ['user_id' => $user->id]);
+
+        $controller = $this->getController();
+        /** @var TestLogger $log */
+        $log = $this->args['log'];
+        $this->app->instance(LoggerInterface::class, $log);
+        /** @var EngelsystemMailer|MockObject $mailer */
+        $mailer = $this->args['mailer'];
+        $this->app->instance(EngelsystemMailer::class, $mailer);
+        $this->setExpects($mailer, 'sendViewTranslated');
+
+        $controller->postResetByUserId($request);
+
+        $this->assertNotEmpty((new PasswordReset())->find($user->id)->first());
+        $this->assertTrue($log->hasInfoThatContains($user->name));
+        $this->assertHasNoNotifications();
     }
 
     protected function getControllerArgs(): array


### PR DESCRIPTION
This PR allows to trigger the mail based password reset flow from the admin_user.php edit page:
<img width="574" height="213" alt="grafik" src="https://github.com/user-attachments/assets/d231bb6e-1292-4d98-b23c-2bbde9d1c28c" />

I moved the existing logic used in the "I forgot my password" flow into the newly created ``PasswordReset`` helper.

- Should this button honor the ``email_human`` setting and only be visible when the user opted-in?
  - currently it is always visible.
- Should there be a confirmation dialog to prevent sending accidental mails?
  - currently this is a one-click action