### PR TITLE
Remove /stats

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -14,7 +14,7 @@ return [
         'password' => env_secret('MYSQL_PASSWORD', ''),
     ],
 
-    // For accessing /metrics (and /stats)
+    // For accessing /metrics
     'api_key'                 => env('API_KEY', ''),
 
     // Enable maintenance mode (show a static page to all users)

--- a/config/routes.php
+++ b/config/routes.php
@@ -72,9 +72,8 @@ $route->addGroup(
     }
 );
 
-// Stats
+// Metrics
 $route->get('/metrics', 'Metrics\\Controller@metrics');
-$route->get('/stats', 'Metrics\\Controller@stats');
 
 // Angeltypes
 $route->addGroup('/angeltypes', function (RouteCollector $route): void {

--- a/src/Controllers/Metrics/Controller.php
+++ b/src/Controllers/Metrics/Controller.php
@@ -235,41 +235,17 @@ class Controller extends BaseController
             ->withContent($this->engine->get('/metrics', $data));
     }
 
-    public function stats(): Response
-    {
-        $this->checkAuth(true);
-
-        $data = [
-            'user_count'         => $this->stats->usersState() + $this->stats->usersState(null, false),
-            'arrived_user_count' => $this->stats->usersState(),
-            'done_work_hours'    => round($this->stats->workSeconds(true) / 60 / 60),
-            'users_in_action'    => $this->stats->currentlyWorkingUsers(),
-        ];
-
-        return $this->response
-            ->withHeader('Content-Type', 'application/json')
-            ->withContent(json_encode($data));
-    }
-
     /**
      * Ensure that the request is authorized
      */
-    protected function checkAuth(bool $isJson = false): void
+    protected function checkAuth(): void
     {
         $apiKey = $this->config->get('api_key');
         if (empty($apiKey) || $this->request->get('api_key') == $apiKey) {
             return;
         }
 
-        $message = 'The api_key is invalid';
-        $headers = [];
-
-        if ($isJson) {
-            $message = json_encode(['error' => $message]);
-            $headers['Content-Type'] = 'application/json';
-        }
-
-        throw new HttpForbidden($message, $headers);
+        throw new HttpForbidden('The api_key is invalid');
     }
 
     /**

--- a/src/Middleware/ApiRouteHandler.php
+++ b/src/Middleware/ApiRouteHandler.php
@@ -29,7 +29,6 @@ class ApiRouteHandler implements MiddlewareInterface
             '/ical',
             '/metrics',
             '/shifts-json-export',
-            '/stats',
         ]
     ) {
     }

--- a/tests/Unit/Controllers/Metrics/ControllerTest.php
+++ b/tests/Unit/Controllers/Metrics/ControllerTest.php
@@ -27,6 +27,7 @@ class ControllerTest extends TestCase
      * @covers \Engelsystem\Controllers\Metrics\Controller::__construct
      * @covers \Engelsystem\Controllers\Metrics\Controller::metrics
      * @covers \Engelsystem\Controllers\Metrics\Controller::formatStats
+     * @covers \Engelsystem\Controllers\Metrics\Controller::checkAuth
      */
     public function testMetrics(): void
     {
@@ -195,52 +196,6 @@ class ControllerTest extends TestCase
 
     /**
      * @covers \Engelsystem\Controllers\Metrics\Controller::checkAuth
-     * @covers \Engelsystem\Controllers\Metrics\Controller::stats
-     */
-    public function testStats(): void
-    {
-        /** @var Response|MockObject $response */
-        /** @var Request|MockObject $request */
-        /** @var MetricsEngine|MockObject $engine */
-        /** @var Stats|MockObject $stats */
-        /** @var Config $config */
-        /** @var Version|MockObject $version */
-        list($response, $request, $engine, $stats, $config, $version) = $this->getMocks();
-
-        $response->expects($this->once())
-            ->method('withHeader')
-            ->with('Content-Type', 'application/json')
-            ->willReturn($response);
-        $response->expects($this->once())
-            ->method('withContent')
-            ->with(json_encode([
-                'user_count'         => 20,
-                'arrived_user_count' => 10,
-                'done_work_hours'    => 99,
-                'users_in_action'    => 5,
-            ]))
-            ->willReturn($response);
-
-        $request->expects($this->once())
-            ->method('get')
-            ->with('api_key')
-            ->willReturn('ApiKey987');
-
-        $config->set('api_key', 'ApiKey987');
-
-        $stats->expects($this->once())
-            ->method('workSeconds')
-            ->with(true)
-            ->willReturn((int) (60 * 60 * 99.47));
-        $this->setExpects($stats, 'usersState', null, 10, $this->exactly(3));
-        $this->setExpects($stats, 'currentlyWorkingUsers', null, 5);
-
-        $controller = new Controller($response, $engine, $config, $request, $stats, $version);
-        $controller->stats();
-    }
-
-    /**
-     * @covers \Engelsystem\Controllers\Metrics\Controller::checkAuth
      */
     public function testCheckAuth(): void
     {
@@ -262,8 +217,8 @@ class ControllerTest extends TestCase
         $controller = new Controller($response, $engine, $config, $request, $stats, $version);
 
         $this->expectException(HttpForbidden::class);
-        $this->expectExceptionMessage(json_encode(['error' => 'The api_key is invalid']));
-        $controller->stats();
+        $this->expectExceptionMessage('The api_key is invalid');
+        $controller->metrics();
     }
 
     protected function getMocks(): array


### PR DESCRIPTION
Removes the legacy `/stats` endpoint as much more granular metrics are available via `/metrics`