### PR TITLE
tests: Make GoodieTests run successful with disabled night-shifts in config.php

### DIFF
--- a/tests/Feature/Helpers/GoodieTest.php
+++ b/tests/Feature/Helpers/GoodieTest.php
@@ -91,15 +91,14 @@ class GoodieTest extends ApplicationFeatureTest
         parent::setUp();
 
         $this->createdModels = [];
-        config(
-            'night_shifts',
-            [
+        config([
+            'night_shifts' => [
                 'enabled' => true,
                 'start' => 2,
                 'end' => 6,
                 'multiplier' => 2,
-            ]
-        );
+            ],
+        ]);
     }
 
     public function tearDown(): void


### PR DESCRIPTION
This PR makes GoodieTests run successful even in situations when night-shifts are disabled in the main config.php.
The reason for failing tests is/was the non-correct usage of the config() function.