### PR TITLE
ui: prevent user nick icon/name from wrapping

### DIFF
--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -983,7 +983,8 @@ function User_Nick_render($user, $plain = false)
     }
 
     return render_profile_link(
-        '<span class="icon-icon_angel"></span>&nbsp;' . htmlspecialchars($user->displayName) . '</a>',
+        '<span class="text-nowrap"><span class="icon-icon_angel"></span> '
+            . htmlspecialchars($user->displayName) . '</span>',
         $user->id,
         ($user->state->arrived ? '' : 'text-muted')
     );

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -114,7 +114,7 @@
                     {% include "layouts/parts/language_dropdown.twig" %}
                     <li class="nav-item dropdown dropdown-user-menu">
                         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            {{ m.angel() }} {{ user.displayName }}
+                            <span class="text-nowrap">{{ m.angel() }} {{ user.displayName }}</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end">
                             {% if can('user_myshifts') %}

--- a/resources/views/macros/base.twig
+++ b/resources/views/macros/base.twig
@@ -26,7 +26,7 @@
     <a href="{{ opt.url|default(url('/users', {'action': 'view', 'user_id': user.id})) }}"
             {%- if not user.state.arrived %} class="text-muted"{% endif -%}
     >
-        {{ _self.angel() }}&nbsp;{{ user.displayName }}
+        <span class="text-nowrap">{{ _self.angel() }} {{ user.displayName }}</span>
         {%- if opt.pronoun|default(false) and config('enable_pronoun')
             and user.personalData.pronoun %}
             ({{ user.personalData.pronoun }})


### PR DESCRIPTION
## Summary
- Use CSS `background-image` for the angel icon instead of a separate `<span>` element with `&nbsp;`
- Keeps icon and name together as a single unit that won't break across lines
- Icon is slightly smaller (0.9em) for better visual balance

## Notes
- The `angel()` Twig macro is now unused and can be removed