### PR TITLE
api: add shift entry ID to API response

### DIFF
--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -291,6 +291,10 @@ components:
     ShiftEntry:
       type: object
       properties:
+        id:
+          type: integer
+          example: 42
+          description: The shift entry ID
         user:
           $ref: '#/components/schemas/Reference'
         freeloaded_by:
@@ -301,6 +305,7 @@ components:
             Contains a reference to the user who has marked this shift entry as freeloaded, if
             for a user not arriving to their shift
       required:
+        - id
         - user
         - freeloaded_by
     ShiftType:

--- a/src/Controllers/Api/ShiftsController.php
+++ b/src/Controllers/Api/ShiftsController.php
@@ -186,6 +186,7 @@ class ShiftsController extends ApiController
                 }
 
                 $entries = $entries->map(fn(ShiftEntry $entry) => [
+                    'id' => $entry->id,
                     'user' => UserResource::toIdentifierArray($entry->user),
                     'freeloaded_by' => $entry->freeloaded_by
                         ? UserResource::toIdentifierArray($entry->freeloadedBy)

--- a/tests/Unit/Controllers/Api/ShiftsControllerTest.php
+++ b/tests/Unit/Controllers/Api/ShiftsControllerTest.php
@@ -73,7 +73,10 @@ class ShiftsControllerTest extends ApiBaseControllerTest
         $entry = $entriesC[1];
         $this->assertCount(3, $entry['entries']);
         $this->assertEquals(0, $entry['needs']);
-        $user = $entry['entries'][0]['user'];
+        $shiftEntry = $entry['entries'][0];
+        $this->assertArrayHasKey('id', $shiftEntry);
+        $this->assertIsInt($shiftEntry['id']);
+        $user = $shiftEntry['user'];
         $this->assertArrayHasKey('id', $user);
         $this->assertArrayHasKey('name', $user);
         $this->assertArrayNotHasKey('email', $user);


### PR DESCRIPTION
## Summary

Adds the `shift_entry_id` field to shift entries in the API response, allowing API consumers to uniquely identify individual shift assignments.

## Motivation

Currently, the shift entries API endpoint returns user information but not the shift entry ID. This makes it impossible to uniquely identify individual shift entries when a user is assigned to the same shift multiple times (e.g., for different roles or time slots within the same shift).

## Changes

- Added `id` field to shift entry mapping in `ShiftsController`
- Updated OpenAPI schema to document the new field as required
- Added test assertions to verify the field is present and returns an integer

## Example Response

Before:
```json
{
  "user": {"id": 58, "name": "tribut"},
  "freeloaded_by": null
}
```

After:
```json
{
  "id": 16838,
  "user": {"id": 58, "name": "tribut"},
  "freeloaded_by": null
}
```

## API Version

This change affects the `v0-beta` API endpoints that return shift entries:
- `/angeltypes/{id}/shifts`
- `/locations/{id}/shifts`
- `/shifttypes/{id}/shifts`
- `/users/{id}/shifts`