### PR TITLE
ui: add labels to icon-only navbar items

### DIFF
--- a/includes/view/UserHintsRenderer.php
+++ b/includes/view/UserHintsRenderer.php
@@ -7,7 +7,9 @@ class UserHintsRenderer
     /** @var string[] */
     private $hints = [];
 
-    private $important = false;
+    private bool $important = false;
+
+    private int $count = 0;
 
     /**
      * Add a hint to the list, if its not null and a not empty string.
@@ -15,9 +17,10 @@ class UserHintsRenderer
      * @param string  $hint      The hint
      * @param boolean $important Is the hint important?
      */
-    public function addHint($hint, $important = false)
+    public function addHint($hint, $important = false): void
     {
         if (!empty($hint)) {
+            $this->count++;
             if ($important) {
                 $this->important = true;
                 $this->hints[] = error($hint, true, true);
@@ -53,6 +56,7 @@ class UserHintsRenderer
             return '<li class="nav-item nav-item--userhints d-flex align-items-center bg-' . $class_hint . '">'
                 . '<a class="nav-link dropdown-toggle text-light" href="#" role="button"' . $attr . '>'
                 . icon($icon)
+                . '<span class="badge ps-0 pe-1">' . $this->count . '</span>'
                 . '</a>'
                 . '</li>';
         }

--- a/resources/views/layouts/parts/language_dropdown.twig
+++ b/resources/views/layouts/parts/language_dropdown.twig
@@ -4,6 +4,7 @@
     <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             {{ m.icon('translate') }}
+            <span>{{ session_get('locale')|split('_')[0]|upper }}</span>
         </a>
         <ul class="dropdown-menu dropdown-menu-end">
             {{ menuLanguages()|join(" ")|raw }}

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -101,7 +101,8 @@
 
                     {% if can('user_messages') %}
                         {{ _self.toolbar_item(
-                            user_messages ? '<span class="badge bg-danger">' ~ user_messages ~ '</span>' : '',
+                            '<span class="d-xxl-none">' ~ __('message.title') ~ '</span>'
+                            ~ (user_messages ? ' <span class="badge bg-danger">' ~ user_messages ~ '</span>' : ''),
                             url('/messages'),
                             'messages',
                             'envelope'


### PR DESCRIPTION
## Summary
- Hints button now shows count badge (e.g. "⚠ 2") so users know how many items need attention
- Language dropdown shows current language code (e.g. "EN") instead of icon-only
- Messages shows "Messages" label on mobile view (hidden on desktop)

Improves mobile UX by making icon-only items self-explanatory.