### PR TITLE
Improve English translations

### DIFF
--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -41,8 +41,8 @@ msgstr "Please enter your nick."
 
 msgid "validation.username.username"
 msgstr ""
-"Please enter a valid nick:"
-"Use up to 24 letters, numbers or connecting punctuations (.-_) for your nickname."
+"Please enter a valid nick: "
+"Use up to 24 letters, numbers, or connecting punctuation (. - _) for your nickname."
 
 msgid "validation.email.required"
 msgstr "The e-mail address is required."
@@ -54,7 +54,7 @@ msgid "validation.new_password.length"
 msgstr "Your new password is too short."
 
 msgid "validation.password.confirmed"
-msgstr "Your passwords are not equal."
+msgstr "Your passwords do not match."
 
 msgid "validation.password_confirmation.required"
 msgstr "You have to confirm your password."
@@ -69,7 +69,7 @@ msgid "validation.planned_arrival_date.required"
 msgstr "Please enter your planned date of arrival."
 
 msgid "validation.planned_arrival_date.min"
-msgstr "The planned date of arrival must not be before the buil-up start date."
+msgstr "The planned date of arrival must not be before the build-up start date."
 
 msgid "validation.planned_arrival_date.between"
 msgstr "The planned date of arrival must be between the build-up and tear-down date."
@@ -96,13 +96,13 @@ msgid "validation.schedule-url.required"
 msgstr "The schedule URL is required."
 
 msgid "validation.schedule-url.url"
-msgstr "The schedule URL needs to be of type URL."
+msgstr "The schedule URL must be a valid URL."
 
 msgid "validation.shift-type.required"
 msgstr "The shift type is required."
 
 msgid "validation.shift-type.int"
-msgstr "The shift type has to ba a number."
+msgstr "The shift type has to be a number."
 
 msgid "validation.minutes-before.int"
 msgstr "The minutes before the talk have to be an integer."
@@ -117,7 +117,7 @@ msgid "news.comment-delete.success"
 msgstr "Comment successfully deleted."
 
 msgid "news.edit.duplicate"
-msgstr "This news has already been created."
+msgstr "This news item has already been created."
 
 msgid "news.edit.success"
 msgstr "News successfully updated."
@@ -192,7 +192,7 @@ msgid "faq.edit.success"
 msgstr "FAQ entry successfully updated."
 
 msgid "question.menu"
-msgstr "Ask the Heaven"
+msgstr "Ask Heaven"
 
 msgid "question.delete.success"
 msgstr "Question deleted successfully."
@@ -204,7 +204,7 @@ msgid "question.edit.success"
 msgstr "Question updated successfully."
 
 msgid "tag.edit.duplicate"
-msgstr "A tag with the name already exists!"
+msgstr "A tag with this name already exists!"
 
 msgid "tag.edit.success"
 msgstr "Tag updated successfully."
@@ -216,19 +216,19 @@ msgid "notification.news.new"
 msgstr "New news: %s"
 
 msgid "notification.news.new.introduction"
-msgstr "A new news is available: %1$s"
+msgstr "A news item is available: %1$s"
 
 msgid "notification.news.new.text"
 msgstr "You can view it at %3$s"
 
 msgid "notification.news.updated"
-msgstr "Updated News: %s"
+msgstr "Updated news: %s"
 
 msgid "notification.messages.new"
 msgstr "New private message from %s"
 
 msgid "notification.messages.new.text"
-msgstr "you've got a new private message from \"%s\". You can view it at %s"
+msgstr "You've got a new private message from \"%s\". You can view it at %s"
 
 msgid "notification.angeltype.confirmed"
 msgstr "You have been confirmed as an %s"
@@ -252,10 +252,10 @@ msgid "angeltype.add.success"
 msgstr "Successfully joined angel type"
 
 msgid "notification.shift.deleted"
-msgstr "Your Shift was deleted"
+msgstr "Your shift was deleted"
 
 msgid "notification.shift.deleted.introduction"
-msgstr "A Shift you are registered on was deleted:"
+msgstr "A shift you are registered for was deleted:"
 
 msgid "notification.shift.deleted.worklog"
 msgstr ""
@@ -299,10 +299,10 @@ msgid "shifttype.delete.success"
 msgstr "Shift type successfully deleted."
 
 msgid "validation.name.exists"
-msgstr "The name is already used."
+msgstr "The name is already in use."
 
 msgid "registration.disabled"
-msgstr "The registration is disabled."
+msgstr "Registration is disabled."
 
 msgid "registration.successful.supporter"
 msgstr "Registration successful."
@@ -320,7 +320,7 @@ msgid "jwt.wrong_format"
 msgstr "The opened link is not complete"
 
 msgid "jwt.code_error"
-msgstr "The opened link has some problems"
+msgstr "The link is invalid or corrupted"
 
 msgid "config.event"
 msgstr "Event"
@@ -397,7 +397,7 @@ msgid "config.display_full_name"
 msgstr "Display full name"
 
 msgid "config.display_full_name.info"
-msgstr "Show a users first name and last name instead of username"
+msgstr "Show a user's first name and last name instead of username"
 
 msgid "config.enable_pronoun"
 msgstr "Pronouns"
@@ -412,13 +412,13 @@ msgid "config.enable_force_active"
 msgstr "Force active"
 
 msgid "config.enable_force_active.info"
-msgstr "Allows to enforce goodies"
+msgstr "Allows enforcing goodies"
 
 msgid "config.enable_force_food"
 msgstr "Unlimited food vouchers"
 
 msgid "config.enable_force_food.info"
-msgstr "Allows to get unlimited food vouchers"
+msgstr "Allows getting unlimited food vouchers"
 
 msgid "config.enable_voucher"
 msgstr "(Food-) vouchers"
@@ -463,7 +463,7 @@ msgid "config.join_qr_code"
 msgstr "Join QR code"
 
 msgid "config.join_qr_code.info"
-msgstr "Allow joining angel type via generated QR code, requires app_key"
+msgstr "Allow joining an angel type via generated QR code, requires app_key"
 
 msgid "config.certificates"
 msgstr "Certificates"
@@ -489,7 +489,7 @@ msgstr "Sign up after start"
 msgid "config.signup_post_minutes.info"
 msgstr ""
 "Allow shift signup this number of minutes after start of shift. "
-"If \"Sign up after start fraction\" is set, it's first applied before adding the number of minutes specified here."
+"If \"Sign up after start fraction\" is set, it is applied first before adding the number of minutes specified here."
 
 msgid "config.signup_post_fraction"
 msgstr "Sign up after start fraction"
@@ -497,14 +497,14 @@ msgstr "Sign up after start fraction"
 msgid "config.signup_post_fraction.info"
 msgstr ""
 "Allow sign up this fraction of the shift length after the start of the shift. "
-"If its 1, sign up is allowed until end of shift, 0.5 means first half of the shift. "
-"If \"Sign up minutes after start\" is set, this is first applied and then the minutes added on top."
+"If it's 1, sign up is allowed until the end of the shift; 0.5 means the first half of the shift. "
+"If \"Sign up minutes after start\" is set, this is applied first and then the minutes are added on top."
 
 msgid "config.last_unsubscribe"
 msgstr "Last unsubscribe"
 
 msgid "config.last_unsubscribe.info"
-msgstr "Number of hours that a user can sign out of own shifts beforehand"
+msgstr "Number of hours that a user can sign out of their own shifts beforehand"
 
 msgid "config.max_freeloadable_shifts"
 msgstr "Maximum freeloadable shifts"
@@ -545,7 +545,7 @@ msgid "config.night_shifts.start"
 msgstr "Night shifts start hour"
 
 msgid "config.night_shifts.end"
-msgstr "Night shifts end (without including hour)"
+msgstr "Night shifts end hour (exclusive)"
 
 msgid "config.night_shifts.multiplier"
 msgstr "Night shifts multiplier"
@@ -664,7 +664,7 @@ msgid "config.display_news"
 msgstr "Displayed news"
 
 msgid "config.display_news.info"
-msgstr "Number of news shown on one site and for feed readers"
+msgstr "Number of news items shown on one page and for feed readers"
 
 msgid "config.display_users"
 msgstr "Displayed users"
@@ -682,7 +682,7 @@ msgid "config.password_min_length"
 msgstr "Minimum password length"
 
 msgid "config.enable_password"
-msgstr "Passwort"
+msgstr "Password"
 
 msgid "config.enable_password.info"
 msgstr ""
@@ -766,8 +766,8 @@ msgstr "Username filter regex"
 
 msgid "config.username_regex.info"
 msgstr ""
-"Regular expression describing a FALSE username. "
-"Per default usernames must only contain alphanumeric chars, \"-\", \"_\" or \".\"."
+"Regular expression describing an invalid username. "
+"By default, usernames must only contain alphanumeric characters, \"-\", \"_\", or \".\"."
 
 msgid "config.disabled_user_view_columns"
 msgstr "Hidden user table columns"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -17,7 +17,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 
 msgid "auth.password.error"
-msgstr "Your password is incorrect. Please try it again."
+msgstr "Your password is incorrect. Please try again."
 
 msgid "form.submit"
 msgstr "Submit"
@@ -146,7 +146,7 @@ msgid "form.tags"
 msgstr "Tags"
 
 msgid "form.tags.info"
-msgstr "Comma seperated list of tags"
+msgstr "Comma-separated list of tags"
 
 msgid "schedule.import"
 msgstr "Import schedule"
@@ -164,7 +164,7 @@ msgid "schedule.last_update"
 msgstr "Last updated: %s"
 
 msgid "schedule.import.text"
-msgstr "Imports create locations and create, update and delete shifts according to a schedule.xml export."
+msgstr "Imports create locations and create, update, or delete shifts according to a schedule.xml export."
 
 msgid "schedule.import.load.title"
 msgstr "Import schedule: Preview"
@@ -293,7 +293,7 @@ msgid "log.log"
 msgstr "Logs"
 
 msgid "log.only_own"
-msgstr "You can view your own logs. The logs of other users can be checked by bureaucrats."
+msgstr "You can view your own logs. Logs of other users are visible to bureaucrats."
 
 msgid "log.time"
 msgstr "Time"
@@ -338,7 +338,7 @@ msgid "settings.profile.mobile"
 msgstr "Mobile"
 
 msgid "settings.profile.mobile_show"
-msgstr "Show mobile number to other users to contact me."
+msgstr "Show my mobile number to other users."
 
 msgid "settings.profile.email-preferences"
 msgstr "E-mail preferences"
@@ -350,11 +350,11 @@ msgid "settings.profile.email.already-taken"
 msgstr "This e-mail address is already taken."
 
 msgid "settings.profile.email_shiftinfo"
-msgstr "The %s is allowed to send me an e-mail (e.g. when my shifts change)."
+msgstr "The %s may send me e-mails (e.g., when my shifts change)."
 
 msgid "registration.email_system"
-msgstr "The %s is allowed to send me an e-mail "
-"(e.g. when my shifts change, on new private messages or there is new news)."
+msgstr "The %s may send me e-mails "
+"(e.g., when my shifts change, on new private messages, or when there is new news)."
 
 msgid "registration.email_system.info"
 msgstr "Detailed preferences can be set in your profile."
@@ -366,7 +366,7 @@ msgid "settings.profile.email_messages"
 msgstr "Notify me on new private messages."
 
 msgid "settings.profile.email_by_human_allowed"
-msgstr "Allow heaven angels to contact me by e-mail."
+msgstr "Allow Heaven Angels to contact me by e-mail."
 
 msgid "settings.profile.email_goodie"
 msgstr "To possibly receive vouchers for the next similar event, I consent "
@@ -391,7 +391,7 @@ msgid "settings.profile.shirt.link"
 msgstr "More information"
 
 msgid "settings.profile.angeltypes.info"
-msgstr "You can manage your angel types <a href=\"%s\">on the angel types page</a>."
+msgstr "You can manage your angel types <a href=\"%s\">here</a>."
 
 msgid "profile.my_shifts"
 msgstr "My shifts"
@@ -477,20 +477,20 @@ msgid "settings.certificates.drive_forklift"
 msgstr "Forklift"
 
 msgid "settings.certificates.ifsg_light"
-msgstr "I was instructed about IfSG §43 (aka Frikadellendiplom light) on site."
+msgstr "I received onsite instruction about IfSG §43 (Frikadellendiplom light / basic food hygiene certificate)."
 
 msgid "settings.certificates.ifsg_light_admin"
-msgstr "Was instructed about IfSG §43 (aka Frikadellendiplom light) on site."
+msgstr "Received onsite instruction about IfSG §43 (Frikadellendiplom light / basic food hygiene certificate)."
 
 msgid "settings.certificates.ifsg"
-msgstr "I have gotten the instruction about §43 IfSG (aka Frikadellendiplom) from my Health Department "
-"and a second instruction from us or my employer/chef/association within 3 months. "
-"Additionally my second instruction is not older than 2 years."
+msgstr "I received the instruction about §43 IfSG (Frikadellendiplom / food hygiene certificate) from my Health Department "
+"and a second instruction from the event organizers or my employer/supervisor/association within 3 months. "
+"Additionally, my second instruction is not older than 2 years."
 
 msgid "settings.certificates.ifsg_admin"
-msgstr "Got the instruction about §43 IfSG (aka Frikadellendiplom) from a Health Department "
-"and a second instruction from us or his employer/chef/association within 3 months. "
-"Additionally the second instruction is not older than 2 years."
+msgstr "Received the instruction about §43 IfSG (Frikadellendiplom / food hygiene certificate) from a Health Department "
+"and a second instruction from the event organizers or their employer/supervisor/association within 3 months. "
+"Additionally, the second instruction is not older than 2 years."
 
 msgid "settings.certificates.confirmed"
 msgstr "Certificate confirmed"
@@ -609,7 +609,7 @@ msgid "faq.faq"
 msgstr "FAQ"
 
 msgid "faq.questions_link"
-msgstr "If you don't find an answer, you can <a href=\"%s\">ask the heaven</a>."
+msgstr "If you don't find an answer, you can <a href=\"%s\">ask Heaven</a>."
 
 msgid "faq.edit"
 msgstr "Edit FAQ entry"
@@ -756,7 +756,7 @@ msgid "angeltypes.angeltypes"
 msgstr "Angel types"
 
 msgid "angeltypes.about"
-msgstr "Teams-/Job description"
+msgstr "Team/Task description"
 
 msgid "angeltypes.about.text"
 msgstr "Here you can find the list of teams and their tasks. If you have further questions, "
@@ -766,32 +766,32 @@ msgid "angeltypes.restricted"
 msgstr "Requires introduction"
 
 msgid "angeltypes.restricted.info"
-msgstr "Angel types which require introduction can only be used by an angel "
-"if enabled by a supporter (double opt-in)."
+msgstr "Angel types that require introduction can only be joined by Angels "
+"after being enabled by a supporter (double opt-in)."
 
 msgid "angeltypes.restricted.hint"
-msgstr "This angel type requires the attendance at an introduction meeting. "
+msgstr "This angel type requires attendance at an introduction meeting. "
 "You might find additional information in the description."
 
 msgid "angeltypes.can-change-later"
 msgstr "You can change your selection later in the settings."
 
 msgid "angeltypes.shift.self_signup.info"
-msgstr "Angel types which have shift self signup enabled allow angels to self sign up for their shifts, "
-"if shift self signup is disabled only supporters and admins can sign angels into shifts of these angel types."
+msgstr "Angel types with shift self-signup enabled allow Angels to sign up for their own shifts. "
+"If shift self-signup is disabled, only supporters and admins can assign Angels to shifts for these angel types."
 
 msgid "shift.self_signup"
-msgstr "Shift self signup"
+msgstr "Shift self-signup"
 
 msgid "shift.self_signup.allowed"
-msgstr "Shift self signup allowed"
+msgstr "Shift self-signup allowed"
 
 msgid "angeltypes.hide_on_shift_view"
 msgstr "Hide on shift view"
 
 msgid "angeltypes.hide_on_shift_view.info"
-msgstr "If checked only admins and members of the angel type "
-"can see the filter option for this angel type on the shifts page"
+msgstr "If checked, only admins and members of the angel type "
+"can see the filter option for this angel type on the shifts page."
 
 msgid "angeltypes.qr"
 msgstr "Join angel type \"%s\" QR code"
@@ -873,7 +873,7 @@ msgstr "What do you want to do?"
 
 msgid "registration.jobs"
 msgstr "You can find more information about how to help us in the "
-"<a href=\"%s\" target=\"_blank\">Teams-/Job description</a>."
+"<a href=\"%s\" target=\"_blank\">Team/Task description</a>."
 
 msgid "registration.register"
 msgstr "Register"
@@ -946,10 +946,10 @@ msgstr "User info"
 msgid "user.info.hint"
 msgstr ""
 "Is displayed for shift coordinators and admins in the user view. "
-"If an angel is not marked as arrived a user-info removes the not-arrived notification in the angels sysmenu."
+"If an Angel is not marked as arrived, a user info removes the not-arrived notification in the Angel's system menu."
 
 msgid "user_info.not_arrived_hint"
-msgstr "If you want to sign up for shifts, feel free to drop by heaven."
+msgstr "If you want to sign up for shifts, feel free to drop by Heaven."
 
 msgid "email.greeting"
 msgstr "Hi %s,"
@@ -1038,7 +1038,7 @@ msgid "login.password.reset"
 msgstr "I forgot my password"
 
 msgid "login.registration"
-msgstr "Please sign up, if you want to help us!"
+msgstr "Please sign up if you want to help us!"
 
 msgid "login.registration.external"
 msgstr "Registration is only available via external login."
@@ -1109,39 +1109,39 @@ msgid "general.back"
 msgstr "Back"
 
 msgid "admin_shifts.no_locations"
-msgstr "No location has been created yet. Shifts can't be created without one."
+msgstr "No location has been created yet. Shifts cannot be created without one."
 
 msgid "admin_shifts.no_shifttypes"
-msgstr "No shift type has been created yet. Shifts can't be created without one."
+msgstr "No shift type has been created yet. Shifts cannot be created without one."
 
 msgid "admin_shifts.no_angeltypes"
-msgstr "No angel type has been created yet. Shifts can't be created without one."
+msgstr "No angel type has been created yet. Shifts cannot be created without one."
 
 msgid "shift.sign_out.hint"
-msgstr "You can self sign out up to %s hours before the start of the shift. "
-"If you can't attend your shift, ask heaven to sign you out."
+msgstr "You can sign yourself out up to %s hours before the start of the shift. "
+"If you can't attend your shift, ask Heaven to sign you out."
 
 msgid "freeload.info.goodie"
 msgstr "You were not present for this shift. "
-"The double length of the shift was deducted from your %s. Please contact heaven if you have questions."
+"The double length of the shift was deducted from your %s. Please contact Heaven if you have questions."
 
 msgid "freeload.info"
 msgstr "You were not present for this shift. "
-"Please contact heaven if you have questions."
+"Please contact Heaven if you have questions."
 
 msgid "freeload.freeloader.info"
 msgstr "You were not present for at least %s shifts. Therefore, shift registration is blocked. "
-"Please go to heaven to be unlocked again."
+"Please go to Heaven to be unlocked again."
 
 msgid "freeload.freeloaded.info.goodie"
 msgstr ""
-"If an angel was not present for a shift, the double length of the shift is deducted from the %s. "
-"If %s shifts are freeloaded, the shift registration is blocked for the angel."
+"If an Angel was not present for a shift, double the shift length is deducted from the %s. "
+"If %s shifts are freeloaded, shift registration is blocked for the Angel."
 
 msgid "freeload.freeloaded.info"
 msgstr ""
-"The angel was not present for a shift. "
-"If %s shifts are freeloaded, the shift registration is blocked for the angel."
+"The Angel was not present for a shift. "
+"If %s shifts are freeloaded, shift registration is blocked for the Angel."
 
 msgid "config.config"
 msgstr "Config"


### PR DESCRIPTION
Hi, I'm Teal from c3lingo. We wanted to help improve the English translations for the Engelsystem.

This PR includes:
- Fix grammatical errors and awkward phrasing
- Standardize terminology (Angels, Heaven, shift self-signup)
- Add English explanations for German terms (Frikadellendiplom)
- Fix typos (separated, build-up, various spelling errors)

All changes were verified against the German source translations to ensure accuracy.