### PR TITLE
feat: add spoken languages as user profile attributes

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -195,6 +195,10 @@ return [
                     'type' => 'boolean',
                     'default' => true,
                 ],
+                'enable_user_languages' => [
+                    'type' => 'boolean',
+                    'default' => false,
+                ],
                 'required_user_fields' => [
                     'type' => 'select_multi',
                     'data' => [

--- a/config/routes.php
+++ b/config/routes.php
@@ -40,6 +40,8 @@ $route->addGroup(
         $route->post('/theme', 'SettingsController@saveTheme');
         $route->get('/language', 'SettingsController@language');
         $route->post('/language', 'SettingsController@saveLanguage');
+        $route->get('/spoken-languages', 'SettingsController@spokenLanguages');
+        $route->post('/spoken-languages', 'SettingsController@saveSpokenLanguages');
         $route->get('/certificates', 'SettingsController@certificate');
         $route->post('/certificates/ifsg', 'SettingsController@saveIfsgCertificate');
         $route->post('/certificates/driving', 'SettingsController@saveDrivingLicense');

--- a/db/factories/User/UserLanguageFactory.php
+++ b/db/factories/User/UserLanguageFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Engelsystem\Models\User;
+
+use Engelsystem\Models\User\User;
+use Engelsystem\Models\User\UserLanguage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserLanguageFactory extends Factory
+{
+    /** @var string */
+    protected $model = UserLanguage::class; // phpcs:ignore
+
+    public function definition(): array
+    {
+        $languages = ['en', 'de', 'fr', 'es', 'nl', 'pt-BR', 'zh-CN', 'ja', 'ko', 'ru'];
+
+        return [
+            'user_id'       => User::factory(),
+            'language_code' => $this->faker->randomElement($languages),
+            'is_native'     => $this->faker->boolean(30),
+        ];
+    }
+
+    /**
+     * Mark language as native
+     */
+    public function native(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'is_native' => true,
+        ]);
+    }
+}

--- a/db/migrations/2025_12_29_000000_create_user_languages_table.php
+++ b/db/migrations/2025_12_29_000000_create_user_languages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateUserLanguagesTable extends Migration
+{
+    use Reference;
+
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        $this->schema->create('user_languages', function (Blueprint $table): void {
+            $table->increments('id');
+            $this->referencesUser($table);
+            $table->string('language_code', 10);
+            $table->boolean('is_native')->default(false);
+            $table->unique(['user_id', 'language_code']);
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        $this->schema->drop('user_languages');
+    }
+}

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -3,6 +3,7 @@
 use Carbon\CarbonInterval;
 use Engelsystem\Config\GoodieType;
 use Engelsystem\Helpers\Carbon;
+use Engelsystem\Helpers\Language;
 use Engelsystem\Helpers\UserVouchers;
 use Engelsystem\Models\AngelType;
 use Engelsystem\Models\Group;
@@ -789,6 +790,7 @@ function User_view(
                 User_view_state($admin_user_privilege, $freeloader, $user_source),
                 User_angeltypes_render($user_angeltypes),
                 User_groups_render($user_groups),
+                User_languages_render($user_source),
                 $admin_user_privilege ? User_oauth_render($user_source) : '',
             ]),
             ($its_me || $admin_user_privilege) ? '<h2>' . $my_shifts_title . '</h2>' : '',
@@ -945,6 +947,40 @@ function User_groups_render($user_groups)
 
     return div('col-md-2', [
         '<h4>' . __('Rights') . '</h4>',
+        join('<br>', $output),
+    ]);
+}
+
+/**
+ * Render user's spoken languages
+ *
+ * @param User $user
+ * @return string
+ */
+function User_languages_render(User $user)
+{
+    if (!config('enable_user_languages')) {
+        return '';
+    }
+
+    $languages = $user->languages;
+    if ($languages->isEmpty()) {
+        return '';
+    }
+
+    $output = [];
+    foreach ($languages as $lang) {
+        $name = Language::getName($lang->language_code);
+        if ($lang->is_native) {
+            $output[] = '<strong>' . htmlspecialchars($name) . '</strong>'
+                . ' <span class="badge bg-secondary">' . __('settings.spoken_languages.native') . '</span>';
+        } else {
+            $output[] = htmlspecialchars($name);
+        }
+    }
+
+    return div('col-md-2', [
+        heading(__('settings.spoken_languages'), 4),
         join('<br>', $output),
     ]);
 }

--- a/resources/assets/js/spoken-languages.js
+++ b/resources/assets/js/spoken-languages.js
@@ -1,0 +1,142 @@
+import { ready } from './ready';
+
+/**
+ * Spoken languages editor for user settings
+ */
+ready(() => {
+  const editor = document.getElementById('language-editor');
+  if (!editor) return;
+
+  const options = JSON.parse(editor.dataset.options || '[]');
+  const nativeLabel = editor.dataset.nativeLabel || 'Native';
+  const deleteLabel = editor.dataset.deleteLabel || 'Delete';
+
+  const input = document.getElementById('language-input');
+  const dropdown = document.getElementById('language-dropdown');
+  const selectedContainer = document.getElementById('selected-languages');
+  const hiddenInput = document.getElementById('languages-hidden');
+
+  if (!input || !dropdown || !selectedContainer || !hiddenInput) return;
+
+  const getSelectedCodes = () => {
+    return hiddenInput.value ? hiddenInput.value.split(',').filter((c) => c) : [];
+  };
+
+  const updateHiddenInput = () => {
+    const codes = Array.from(selectedContainer.querySelectorAll('[data-code]')).map((el) => el.dataset.code);
+    hiddenInput.value = codes.join(',');
+  };
+
+  const escapeHtml = (text) => {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  };
+
+  const addLanguage = (code, name) => {
+    const selected = getSelectedCodes();
+    if (selected.includes(code)) return;
+
+    const isLight = document.body.dataset.theme_type === 'light';
+    const card = document.createElement('div');
+    card.className = `card mb-2 ${isLight ? 'bg-white' : 'bg-dark'}`;
+    card.dataset.code = code;
+    card.innerHTML = `
+      <div class="card-body py-2 px-3 d-flex align-items-center justify-content-between">
+        <div>
+          <span class="badge bg-secondary me-2">${escapeHtml(code)}</span>
+          <span>${escapeHtml(name)}</span>
+        </div>
+        <div class="d-flex align-items-center gap-3">
+          <div class="form-check">
+            <input type="checkbox"
+                   class="form-check-input"
+                   name="native[]"
+                   value="${escapeHtml(code)}"
+                   id="native-${escapeHtml(code)}">
+            <label class="form-check-label" for="native-${escapeHtml(code)}">
+              ${escapeHtml(nativeLabel)}
+            </label>
+          </div>
+          <button type="button" class="btn btn-sm btn-outline-danger remove-language" aria-label="${escapeHtml(deleteLabel)}">
+            <i class="bi bi-x-lg"></i>
+          </button>
+        </div>
+      </div>
+    `;
+    selectedContainer.appendChild(card);
+    updateHiddenInput();
+    input.value = '';
+    hideDropdown();
+  };
+
+  const removeLanguage = (card) => {
+    card.remove();
+    updateHiddenInput();
+  };
+
+  const showDropdown = (matches) => {
+    dropdown.innerHTML = '';
+    matches.forEach((opt) => {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'dropdown-item';
+      item.innerHTML = `<span class="badge bg-secondary me-2">${escapeHtml(opt.code)}</span>${escapeHtml(opt.name)}`;
+      item.addEventListener('click', () => addLanguage(opt.code, opt.name));
+      dropdown.appendChild(item);
+    });
+    dropdown.style.display = 'block';
+  };
+
+  const hideDropdown = () => {
+    dropdown.style.display = 'none';
+  };
+
+  input.addEventListener('input', function () {
+    const query = this.value.toLowerCase().trim();
+    if (query.length < 1) {
+      hideDropdown();
+      return;
+    }
+
+    const selected = getSelectedCodes().map((c) => c.toLowerCase());
+    const matches = options
+      .filter((opt) => {
+        const codeMatch = opt.code.toLowerCase().startsWith(query);
+        const nameMatch = opt.name.toLowerCase().includes(query);
+        const notSelected = !selected.includes(opt.code.toLowerCase());
+        return (codeMatch || nameMatch) && notSelected;
+      })
+      .slice(0, 10);
+
+    if (matches.length > 0) {
+      showDropdown(matches);
+    } else {
+      hideDropdown();
+    }
+  });
+
+  input.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const firstItem = dropdown.querySelector('.dropdown-item');
+      if (firstItem) firstItem.click();
+    } else if (e.key === 'Escape') {
+      hideDropdown();
+    }
+  });
+
+  document.addEventListener('click', function (e) {
+    if (!editor.contains(e.target)) {
+      hideDropdown();
+    }
+  });
+
+  selectedContainer.addEventListener('click', function (e) {
+    const removeBtn = e.target.closest('.remove-language');
+    if (removeBtn) {
+      const card = removeBtn.closest('[data-code]');
+      if (card) removeLanguage(card);
+    }
+  });
+});

--- a/resources/assets/js/vendor.js
+++ b/resources/assets/js/vendor.js
@@ -6,3 +6,4 @@ import './dashboard';
 import './design';
 import './voucher';
 import './table-responsive-sticky-header';
+import './spoken-languages';

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -572,6 +572,9 @@ msgstr "Nächste Schicht"
 msgid "shift.previous"
 msgstr "Vorherige Schicht"
 
+msgid "shift.team_languages"
+msgstr "Team spricht"
+
 msgid "general.shift"
 msgstr "Schicht"
 
@@ -1742,6 +1745,24 @@ msgstr "Hier kannst Du Deine Sprache ändern."
 
 msgid "settings.language.success"
 msgstr "Sprache wurde erfolgreich geändert."
+
+msgid "settings.spoken_languages"
+msgstr "Gesprochene Sprachen"
+
+msgid "settings.spoken_languages.info"
+msgstr "Füge die Sprachen hinzu, die du sprichst, um Schichten mit Teams zu finden, mit denen du kommunizieren kannst."
+
+msgid "settings.spoken_languages.add"
+msgstr "Sprache hinzufügen"
+
+msgid "settings.spoken_languages.placeholder"
+msgstr "Tippe, um Sprachen zu suchen..."
+
+msgid "settings.spoken_languages.native"
+msgstr "Muttersprache"
+
+msgid "settings.spoken_languages.success"
+msgstr "Gesprochene Sprachen wurden erfolgreich gespeichert."
 
 msgid "settings.api"
 msgstr "API"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -566,6 +566,24 @@ msgstr "Here you can change your language."
 msgid "settings.language.success"
 msgstr "Language was changed successfully."
 
+msgid "settings.spoken_languages"
+msgstr "Spoken Languages"
+
+msgid "settings.spoken_languages.info"
+msgstr "Add the languages you speak to help find shifts with teams you can communicate with."
+
+msgid "settings.spoken_languages.add"
+msgstr "Add a language"
+
+msgid "settings.spoken_languages.placeholder"
+msgstr "Type to search languages..."
+
+msgid "settings.spoken_languages.native"
+msgstr "Native"
+
+msgid "settings.spoken_languages.success"
+msgstr "Spoken languages saved successfully."
+
 msgid "settings.api"
 msgstr "API"
 
@@ -1014,6 +1032,9 @@ msgstr "Next shift"
 
 msgid "shift.previous"
 msgstr "Previous shift"
+
+msgid "shift.team_languages"
+msgstr "Team speaks"
 
 msgid "general.shift"
 msgstr "Shift"

--- a/resources/views/pages/settings/spoken-languages.twig
+++ b/resources/views/pages/settings/spoken-languages.twig
@@ -16,7 +16,10 @@
 
         <div class="row g-4">
             <div class="col-12">
-                <div id="language-editor" data-options="{{ language_options|json_encode }}">
+                <div id="language-editor"
+                     data-options="{{ language_options|json_encode }}"
+                     data-native-label="{{ __('settings.spoken_languages.native') }}"
+                     data-delete-label="{{ __('form.delete') }}">
                     <div class="mb-3">
                         <label for="language-input" class="form-label">{{ __('settings.spoken_languages.add') }}</label>
                         <div class="position-relative">
@@ -31,7 +34,7 @@
 
                     <div id="selected-languages" class="mb-3">
                         {% for lang in user_languages %}
-                            <div class="card mb-2" data-code="{{ lang.code }}">
+                            <div class="card mb-2 {% if theme.type == 'light' %}bg-white{% else %}bg-dark{% endif %}" data-code="{{ lang.code }}">
                                 <div class="card-body py-2 px-3 d-flex align-items-center justify-content-between">
                                     <div>
                                         <span class="badge bg-secondary me-2">{{ lang.code }}</span>
@@ -67,135 +70,4 @@
             </div>
         </div>
     </form>
-
-    <script>
-    (function() {
-        const editor = document.getElementById('language-editor');
-        const options = JSON.parse(editor.dataset.options);
-        const input = document.getElementById('language-input');
-        const dropdown = document.getElementById('language-dropdown');
-        const selectedContainer = document.getElementById('selected-languages');
-        const hiddenInput = document.getElementById('languages-hidden');
-
-        function getSelectedCodes() {
-            return hiddenInput.value ? hiddenInput.value.split(',').filter(c => c) : [];
-        }
-
-        function updateHiddenInput() {
-            const codes = Array.from(selectedContainer.querySelectorAll('[data-code]'))
-                .map(el => el.dataset.code);
-            hiddenInput.value = codes.join(',');
-        }
-
-        function addLanguage(code, name) {
-            const selected = getSelectedCodes();
-            if (selected.includes(code)) return;
-
-            const card = document.createElement('div');
-            card.className = 'card mb-2';
-            card.dataset.code = code;
-            card.innerHTML = `
-                <div class="card-body py-2 px-3 d-flex align-items-center justify-content-between">
-                    <div>
-                        <span class="badge bg-secondary me-2">${escapeHtml(code)}</span>
-                        <span>${escapeHtml(name)}</span>
-                    </div>
-                    <div class="d-flex align-items-center gap-3">
-                        <div class="form-check">
-                            <input type="checkbox"
-                                   class="form-check-input"
-                                   name="native[]"
-                                   value="${escapeHtml(code)}"
-                                   id="native-${escapeHtml(code)}">
-                            <label class="form-check-label" for="native-${escapeHtml(code)}">
-                                {{ __('settings.spoken_languages.native') }}
-                            </label>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-danger remove-language" aria-label="{{ __('form.delete') }}">
-                            <i class="bi bi-x-lg"></i>
-                        </button>
-                    </div>
-                </div>
-            `;
-            selectedContainer.appendChild(card);
-            updateHiddenInput();
-            input.value = '';
-            hideDropdown();
-        }
-
-        function removeLanguage(card) {
-            card.remove();
-            updateHiddenInput();
-        }
-
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
-        }
-
-        function showDropdown(matches) {
-            dropdown.innerHTML = '';
-            matches.forEach(opt => {
-                const item = document.createElement('button');
-                item.type = 'button';
-                item.className = 'dropdown-item';
-                item.innerHTML = `<span class="badge bg-secondary me-2">${escapeHtml(opt.code)}</span>${escapeHtml(opt.name)}`;
-                item.addEventListener('click', () => addLanguage(opt.code, opt.name));
-                dropdown.appendChild(item);
-            });
-            dropdown.style.display = 'block';
-        }
-
-        function hideDropdown() {
-            dropdown.style.display = 'none';
-        }
-
-        input.addEventListener('input', function() {
-            const query = this.value.toLowerCase().trim();
-            if (query.length < 1) {
-                hideDropdown();
-                return;
-            }
-
-            const selected = getSelectedCodes().map(c => c.toLowerCase());
-            const matches = options.filter(opt => {
-                const codeMatch = opt.code.toLowerCase().startsWith(query);
-                const nameMatch = opt.name.toLowerCase().includes(query);
-                const notSelected = !selected.includes(opt.code.toLowerCase());
-                return (codeMatch || nameMatch) && notSelected;
-            }).slice(0, 10);
-
-            if (matches.length > 0) {
-                showDropdown(matches);
-            } else {
-                hideDropdown();
-            }
-        });
-
-        input.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                const firstItem = dropdown.querySelector('.dropdown-item');
-                if (firstItem) firstItem.click();
-            } else if (e.key === 'Escape') {
-                hideDropdown();
-            }
-        });
-
-        document.addEventListener('click', function(e) {
-            if (!editor.contains(e.target)) {
-                hideDropdown();
-            }
-        });
-
-        selectedContainer.addEventListener('click', function(e) {
-            const removeBtn = e.target.closest('.remove-language');
-            if (removeBtn) {
-                const card = removeBtn.closest('[data-code]');
-                if (card) removeLanguage(card);
-            }
-        });
-    })();
-    </script>
 {% endblock %}

--- a/resources/views/pages/settings/spoken-languages.twig
+++ b/resources/views/pages/settings/spoken-languages.twig
@@ -1,0 +1,201 @@
+{% extends 'pages/settings/settings.twig' %}
+{% import 'macros/form.twig' as f %}
+{% import 'macros/base.twig' as m %}
+
+{% block title %}{{ __('settings.spoken_languages') }}{% endblock %}
+
+{% block row_content %}
+    <form action="" enctype="multipart/form-data" method="post">
+        {{ csrf() }}
+
+        <div class="row g-4">
+            <div class="col-12">
+                {{ m.info(__('settings.spoken_languages.info')) }}
+            </div>
+        </div>
+
+        <div class="row g-4">
+            <div class="col-12">
+                <div id="language-editor" data-options="{{ language_options|json_encode }}">
+                    <div class="mb-3">
+                        <label for="language-input" class="form-label">{{ __('settings.spoken_languages.add') }}</label>
+                        <div class="position-relative">
+                            <input type="text"
+                                   id="language-input"
+                                   class="form-control"
+                                   placeholder="{{ __('settings.spoken_languages.placeholder') }}"
+                                   autocomplete="off">
+                            <div id="language-dropdown" class="dropdown-menu w-100" style="display: none; position: absolute; top: 100%; left: 0; max-height: 200px; overflow-y: auto;"></div>
+                        </div>
+                    </div>
+
+                    <div id="selected-languages" class="mb-3">
+                        {% for lang in user_languages %}
+                            <div class="card mb-2" data-code="{{ lang.code }}">
+                                <div class="card-body py-2 px-3 d-flex align-items-center justify-content-between">
+                                    <div>
+                                        <span class="badge bg-secondary me-2">{{ lang.code }}</span>
+                                        <span>{{ lang.name }}</span>
+                                    </div>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <div class="form-check">
+                                            <input type="checkbox"
+                                                   class="form-check-input"
+                                                   name="native[]"
+                                                   value="{{ lang.code }}"
+                                                   id="native-{{ lang.code }}"
+                                                   {{ lang.is_native ? 'checked' : '' }}>
+                                            <label class="form-check-label" for="native-{{ lang.code }}">
+                                                {{ __('settings.spoken_languages.native') }}
+                                            </label>
+                                        </div>
+                                        <button type="button" class="btn btn-sm btn-outline-danger remove-language" aria-label="{{ __('form.delete') }}">
+                                            {{ m.icon('x-lg') }}
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    <input type="hidden" name="languages" id="languages-hidden" value="{{ user_languages|map(l => l.code)|join(',') }}">
+                </div>
+            </div>
+
+            <div class="col-12">
+                {{ f.submit(__('form.save'), {'icon_left': 'save'}) }}
+            </div>
+        </div>
+    </form>
+
+    <script>
+    (function() {
+        const editor = document.getElementById('language-editor');
+        const options = JSON.parse(editor.dataset.options);
+        const input = document.getElementById('language-input');
+        const dropdown = document.getElementById('language-dropdown');
+        const selectedContainer = document.getElementById('selected-languages');
+        const hiddenInput = document.getElementById('languages-hidden');
+
+        function getSelectedCodes() {
+            return hiddenInput.value ? hiddenInput.value.split(',').filter(c => c) : [];
+        }
+
+        function updateHiddenInput() {
+            const codes = Array.from(selectedContainer.querySelectorAll('[data-code]'))
+                .map(el => el.dataset.code);
+            hiddenInput.value = codes.join(',');
+        }
+
+        function addLanguage(code, name) {
+            const selected = getSelectedCodes();
+            if (selected.includes(code)) return;
+
+            const card = document.createElement('div');
+            card.className = 'card mb-2';
+            card.dataset.code = code;
+            card.innerHTML = `
+                <div class="card-body py-2 px-3 d-flex align-items-center justify-content-between">
+                    <div>
+                        <span class="badge bg-secondary me-2">${escapeHtml(code)}</span>
+                        <span>${escapeHtml(name)}</span>
+                    </div>
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="form-check">
+                            <input type="checkbox"
+                                   class="form-check-input"
+                                   name="native[]"
+                                   value="${escapeHtml(code)}"
+                                   id="native-${escapeHtml(code)}">
+                            <label class="form-check-label" for="native-${escapeHtml(code)}">
+                                {{ __('settings.spoken_languages.native') }}
+                            </label>
+                        </div>
+                        <button type="button" class="btn btn-sm btn-outline-danger remove-language" aria-label="{{ __('form.delete') }}">
+                            <i class="bi bi-x-lg"></i>
+                        </button>
+                    </div>
+                </div>
+            `;
+            selectedContainer.appendChild(card);
+            updateHiddenInput();
+            input.value = '';
+            hideDropdown();
+        }
+
+        function removeLanguage(card) {
+            card.remove();
+            updateHiddenInput();
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function showDropdown(matches) {
+            dropdown.innerHTML = '';
+            matches.forEach(opt => {
+                const item = document.createElement('button');
+                item.type = 'button';
+                item.className = 'dropdown-item';
+                item.innerHTML = `<span class="badge bg-secondary me-2">${escapeHtml(opt.code)}</span>${escapeHtml(opt.name)}`;
+                item.addEventListener('click', () => addLanguage(opt.code, opt.name));
+                dropdown.appendChild(item);
+            });
+            dropdown.style.display = 'block';
+        }
+
+        function hideDropdown() {
+            dropdown.style.display = 'none';
+        }
+
+        input.addEventListener('input', function() {
+            const query = this.value.toLowerCase().trim();
+            if (query.length < 1) {
+                hideDropdown();
+                return;
+            }
+
+            const selected = getSelectedCodes().map(c => c.toLowerCase());
+            const matches = options.filter(opt => {
+                const codeMatch = opt.code.toLowerCase().startsWith(query);
+                const nameMatch = opt.name.toLowerCase().includes(query);
+                const notSelected = !selected.includes(opt.code.toLowerCase());
+                return (codeMatch || nameMatch) && notSelected;
+            }).slice(0, 10);
+
+            if (matches.length > 0) {
+                showDropdown(matches);
+            } else {
+                hideDropdown();
+            }
+        });
+
+        input.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                const firstItem = dropdown.querySelector('.dropdown-item');
+                if (firstItem) firstItem.click();
+            } else if (e.key === 'Escape') {
+                hideDropdown();
+            }
+        });
+
+        document.addEventListener('click', function(e) {
+            if (!editor.contains(e.target)) {
+                hideDropdown();
+            }
+        });
+
+        selectedContainer.addEventListener('click', function(e) {
+            const removeBtn = e.target.closest('.remove-language');
+            if (removeBtn) {
+                const card = removeBtn.closest('[data-code]');
+                if (card) removeLanguage(card);
+            }
+        });
+    })();
+    </script>
+{% endblock %}

--- a/src/Controllers/Api/Resources/UserDetailResource.php
+++ b/src/Controllers/Api/Resources/UserDetailResource.php
@@ -22,6 +22,10 @@ class UserDetailResource extends UserResource
                 'provider' => $o->provider,
                 'identifier' => $o->identifier,
             ])->toArray(),
+            'spoken_languages' => $this->model->languages->map(fn($lang) => [
+                'code' => $lang->language_code,
+                'is_native' => $lang->is_native,
+            ])->toArray(),
         ]);
     }
 }

--- a/src/Helpers/Language.php
+++ b/src/Helpers/Language.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Helpers;
+
+/**
+ * Helper class for BCP47 language tag validation and name lookup
+ */
+class Language
+{
+    /**
+     * Common BCP47 regional variants used in translation contexts
+     */
+    public const COMMON_TAGS = [
+        // Arabic
+        'ar-AE' => 'Arabic (UAE)',
+        'ar-EG' => 'Arabic (Egypt)',
+        'ar-MA' => 'Arabic (Morocco)',
+        'ar-SA' => 'Arabic (Saudi Arabia)',
+        // Chinese
+        'zh-CN' => 'Chinese (China, Simplified)',
+        'zh-Hans' => 'Chinese (Simplified)',
+        'zh-Hant' => 'Chinese (Traditional)',
+        'zh-HK' => 'Chinese (Hong Kong)',
+        'zh-TW' => 'Chinese (Taiwan)',
+        // Dutch
+        'nl-BE' => 'Dutch (Belgium)',
+        'nl-NL' => 'Dutch (Netherlands)',
+        // English
+        'en-AU' => 'English (Australia)',
+        'en-CA' => 'English (Canada)',
+        'en-GB' => 'English (UK)',
+        'en-IE' => 'English (Ireland)',
+        'en-IN' => 'English (India)',
+        'en-NZ' => 'English (New Zealand)',
+        'en-US' => 'English (US)',
+        'en-ZA' => 'English (South Africa)',
+        // French
+        'fr-BE' => 'French (Belgium)',
+        'fr-CA' => 'French (Canada)',
+        'fr-CH' => 'French (Switzerland)',
+        'fr-FR' => 'French (France)',
+        // German
+        'de-AT' => 'German (Austria)',
+        'de-CH' => 'German (Switzerland)',
+        'de-DE' => 'German (Germany)',
+        'de-LU' => 'German (Luxembourg)',
+        // Portuguese
+        'pt-BR' => 'Portuguese (Brazil)',
+        'pt-PT' => 'Portuguese (Portugal)',
+        // Russian
+        'ru-BY' => 'Russian (Belarus)',
+        'ru-RU' => 'Russian (Russia)',
+        // Spanish
+        'es-419' => 'Spanish (Latin America)',
+        'es-AR' => 'Spanish (Argentina)',
+        'es-ES' => 'Spanish (Spain)',
+        'es-MX' => 'Spanish (Mexico)',
+        'es-US' => 'Spanish (US)',
+    ];
+
+    /**
+     * ISO 639-1 language codes with names
+     */
+    public const ISO_639_1 = [
+        'aa' => 'Afar',
+        'ab' => 'Abkhazian',
+        'af' => 'Afrikaans',
+        'ak' => 'Akan',
+        'am' => 'Amharic',
+        'ar' => 'Arabic',
+        'as' => 'Assamese',
+        'ay' => 'Aymara',
+        'az' => 'Azerbaijani',
+        'ba' => 'Bashkir',
+        'be' => 'Belarusian',
+        'bg' => 'Bulgarian',
+        'bh' => 'Bihari',
+        'bi' => 'Bislama',
+        'bn' => 'Bengali',
+        'bo' => 'Tibetan',
+        'br' => 'Breton',
+        'bs' => 'Bosnian',
+        'ca' => 'Catalan',
+        'ce' => 'Chechen',
+        'co' => 'Corsican',
+        'cs' => 'Czech',
+        'cy' => 'Welsh',
+        'da' => 'Danish',
+        'de' => 'German',
+        'dz' => 'Dzongkha',
+        'el' => 'Greek',
+        'en' => 'English',
+        'eo' => 'Esperanto',
+        'es' => 'Spanish',
+        'et' => 'Estonian',
+        'eu' => 'Basque',
+        'fa' => 'Persian',
+        'fi' => 'Finnish',
+        'fj' => 'Fijian',
+        'fo' => 'Faroese',
+        'fr' => 'French',
+        'fy' => 'Western Frisian',
+        'ga' => 'Irish',
+        'gd' => 'Scottish Gaelic',
+        'gl' => 'Galician',
+        'gn' => 'Guarani',
+        'gu' => 'Gujarati',
+        'ha' => 'Hausa',
+        'he' => 'Hebrew',
+        'hi' => 'Hindi',
+        'hr' => 'Croatian',
+        'ht' => 'Haitian Creole',
+        'hu' => 'Hungarian',
+        'hy' => 'Armenian',
+        'ia' => 'Interlingua',
+        'id' => 'Indonesian',
+        'ie' => 'Interlingue',
+        'ig' => 'Igbo',
+        'is' => 'Icelandic',
+        'it' => 'Italian',
+        'ja' => 'Japanese',
+        'jv' => 'Javanese',
+        'ka' => 'Georgian',
+        'kk' => 'Kazakh',
+        'km' => 'Khmer',
+        'kn' => 'Kannada',
+        'ko' => 'Korean',
+        'ku' => 'Kurdish',
+        'ky' => 'Kyrgyz',
+        'la' => 'Latin',
+        'lb' => 'Luxembourgish',
+        'lo' => 'Lao',
+        'lt' => 'Lithuanian',
+        'lv' => 'Latvian',
+        'mg' => 'Malagasy',
+        'mi' => 'Maori',
+        'mk' => 'Macedonian',
+        'ml' => 'Malayalam',
+        'mn' => 'Mongolian',
+        'mr' => 'Marathi',
+        'ms' => 'Malay',
+        'mt' => 'Maltese',
+        'my' => 'Burmese',
+        'ne' => 'Nepali',
+        'nl' => 'Dutch',
+        'no' => 'Norwegian',
+        'ny' => 'Chichewa',
+        'oc' => 'Occitan',
+        'om' => 'Oromo',
+        'or' => 'Odia',
+        'pa' => 'Punjabi',
+        'pl' => 'Polish',
+        'ps' => 'Pashto',
+        'pt' => 'Portuguese',
+        'qu' => 'Quechua',
+        'rm' => 'Romansh',
+        'ro' => 'Romanian',
+        'ru' => 'Russian',
+        'rw' => 'Kinyarwanda',
+        'sa' => 'Sanskrit',
+        'sd' => 'Sindhi',
+        'si' => 'Sinhala',
+        'sk' => 'Slovak',
+        'sl' => 'Slovenian',
+        'sm' => 'Samoan',
+        'sn' => 'Shona',
+        'so' => 'Somali',
+        'sq' => 'Albanian',
+        'sr' => 'Serbian',
+        'st' => 'Southern Sotho',
+        'su' => 'Sundanese',
+        'sv' => 'Swedish',
+        'sw' => 'Swahili',
+        'ta' => 'Tamil',
+        'te' => 'Telugu',
+        'tg' => 'Tajik',
+        'th' => 'Thai',
+        'ti' => 'Tigrinya',
+        'tk' => 'Turkmen',
+        'tl' => 'Tagalog',
+        'tr' => 'Turkish',
+        'tt' => 'Tatar',
+        'ug' => 'Uyghur',
+        'uk' => 'Ukrainian',
+        'ur' => 'Urdu',
+        'uz' => 'Uzbek',
+        'vi' => 'Vietnamese',
+        'wo' => 'Wolof',
+        'xh' => 'Xhosa',
+        'yi' => 'Yiddish',
+        'yo' => 'Yoruba',
+        'zh' => 'Chinese',
+        'zu' => 'Zulu',
+    ];
+
+    /**
+     * Validates a BCP47 language tag
+     *
+     * Accepts:
+     * - ISO 639-1 codes (e.g., 'en', 'de')
+     * - Regional variants (e.g., 'pt-BR', 'zh-Hans')
+     */
+    public static function isValid(string $code): bool
+    {
+        $code = trim($code);
+
+        if (empty($code)) {
+            return false;
+        }
+
+        // Check common tags first (case-insensitive)
+        foreach (array_keys(self::COMMON_TAGS) as $tag) {
+            if (strcasecmp($tag, $code) === 0) {
+                return true;
+            }
+        }
+
+        // Check ISO 639-1 base codes
+        $parts = explode('-', $code);
+        $baseCode = strtolower($parts[0]);
+
+        if (!isset(self::ISO_639_1[$baseCode])) {
+            return false;
+        }
+
+        // If it's just a base code, it's valid
+        if (count($parts) === 1) {
+            return true;
+        }
+
+        // Validate region/script part (2-4 alphanumeric characters)
+        $region = $parts[1];
+        return (bool) preg_match('/^[A-Za-z0-9]{2,4}$/', $region);
+    }
+
+    /**
+     * Get the human-readable name for a language code
+     */
+    public static function getName(string $code): string
+    {
+        $code = trim($code);
+
+        if (empty($code)) {
+            return $code;
+        }
+
+        // Check common tags first (case-insensitive match, return proper case)
+        foreach (self::COMMON_TAGS as $tag => $name) {
+            if (strcasecmp($tag, $code) === 0) {
+                return $name;
+            }
+        }
+
+        // Parse the code
+        $parts = explode('-', $code);
+        $baseCode = strtolower($parts[0]);
+
+        if (!isset(self::ISO_639_1[$baseCode])) {
+            return $code;
+        }
+
+        $baseName = self::ISO_639_1[$baseCode];
+
+        // If there's a region, append it
+        if (count($parts) > 1) {
+            return $baseName . ' (' . strtoupper($parts[1]) . ')';
+        }
+
+        return $baseName;
+    }
+
+    /**
+     * Normalize a language code to consistent casing
+     *
+     * @return string Normalized code (lowercase base, uppercase region)
+     */
+    public static function normalize(string $code): string
+    {
+        $code = trim($code);
+
+        if (empty($code)) {
+            return $code;
+        }
+
+        // Check common tags for exact match
+        foreach (array_keys(self::COMMON_TAGS) as $tag) {
+            if (strcasecmp($tag, $code) === 0) {
+                return $tag;
+            }
+        }
+
+        $parts = explode('-', $code);
+        $normalized = strtolower($parts[0]);
+
+        if (count($parts) > 1) {
+            // Script tags are title case, region codes are uppercase
+            $second = $parts[1];
+            if (strlen($second) === 4) {
+                // Script (e.g., Hans, Hant)
+                $normalized .= '-' . ucfirst(strtolower($second));
+            } else {
+                // Region (e.g., BR, US)
+                $normalized .= '-' . strtoupper($second);
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Get all available language options for autocomplete
+     *
+     * @return array<array{code: string, name: string}>
+     */
+    public static function getAllOptions(): array
+    {
+        $options = [];
+
+        // Add common tags first (they're most likely to be used)
+        foreach (self::COMMON_TAGS as $code => $name) {
+            $options[] = ['code' => $code, 'name' => $name];
+        }
+
+        // Add ISO 639-1 languages
+        foreach (self::ISO_639_1 as $code => $name) {
+            $options[] = ['code' => $code, 'name' => $name];
+        }
+
+        return $options;
+    }
+}

--- a/src/Models/User/User.php
+++ b/src/Models/User/User.php
@@ -66,6 +66,7 @@ use Illuminate\Support\Collection as SupportCollection;
  * @property-read Collection|Message[]          $messages
  * @property-read Collection|Shift[]            $shiftsCreated
  * @property-read Collection|Shift[]            $shiftsUpdated
+ * @property-read Collection|UserLanguage[]     $languages
  *
  * @method static QueryBuilder|User[] whereId($value)
  * @method static QueryBuilder|User[] whereName($value)
@@ -288,6 +289,11 @@ class User extends BaseModel
     public function shiftsUpdated(): HasMany
     {
         return $this->hasMany(Shift::class, 'updated_by');
+    }
+
+    public function languages(): HasMany
+    {
+        return $this->hasMany(UserLanguage::class);
     }
 
     public function getDisplayNameAttribute(): string

--- a/src/Models/User/UserLanguage.php
+++ b/src/Models/User/UserLanguage.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Models\User;
+
+use Engelsystem\Models\BaseModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+/**
+ * @property int         $id
+ * @property int         $user_id
+ * @property string      $language_code
+ * @property bool        $is_native
+ *
+ * @property-read User   $user
+ *
+ * @method static QueryBuilder|UserLanguage[] whereId($value)
+ * @method static QueryBuilder|UserLanguage[] whereUserId($value)
+ * @method static QueryBuilder|UserLanguage[] whereLanguageCode($value)
+ * @method static QueryBuilder|UserLanguage[] whereIsNative($value)
+ */
+class UserLanguage extends BaseModel
+{
+    use HasFactory;
+    use UsesUserModel;
+
+    /** @var string The table associated with the model */
+    protected $table = 'user_languages'; // phpcs:ignore
+
+    /** @var array<string, bool> Default attributes */
+    protected $attributes = [ // phpcs:ignore
+        'is_native' => false,
+    ];
+
+    /** @var array<string> */
+    protected $fillable = [ // phpcs:ignore
+        'user_id',
+        'language_code',
+        'is_native',
+    ];
+
+    /** @var array<string, string> */
+    protected $casts = [ // phpcs:ignore
+        'user_id' => 'integer',
+        'is_native' => 'boolean',
+    ];
+}

--- a/tests/Unit/Helpers/LanguageTest.php
+++ b/tests/Unit/Helpers/LanguageTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Helpers;
+
+use Engelsystem\Helpers\Language;
+use Engelsystem\Test\Unit\TestCase;
+
+class LanguageTest extends TestCase
+{
+    /**
+     * @covers \Engelsystem\Helpers\Language::isValid
+     */
+    public function testIsValidIso639(): void
+    {
+        // Valid ISO 639-1 codes
+        $this->assertTrue(Language::isValid('en'));
+        $this->assertTrue(Language::isValid('de'));
+        $this->assertTrue(Language::isValid('fr'));
+        $this->assertTrue(Language::isValid('zh'));
+
+        // Invalid codes
+        $this->assertFalse(Language::isValid(''));
+        $this->assertFalse(Language::isValid('xxx'));
+        $this->assertFalse(Language::isValid('english'));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::isValid
+     */
+    public function testIsValidBcp47(): void
+    {
+        // Valid BCP47 tags
+        $this->assertTrue(Language::isValid('en-US'));
+        $this->assertTrue(Language::isValid('pt-BR'));
+        $this->assertTrue(Language::isValid('zh-Hans'));
+        $this->assertTrue(Language::isValid('zh-TW'));
+        $this->assertTrue(Language::isValid('de-AT'));
+
+        // Case insensitive
+        $this->assertTrue(Language::isValid('EN-us'));
+        $this->assertTrue(Language::isValid('PT-br'));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::isValid
+     */
+    public function testIsValidCommonTags(): void
+    {
+        // Tags from COMMON_TAGS constant
+        $this->assertTrue(Language::isValid('en-GB'));
+        $this->assertTrue(Language::isValid('de-CH'));
+        $this->assertTrue(Language::isValid('zh-CN'));
+        $this->assertTrue(Language::isValid('es-419'));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::getName
+     */
+    public function testGetNameIso639(): void
+    {
+        $this->assertEquals('English', Language::getName('en'));
+        $this->assertEquals('German', Language::getName('de'));
+        $this->assertEquals('French', Language::getName('fr'));
+        $this->assertEquals('Japanese', Language::getName('ja'));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::getName
+     */
+    public function testGetNameBcp47(): void
+    {
+        $this->assertEquals('English (UK)', Language::getName('en-GB'));
+        $this->assertEquals('Portuguese (Brazil)', Language::getName('pt-BR'));
+        $this->assertEquals('German (Switzerland)', Language::getName('de-CH'));
+        $this->assertEquals('Chinese (Simplified)', Language::getName('zh-Hans'));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::getName
+     */
+    public function testGetNameUnknownRegion(): void
+    {
+        // Valid base code with unknown region should still work
+        $this->assertEquals('English (XX)', Language::getName('en-XX'));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::getName
+     */
+    public function testGetNameInvalid(): void
+    {
+        // Invalid codes return themselves
+        $this->assertEquals('xxx', Language::getName('xxx'));
+        $this->assertEquals('', Language::getName(''));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::normalize
+     */
+    public function testNormalize(): void
+    {
+        // Lowercase base code
+        $this->assertEquals('en', Language::normalize('EN'));
+        $this->assertEquals('de', Language::normalize('DE'));
+
+        // Uppercase region
+        $this->assertEquals('en-US', Language::normalize('en-us'));
+        $this->assertEquals('pt-BR', Language::normalize('PT-br'));
+
+        // Title case script
+        $this->assertEquals('zh-Hans', Language::normalize('zh-hans'));
+        $this->assertEquals('zh-Hant', Language::normalize('ZH-HANT'));
+
+        // Common tags preserve their format
+        $this->assertEquals('en-GB', Language::normalize('EN-gb'));
+    }
+
+    /**
+     * @covers \Engelsystem\Helpers\Language::getAllOptions
+     */
+    public function testGetAllOptions(): void
+    {
+        $options = Language::getAllOptions();
+
+        $this->assertIsArray($options);
+        $this->assertNotEmpty($options);
+
+        // Check structure
+        $firstOption = $options[0];
+        $this->assertArrayHasKey('code', $firstOption);
+        $this->assertArrayHasKey('name', $firstOption);
+
+        // Should include common tags and ISO codes
+        $codes = array_column($options, 'code');
+        $this->assertContains('en-GB', $codes);
+        $this->assertContains('de', $codes);
+        $this->assertContains('fr', $codes);
+    }
+}

--- a/tests/Unit/Models/User/UserLanguageTest.php
+++ b/tests/Unit/Models/User/UserLanguageTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Models\User;
+
+use Engelsystem\Models\User\User;
+use Engelsystem\Models\User\UserLanguage;
+use Engelsystem\Test\Unit\Models\ModelTest;
+
+class UserLanguageTest extends ModelTest
+{
+    /**
+     * @covers \Engelsystem\Models\User\UserLanguage
+     */
+    public function testCreate(): void
+    {
+        $user = User::factory()->create();
+
+        $language = UserLanguage::create([
+            'user_id' => $user->id,
+            'language_code' => 'de',
+            'is_native' => true,
+        ]);
+
+        $this->assertNotNull($language->id);
+        $this->assertEquals('de', $language->language_code);
+        $this->assertTrue($language->is_native);
+
+        // Verify it was saved to database
+        $loaded = UserLanguage::find($language->id);
+        $this->assertNotNull($loaded);
+        $this->assertEquals($user->id, $loaded->user_id);
+        $this->assertEquals('de', $loaded->language_code);
+        $this->assertTrue($loaded->is_native);
+    }
+
+    /**
+     * @covers \Engelsystem\Models\User\UserLanguage
+     */
+    public function testUserRelationship(): void
+    {
+        $user = User::factory()->create();
+        $language = UserLanguage::factory()->create([
+            'user_id' => $user->id,
+            'language_code' => 'en',
+        ]);
+
+        $this->assertEquals($user->id, $language->user->id);
+    }
+
+    /**
+     * @covers \Engelsystem\Models\User\UserLanguage
+     */
+    public function testUserLanguagesRelationship(): void
+    {
+        $user = User::factory()->create();
+
+        UserLanguage::factory()->create([
+            'user_id' => $user->id,
+            'language_code' => 'en',
+            'is_native' => true,
+        ]);
+
+        UserLanguage::factory()->create([
+            'user_id' => $user->id,
+            'language_code' => 'de',
+            'is_native' => false,
+        ]);
+
+        $user->refresh();
+
+        $this->assertCount(2, $user->languages);
+        $this->assertEquals('en', $user->languages->firstWhere('language_code', 'en')->language_code);
+        $this->assertTrue($user->languages->firstWhere('language_code', 'en')->is_native);
+        $this->assertFalse($user->languages->firstWhere('language_code', 'de')->is_native);
+    }
+
+    /**
+     * @covers \Engelsystem\Models\User\UserLanguage
+     */
+    public function testDefaults(): void
+    {
+        $user = User::factory()->create();
+
+        $language = UserLanguage::create([
+            'user_id' => $user->id,
+            'language_code' => 'fr',
+        ]);
+
+        $this->assertFalse($language->is_native);
+    }
+}


### PR DESCRIPTION
## Summary

- Allow users to specify languages they speak with native/non-native flag
- Help users find shifts with teams they can communicate with
- New `UserLanguage` model with BCP47 tag validation (supports `en`, `pt-BR`, `zh-Hans`, etc.)
- Settings UI with autocomplete search at `/settings/spoken-languages`
- Languages displayed on user profiles and shift detail pages
- Exposed in API as `spoken_languages` array
- Feature disabled by default (`enable_user_languages` config flag)

## Test plan

- [x] Enable feature via `enable_user_languages: true` in config
- [x] Add languages in settings, verify autocomplete works
- [x] Mark some as native, verify badge displays
- [x] Check languages appear on user profile page
- [x] Sign up for a shift, verify team languages shown on shift view
- [ ] Verify API returns `spoken_languages` array for user detail endpoint

Closes #254