### PR TITLE
feat(api): allow users to access own data without api privilege

### DIFF
--- a/db/migrations/2026_04_22_000000_add_api_own_permission.php
+++ b/db/migrations/2026_04_22_000000_add_api_own_permission.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Builder as SchemaBuilder;
+
+class AddApiOwnPermission extends Migration
+{
+    protected Connection $db;
+
+    public function __construct(SchemaBuilder $schema)
+    {
+        parent::__construct($schema);
+        $this->db = $this->schema->getConnection();
+    }
+
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        $this->db->table('privileges')
+            ->insertOrIgnore([
+                'name' => 'api.own',
+                'description' => 'Access own data via the API',
+            ]);
+
+        $apiOwnId = $this->getPrivilegeId('api.own');
+
+        $groups = $this->db->table('groups')->select('id')->get();
+
+        $insertValues = [];
+        foreach ($groups as $group) {
+            $insertValues[] = ['group_id' => $group->id, 'privilege_id' => $apiOwnId];
+        }
+
+        if (!empty($insertValues)) {
+            $this->db->table('group_privileges')
+                ->insertOrIgnore($insertValues);
+        }
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        $this->db->table('privileges')
+            ->where('name', 'api.own')
+            ->delete();
+    }
+
+    private function getPrivilegeId(string $privilege): int
+    {
+        return $this->db->table('privileges')
+            ->where('name', $privilege)
+            ->get(['id'])
+            ->first()
+            ->id;
+    }
+}

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1746,6 +1746,12 @@ msgstr ""
 "Sie ist noch nicht vollständig, wir arbeiten aber daran sie zu erweitern.\n"
 "Der Einstiegspunkt der API befindet sich unter `%s` und ist in der [OpenAPI Spezifikation](%s) beschrieben."
 
+msgid "settings.api.about.own"
+msgstr ""
+"Du kannst über die API auf deine eigenen Daten im %s zugreifen. "
+"Der Einstiegspunkt befindet sich unter `%s` und ist in der [OpenAPI Spezifikation](%s) beschrieben. "
+"Endpunkte, die auf den eigenen Benutzer beschränkt sind, akzeptieren `self` als Benutzer-ID."
+
 msgid "settings.api.about.warning"
 msgstr ""
 "Teile deinen persönlichen API Key mit niemandem, er erlaubt es deine persönlichen Daten einzusehen "

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -563,6 +563,12 @@ msgstr ""
 "It's not complete but we are working on extending it.\n"
 "The endpoint of the API is located at `%s` and described in the [OpenAPI specification](%s)."
 
+msgid "settings.api.about.own"
+msgstr ""
+"You can use the API to access your own data on the %s. "
+"The endpoint is located at `%s` and described in the [OpenAPI specification](%s). "
+"Endpoints scoped to your own user accept `self` as the user id."
+
 msgid "settings.api.about.warning"
 msgstr ""
 "Don't share your personal API key with anyone as it can be used to view your personal data "

--- a/resources/views/pages/settings/api.twig
+++ b/resources/views/pages/settings/api.twig
@@ -101,6 +101,12 @@
                     url('/api/v0-beta'),
                     url('/api/v0-beta/openapi')
                 ])|markdown|nl2br }}
+            {% elseif can('api.own') %}
+                {{ __('settings.api.about.own', [
+                    config('app_name'),
+                    url('/api/v0-beta'),
+                    url('/api/v0-beta/openapi')
+                ])|markdown|nl2br }}
             {% endif %}
 
             {{ __('settings.api.about.warning')|markdown|nl2br }}

--- a/src/Controllers/Api/AngelTypeController.php
+++ b/src/Controllers/Api/AngelTypeController.php
@@ -9,10 +9,23 @@ use Engelsystem\Controllers\Api\Resources\UserAngelTypeResource;
 use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
 use Engelsystem\Models\AngelType;
+use Psr\Http\Message\ServerRequestInterface;
 
 class AngelTypeController extends ApiController
 {
     use UsesAuth;
+
+    public function hasPermission(ServerRequestInterface $request, string $method): ?bool
+    {
+        if ($method === 'ofUser') {
+            $userId = $request->getAttribute('user_id');
+            if ($userId === 'self' || ($this->auth && (int) $userId === $this->auth->user()->id)) {
+                return true;
+            }
+        }
+
+        return null;
+    }
 
     public function index(): Response
     {

--- a/src/Controllers/Api/AngelTypeController.php
+++ b/src/Controllers/Api/AngelTypeController.php
@@ -9,23 +9,13 @@ use Engelsystem\Controllers\Api\Resources\UserAngelTypeResource;
 use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
 use Engelsystem\Models\AngelType;
-use Psr\Http\Message\ServerRequestInterface;
 
 class AngelTypeController extends ApiController
 {
+    use OwnAuth;
     use UsesAuth;
 
-    public function hasPermission(ServerRequestInterface $request, string $method): ?bool
-    {
-        if ($method === 'ofUser') {
-            $userId = $request->getAttribute('user_id');
-            if ($userId === 'self' || ($this->auth && (int) $userId === $this->auth->user()->id)) {
-                return true;
-            }
-        }
-
-        return null;
-    }
+    protected array $ownRoutes = ['ofUser'];
 
     public function index(): Response
     {

--- a/src/Controllers/Api/OwnAuth.php
+++ b/src/Controllers/Api/OwnAuth.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers\Api;
+
+use Engelsystem\Http\Exceptions\HttpUnauthorized;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Allow authenticated users to access their own data on selected endpoints
+ * without holding the full `api` privilege.
+ *
+ * Controllers using this trait declare the action methods that support
+ * self-access via $ownRoutes. When the request targets the auth user
+ * (user_id "self" or matching id) and the user has the `api.own` privilege,
+ * permission is granted. Otherwise the trait returns null so the regular
+ * permission pipeline applies.
+ */
+trait OwnAuth
+{
+    public function hasPermission(ServerRequestInterface $request, string $method): ?bool
+    {
+        $ownRoutes = property_exists($this, 'ownRoutes') ? $this->ownRoutes : [];
+        if (!in_array($method, $ownRoutes, true)) {
+            return null;
+        }
+
+        if (!isset($this->auth)) {
+            return null;
+        }
+
+        $userId = $request->getAttribute('user_id');
+        $user = $this->auth->user();
+
+        if (!$user) {
+            // Self routes called without auth should return 401, not 403
+            // or, worse, 500 from dereferencing the missing user.
+            if ($userId === 'self') {
+                throw new HttpUnauthorized();
+            }
+            return null;
+        }
+
+        if (!$this->auth->can('api.own')) {
+            return null;
+        }
+
+        if ($userId === 'self' || (int) $userId === $user->id) {
+            return true;
+        }
+
+        return null;
+    }
+}

--- a/src/Controllers/Api/ShiftsController.php
+++ b/src/Controllers/Api/ShiftsController.php
@@ -18,10 +18,23 @@ use Engelsystem\Models\Shifts\ShiftEntry;
 use Engelsystem\Models\Shifts\ShiftType;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Database\Eloquent\Collection;
+use Psr\Http\Message\ServerRequestInterface;
 
 class ShiftsController extends ApiController
 {
     use UsesAuth;
+
+    public function hasPermission(ServerRequestInterface $request, string $method): ?bool
+    {
+        if ($method === 'entriesByUser') {
+            $userId = $request->getAttribute('user_id');
+            if ($userId === 'self' || ($this->auth && (int) $userId === $this->auth->user()->id)) {
+                return true;
+            }
+        }
+
+        return null;
+    }
 
     public function entriesByAngeltype(Request $request): Response
     {

--- a/src/Controllers/Api/ShiftsController.php
+++ b/src/Controllers/Api/ShiftsController.php
@@ -18,23 +18,13 @@ use Engelsystem\Models\Shifts\ShiftEntry;
 use Engelsystem\Models\Shifts\ShiftType;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Database\Eloquent\Collection;
-use Psr\Http\Message\ServerRequestInterface;
 
 class ShiftsController extends ApiController
 {
+    use OwnAuth;
     use UsesAuth;
 
-    public function hasPermission(ServerRequestInterface $request, string $method): ?bool
-    {
-        if ($method === 'entriesByUser') {
-            $userId = $request->getAttribute('user_id');
-            if ($userId === 'self' || ($this->auth && (int) $userId === $this->auth->user()->id)) {
-                return true;
-            }
-        }
-
-        return null;
-    }
+    protected array $ownRoutes = ['entriesByUser'];
 
     public function entriesByAngeltype(Request $request): Response
     {

--- a/src/Controllers/Api/UsersController.php
+++ b/src/Controllers/Api/UsersController.php
@@ -15,10 +15,23 @@ use Engelsystem\Models\BaseModel;
 use Engelsystem\Models\User\User;
 use Engelsystem\Models\UserAngelType;
 use Illuminate\Database\Eloquent\Collection;
+use Psr\Http\Message\ServerRequestInterface;
 
 class UsersController extends ApiController
 {
     use UsesAuth;
+
+    public function hasPermission(ServerRequestInterface $request, string $method): ?bool
+    {
+        if (in_array($method, ['user', 'worklogs'])) {
+            $userId = $request->getAttribute('user_id');
+            if ($userId === 'self' || ($this->auth && (int) $userId === $this->auth->user()->id)) {
+                return true;
+            }
+        }
+
+        return null;
+    }
 
     public function index(): Response
     {

--- a/src/Controllers/Api/UsersController.php
+++ b/src/Controllers/Api/UsersController.php
@@ -15,23 +15,13 @@ use Engelsystem\Models\BaseModel;
 use Engelsystem\Models\User\User;
 use Engelsystem\Models\UserAngelType;
 use Illuminate\Database\Eloquent\Collection;
-use Psr\Http\Message\ServerRequestInterface;
 
 class UsersController extends ApiController
 {
+    use OwnAuth;
     use UsesAuth;
 
-    public function hasPermission(ServerRequestInterface $request, string $method): ?bool
-    {
-        if (in_array($method, ['user', 'worklogs'])) {
-            $userId = $request->getAttribute('user_id');
-            if ($userId === 'self' || ($this->auth && (int) $userId === $this->auth->user()->id)) {
-                return true;
-            }
-        }
-
-        return null;
-    }
+    protected array $ownRoutes = ['user', 'worklogs'];
 
     public function index(): Response
     {

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -23,8 +23,8 @@ class SettingsController extends BaseController
     /** @var string[] */
     protected array $permissions = [
         'user_settings',
-        'api' => 'api||shifts_json_export||ical||atom',
-        'apiKeyReset' => 'api||shifts_json_export||ical||atom',
+        'api' => 'api||api.own||shifts_json_export||ical||atom',
+        'apiKeyReset' => 'api||api.own||shifts_json_export||ical||atom',
     ];
 
     public function __construct(
@@ -409,7 +409,7 @@ class SettingsController extends BaseController
             $menu[url('/settings/oauth')] = ['title' => 'settings.oauth', 'hidden' => $this->checkOauthHidden()];
         }
 
-        if ($this->auth->canAny(['api', 'shifts_json_export', 'ical', 'atom'])) {
+        if ($this->auth->canAny(['api', 'api.own', 'shifts_json_export', 'ical', 'atom'])) {
             $menu[url('/settings/api')] = ['title' => 'settings.api', 'icon' => 'braces'];
         }
 

--- a/src/Http/Exceptions/HttpUnauthorized.php
+++ b/src/Http/Exceptions/HttpUnauthorized.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Http\Exceptions;
+
+use Throwable;
+
+class HttpUnauthorized extends HttpException
+{
+    public function __construct(
+        string $message = '',
+        array $headers = [],
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct(401, $message, $headers, $code, $previous);
+    }
+}

--- a/tests/Unit/Controllers/Api/AngelTypeControllerTest.php
+++ b/tests/Unit/Controllers/Api/AngelTypeControllerTest.php
@@ -12,6 +12,7 @@ use Engelsystem\Models\AngelType;
 use Engelsystem\Models\User\User;
 use Engelsystem\Models\UserAngelType;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class AngelTypeControllerTest extends ApiBaseControllerTest
 {
@@ -104,5 +105,24 @@ class AngelTypeControllerTest extends ApiBaseControllerTest
 
         $this->expectException(ModelNotFoundException::class);
         $controller->ofUser($request);
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testHasPermissionSelfWithApiOwn(): void
+    {
+        $user = User::factory()->create();
+
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->method('user')->willReturn($user);
+        $auth->method('can')->with('api.own')->willReturn(true);
+
+        $controller = new AngelTypeController(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', 'self');
+
+        $this->assertTrue($controller->hasPermission($request, 'ofUser'));
     }
 }

--- a/tests/Unit/Controllers/Api/OwnAuthTest.php
+++ b/tests/Unit/Controllers/Api/OwnAuthTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Controllers\Api;
+
+use Engelsystem\Helpers\Authenticator;
+use Engelsystem\Http\Exceptions\HttpUnauthorized;
+use Engelsystem\Http\Request;
+use Engelsystem\Http\Response;
+use Engelsystem\Models\User\User;
+use Engelsystem\Test\Unit\Controllers\Api\Stub\OwnAuthImplementation;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class OwnAuthTest extends ApiBaseControllerTest
+{
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testReturnsNullForUnknownMethod(): void
+    {
+        $controller = new OwnAuthImplementation(new Response());
+        $request = (new Request())->withAttribute('user_id', 'self');
+
+        $this->assertNull($controller->hasPermission($request, 'somethingElse'));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testReturnsNullWhenAuthMissing(): void
+    {
+        $controller = new OwnAuthImplementation(new Response());
+        $request = (new Request())->withAttribute('user_id', 42);
+
+        $this->assertNull($controller->hasPermission($request, 'allowed'));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testThrowsUnauthorizedForUnauthSelf(): void
+    {
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->expects($this->once())->method('user')->willReturn(null);
+        $auth->expects($this->never())->method('can');
+
+        $controller = new OwnAuthImplementation(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', 'self');
+
+        $this->expectException(HttpUnauthorized::class);
+        $controller->hasPermission($request, 'allowed');
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testReturnsNullForUnauthOtherUser(): void
+    {
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->expects($this->once())->method('user')->willReturn(null);
+
+        $controller = new OwnAuthImplementation(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', 42);
+
+        $this->assertNull($controller->hasPermission($request, 'allowed'));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testReturnsNullWithoutApiOwnPrivilege(): void
+    {
+        $user = User::factory()->create();
+
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->expects($this->any())->method('user')->willReturn($user);
+        $auth->expects($this->once())->method('can')->with('api.own')->willReturn(false);
+
+        $controller = new OwnAuthImplementation(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', 'self');
+
+        $this->assertNull($controller->hasPermission($request, 'allowed'));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testGrantsAccessForSelfAlias(): void
+    {
+        $user = User::factory()->create();
+
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->expects($this->any())->method('user')->willReturn($user);
+        $auth->expects($this->once())->method('can')->with('api.own')->willReturn(true);
+
+        $controller = new OwnAuthImplementation(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', 'self');
+
+        $this->assertTrue($controller->hasPermission($request, 'allowed'));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testGrantsAccessForOwnId(): void
+    {
+        $user = User::factory()->create();
+
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->expects($this->any())->method('user')->willReturn($user);
+        $auth->expects($this->once())->method('can')->with('api.own')->willReturn(true);
+
+        $controller = new OwnAuthImplementation(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', (string) $user->id);
+
+        $this->assertTrue($controller->hasPermission($request, 'allowed'));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testReturnsNullForOtherUserId(): void
+    {
+        $user = User::factory()->create();
+
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->expects($this->any())->method('user')->willReturn($user);
+        $auth->expects($this->once())->method('can')->with('api.own')->willReturn(true);
+
+        $controller = new OwnAuthImplementation(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', (string) ($user->id + 1));
+
+        $this->assertNull($controller->hasPermission($request, 'allowed'));
+    }
+}

--- a/tests/Unit/Controllers/Api/ShiftsControllerTest.php
+++ b/tests/Unit/Controllers/Api/ShiftsControllerTest.php
@@ -21,6 +21,7 @@ use Engelsystem\Models\User\PersonalData;
 use Engelsystem\Models\User\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ShiftsControllerTest extends ApiBaseControllerTest
 {
@@ -212,6 +213,25 @@ class ShiftsControllerTest extends ApiBaseControllerTest
 
         $this->expectException(ModelNotFoundException::class);
         $controller->entriesByUser($request);
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testHasPermissionSelfWithApiOwn(): void
+    {
+        $user = User::factory()->create();
+
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->method('user')->willReturn($user);
+        $auth->method('can')->with('api.own')->willReturn(true);
+
+        $controller = new ShiftsController(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', 'self');
+
+        $this->assertTrue($controller->hasPermission($request, 'entriesByUser'));
     }
 
     public function setUp(): void

--- a/tests/Unit/Controllers/Api/Stub/OwnAuthImplementation.php
+++ b/tests/Unit/Controllers/Api/Stub/OwnAuthImplementation.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Controllers\Api\Stub;
+
+use Engelsystem\Controllers\Api\ApiController;
+use Engelsystem\Controllers\Api\OwnAuth;
+use Engelsystem\Controllers\Api\UsesAuth;
+
+class OwnAuthImplementation extends ApiController
+{
+    use OwnAuth;
+    use UsesAuth;
+
+    /** @var string[] */
+    protected array $ownRoutes = ['allowed'];
+
+    public function setOwnRoutes(array $routes): void
+    {
+        $this->ownRoutes = $routes;
+    }
+}

--- a/tests/Unit/Controllers/Api/UsersControllerTest.php
+++ b/tests/Unit/Controllers/Api/UsersControllerTest.php
@@ -188,4 +188,35 @@ class UsersControllerTest extends ApiBaseControllerTest
 
         $this->assertEquals($worklog->hours, $firstEntry['hours']);
     }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testHasPermissionSelfWithApiOwn(): void
+    {
+        $user = User::factory()->create();
+
+        /** @var Authenticator|MockObject $auth */
+        $auth = $this->createMock(Authenticator::class);
+        $auth->method('user')->willReturn($user);
+        $auth->method('can')->with('api.own')->willReturn(true);
+
+        $controller = new UsersController(new Response());
+        $controller->setAuth($auth);
+        $request = (new Request())->withAttribute('user_id', 'self');
+
+        $this->assertTrue($controller->hasPermission($request, 'user'));
+        $this->assertTrue($controller->hasPermission($request, 'worklogs'));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Api\OwnAuth::hasPermission
+     */
+    public function testHasPermissionFallsThroughForUnrelatedMethods(): void
+    {
+        $controller = new UsersController(new Response());
+        $request = new Request();
+
+        $this->assertNull($controller->hasPermission($request, 'index'));
+    }
 }


### PR DESCRIPTION
## Summary

This PR allows authenticated users to access their own data via the `/api/v0-beta/users/self/*` endpoints without requiring the `api` privilege.

## Changes

Users can now access the following endpoints without the `api` privilege:
- `GET /api/v0-beta/users/self` - Get own user details
- `GET /api/v0-beta/users/self/angeltypes` - Get own angel types
- `GET /api/v0-beta/users/self/shifts` - Get own shifts
- `GET /api/v0-beta/users/self/worklogs` - Get own worklogs

## Implementation

Added `hasPermission()` method overrides in:
- `UsersController` - for `/users/{id}` and `/users/{id}/worklogs`
- `AngelTypeController` - for `/users/{id}/angeltypes`
- `ShiftsController` - for `/users/{id}/shifts`

The permission check allows access when the `user_id` parameter is `"self"` or matches the authenticated user's ID. For all other endpoints and other users' data, the `api` privilege is still required.

## Testing

All existing unit tests pass with these changes.