### PR TITLE
oauth: Implement a config flag to disable disconnecting from provider

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -138,6 +138,8 @@ return [
             'enable_password' => false,
             // Allow registration even if disabled in config (optional)
             'allow_registration' => null,
+            // Allow disconnecting user accounts from the oauth provider (optional)
+            'allow_user_disconnect' => true,
             // Auto join teams
             // Info groups field (optional)
             'groups' => 'groups',

--- a/resources/views/pages/settings/oauth.twig
+++ b/resources/views/pages/settings/oauth.twig
@@ -37,7 +37,7 @@
 
                         {{ f.submit(__('form.connect'), {'size' : 'sm', 'icon_left': 'box-arrow-in-right'}) }}
                     </form>
-                {% else %}
+                {% elseif config.allow_user_disconnect is not defined or config.allow_user_disconnect %}
                     <form method="post" action="{{ url('/oauth/' ~ name ~ '/disconnect') }}">
                         {{ csrf() }}
 

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -194,6 +194,12 @@ class OAuthController extends BaseController
     {
         $providerName = $request->getAttribute('provider');
 
+        $this->requireProvider($providerName);
+
+        if (!($this->config->get('oauth')[$providerName]['allow_user_disconnect'] ?? true)) {
+            throw new HttpNotFound();
+        }
+
         $this->oauth
             ->whereUserId($this->auth->user()->id)
             ->where('provider', $providerName)


### PR DESCRIPTION
This PR implements a per-provider option to restrict disconnecting user accounts from the provider.

In our setup we have a single SSO provider that is to handle all authentication; allowing users to disconnect individual accounts from SSO does not make sense in our use case.