### PR TITLE
api: expose OAuth provider identifiers on user detail

### DIFF
--- a/resources/api/openapi.yml
+++ b/resources/api/openapi.yml
@@ -440,12 +440,33 @@ components:
             arrived:
               type: boolean
               example: true
+            oauth:
+              type: array
+              description: OAuth/SSO provider identifiers linked to this user
+              items:
+                $ref: '#/components/schemas/OAuthIdentifier'
       required:
         - email
         - tshirt_size
         - dates
         - language
         - arrived
+        - oauth
+    OAuthIdentifier:
+      type: object
+      description: OAuth/SSO provider reference for a user
+      properties:
+        provider:
+          type: string
+          example: hub
+          description: The OAuth provider name as configured
+        identifier:
+          type: string
+          example: 550e8400-e29b-41d4-a716-446655440000
+          description: The user's unique identifier at the OAuth provider (sub claim)
+      required:
+        - provider
+        - identifier
     Worklog:
       type: object
       properties:

--- a/src/Controllers/Api/Resources/UserDetailResource.php
+++ b/src/Controllers/Api/Resources/UserDetailResource.php
@@ -18,6 +18,10 @@ class UserDetailResource extends UserResource
                 'planned_departure' => $this->model->personalData->planned_departure_date,
                 'arrival' => $this->model->state->arrival_date,
             ],
+            'oauth' => $this->model->oauth->map(fn($o) => [
+                'provider' => $o->provider,
+                'identifier' => $o->identifier,
+            ])->toArray(),
         ]);
     }
 }

--- a/tests/Unit/Controllers/Api/UsersControllerTest.php
+++ b/tests/Unit/Controllers/Api/UsersControllerTest.php
@@ -9,6 +9,7 @@ use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
 use Engelsystem\Models\AngelType;
+use Engelsystem\Models\OAuth;
 use Engelsystem\Models\User\Contact;
 use Engelsystem\Models\User\PersonalData;
 use Engelsystem\Models\User\Settings;
@@ -59,6 +60,7 @@ class UsersControllerTest extends ApiBaseControllerTest
             ->has(PersonalData::factory())
             ->has(Settings::factory())
             ->has(State::factory())
+            ->has(OAuth::factory())
             ->create();
 
         /** @var Authenticator|MockObject $auth */
@@ -86,6 +88,7 @@ class UsersControllerTest extends ApiBaseControllerTest
         $this->assertArrayHasKey('email', $data['data']);
         $this->assertArrayHasKey('dates', $data['data']);
         $this->assertArrayHasKey('contact', $data['data']);
+        $this->assertArrayHasKey('oauth', $data['data']);
     }
 
     /**
@@ -118,6 +121,7 @@ class UsersControllerTest extends ApiBaseControllerTest
         $this->assertArrayHasKey('id', $data['data']);
         $this->assertEquals($otherUser->id, $data['data']['id']);
         $this->assertArrayNotHasKey('dates', $data['data']);
+        $this->assertArrayNotHasKey('oauth', $data['data']);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Expose OAuth/SSO provider references (`provider` and `identifier`/sub claim) in the user detail API response
- Add `OAuthIdentifier` schema to OpenAPI spec

This enables API consumers to match users across systems by their SSO identity, e.g.:
- VOC ReLive → Engelsystem → Hub
- c3lingo re:scheduled → Engelsystem → Hub

## Test plan

- [x] Unit tests pass
- [x] OpenAPI spec validation passes
- [x] Verify empty `oauth: []` array for users without SSO
- [x] Verify populated array for users with SSO connections