### PR TITLE
Limit the height of the angel list in the myshifts view

### DIFF
--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -346,6 +346,8 @@ function User_view_myshift(Shift $shift, $user_source, $its_me, $supporter)
         $shift_info .= User_view_shiftentries($needed_angel_type);
     }
 
+    $shift_info = div('table-myshifts-shift-info-limit-height', $shift_info);
+
     $night_shift = '';
     if ($shift->isNightShift() && $goodie_enabled) {
         $night_shift = render_night_shift_hint($nightShiftsConfig);

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -307,6 +307,17 @@ table.table-sticky-header thead {
   text-align: right;
 }
 
+.column_shift_info:not(:hover) .table-myshifts-shift-info-limit-height {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+  overflow: hidden;
+
+  @media (min-width: map-get($grid-breakpoints, 'lg')) {
+    -webkit-line-clamp: 4;
+  }
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
Resolves #1487 by limiting the height of the shift-info column to 4 lines (6 on smaller screens). When hovering the cell expands just as in the shift calendar view.

<img width="911" height="728" alt="image" src="https://github.com/user-attachments/assets/65e8a84d-3591-4245-bade-96ae5f67142c" />


Note on the implementation: While there is a vendor prefix of `-webkit` it should work in all the browsers: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/line-clamp#browser_compatibility
