### PR TITLE
feat: add OAuth2 server for SSO identity provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "laravel/serializable-closure": "^2.0",
         "league/commonmark": "^2.7",
         "league/oauth2-client": "^2.7",
+        "league/oauth2-server": "^8.5",
         "league/openapi-psr7-validator": "^0.22.0",
         "nikic/fast-route": "^1.3",
         "nyholm/psr7": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b1bbcb0ba04a66eb133d7531fef1b18",
+    "content-hash": "34d2df6b295ce3524b60de81bc8f6de4",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -239,6 +239,73 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "defuse/php-encryption",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/defuse/php-encryption.git",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/f53396c2d34225064647a05ca76c1da9d99e5828",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/random_compat": ">= 2",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5|^6|^7|^8|^9|^10",
+                "yoast/phpunit-polyfills": "^2.0.0"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Hornby",
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Secure PHP Encryption Library",
+            "keywords": [
+                "aes",
+                "authenticated encryption",
+                "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
+                "encryption",
+                "openssl",
+                "security",
+                "symmetric key cryptography"
+            ],
+            "support": {
+                "issues": "https://github.com/defuse/php-encryption/issues",
+                "source": "https://github.com/defuse/php-encryption/tree/v2.4.0"
+            },
+            "time": "2023-06-19T06:10:36+00:00"
         },
         {
             "name": "devizzent/cebe-php-openapi",
@@ -2176,6 +2243,143 @@
             "time": "2025-11-21T20:52:36+00:00"
         },
         {
+            "name": "lcobucci/clock",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/db3713a61addfffd615b79bf0bc22f0ccc61b86b",
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/coding-standard": "^11.1.0",
+                "phpstan/extension-installer": "^1.3.1",
+                "phpstan/phpstan": "^1.10.25",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^11.3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
+                }
+            ],
+            "description": "Yet another clock abstraction",
+            "support": {
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/3.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-09-24T20:45:14+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "5.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-17T11:30:53+00:00"
+        },
+        {
             "name": "league/commonmark",
             "version": "2.8.0",
             "source": {
@@ -2365,6 +2569,60 @@
             "time": "2022-12-11T20:36:23+00:00"
         },
         {
+            "name": "league/event",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/event.git",
+                "reference": "062ebb450efbe9a09bc2478e89b7c933875b0935"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/062ebb450efbe9a09bc2478e89b7c933875b0935",
+                "reference": "062ebb450efbe9a09bc2478e89b7c933875b0935",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "^2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Event package",
+            "keywords": [
+                "emitter",
+                "event",
+                "listener"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/event/issues",
+                "source": "https://github.com/thephpleague/event/tree/2.3.0"
+            },
+            "time": "2025-03-14T19:51:10+00:00"
+        },
+        {
             "name": "league/oauth2-client",
             "version": "2.9.0",
             "source": {
@@ -2430,6 +2688,94 @@
             "time": "2025-11-25T22:17:17+00:00"
         },
         {
+            "name": "league/oauth2-server",
+            "version": "8.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-server.git",
+                "reference": "cc8778350f905667e796b3c2364a9d3bd7a73518"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/cc8778350f905667e796b3c2364a9d3bd7a73518",
+                "reference": "cc8778350f905667e796b3c2364a9d3bd7a73518",
+                "shasum": ""
+            },
+            "require": {
+                "defuse/php-encryption": "^2.3",
+                "ext-openssl": "*",
+                "lcobucci/clock": "^2.2 || ^3.0",
+                "lcobucci/jwt": "^4.3 || ^5.0",
+                "league/event": "^2.2",
+                "league/uri": "^6.7 || ^7.0",
+                "php": "^8.0",
+                "psr/http-message": "^1.0.1 || ^2.0"
+            },
+            "replace": {
+                "league/oauth2server": "*",
+                "lncd/oauth2": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^3.0.0",
+                "phpstan/phpstan": "^0.12.57",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpunit/phpunit": "^9.6.6",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andy Millington",
+                    "email": "andrew@noexceptions.io",
+                    "homepage": "https://www.noexceptions.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
+            "homepage": "https://oauth2.thephpleague.com/",
+            "keywords": [
+                "Authentication",
+                "api",
+                "auth",
+                "authorisation",
+                "authorization",
+                "oauth",
+                "oauth 2",
+                "oauth 2.0",
+                "oauth2",
+                "protect",
+                "resource",
+                "secure",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-server/issues",
+                "source": "https://github.com/thephpleague/oauth2-server/tree/8.5.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sephster",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T23:06:10+00:00"
+        },
+        {
             "name": "league/openapi-psr7-validator",
             "version": "0.22",
             "source": {
@@ -2493,20 +2839,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.6.0",
+            "version": "7.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "f625804987a0a9112d954f9209d91fec52182344"
+                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/f625804987a0a9112d954f9209d91fec52182344",
-                "reference": "f625804987a0a9112d954f9209d91fec52182344",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
+                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.6",
+                "league/uri-interfaces": "^7.7",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -2579,7 +2925,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.6.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.7.0"
             },
             "funding": [
                 {
@@ -2587,20 +2933,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-18T12:17:23+00:00"
+            "time": "2025-12-07T16:02:06+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.6.0",
+            "version": "7.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368"
+                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/ccbfb51c0445298e7e0b7f4481b942f589665368",
-                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
+                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
                 "shasum": ""
             },
             "require": {
@@ -2663,7 +3009,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.6.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.7.0"
             },
             "funding": [
                 {
@@ -2671,7 +3017,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-18T12:17:23+00:00"
+            "time": "2025-12-07T16:03:21+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -3132,6 +3478,56 @@
                 }
             ],
             "time": "2024-09-09T07:06:30+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/config/app.php
+++ b/config/app.php
@@ -40,6 +40,9 @@ return [
         \Engelsystem\Helpers\DumpServerServiceProvider::class,
         \Engelsystem\Helpers\UuidServiceProvider::class,
         \Engelsystem\Controllers\Api\UsesAuthServiceProvider::class,
+
+        // OAuth2 Server (Identity Provider)
+        \Engelsystem\OAuth2Server\OAuth2ServerServiceProvider::class,
     ],
 
     // Application middleware

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -250,4 +250,29 @@ return [
             . 'you want to contribute, have found any [bugs](https://github.com/engelsystem/engelsystem/issues) '
             . 'or need help.',
     ],
+
+    // OAuth2 Server configuration (Engelsystem as Identity Provider)
+    // Enable this to allow external applications to authenticate via Engelsystem
+    'oauth2_server'           => [
+        // Enable the OAuth2 server functionality
+        'enabled' => (bool) env('OAUTH2_SERVER_ENABLED', false),
+
+        // Path to RSA private key for signing tokens
+        // Generate with: openssl genrsa -out storage/oauth-private.key 2048
+        'private_key' => env('OAUTH2_PRIVATE_KEY', null),
+
+        // Path to RSA public key for verifying tokens
+        // Generate with: openssl rsa -in storage/oauth-private.key -pubout -out storage/oauth-public.key
+        'public_key' => env('OAUTH2_PUBLIC_KEY', null),
+
+        // Encryption key for auth codes and refresh tokens (32+ characters)
+        // Generate with: php -r "echo bin2hex(random_bytes(32));"
+        'encryption_key' => env('OAUTH2_ENCRYPTION_KEY', null),
+
+        // Access token lifetime in seconds (default: 1 hour)
+        'access_token_ttl' => (int) env('OAUTH2_ACCESS_TOKEN_TTL', 3600),
+
+        // Refresh token lifetime in seconds (default: 30 days)
+        'refresh_token_ttl' => (int) env('OAUTH2_REFRESH_TOKEN_TTL', 2592000),
+    ],
 ];

--- a/config/routes.php
+++ b/config/routes.php
@@ -18,13 +18,24 @@ $route->get('/login', 'AuthController@login');
 $route->post('/login', 'AuthController@postLogin');
 $route->get('/logout', 'AuthController@logout');
 
-// OAuth
+// OAuth (client - Engelsystem as consumer)
 $route->addGroup(
     '/oauth/{provider}',
     function (RouteCollector $route): void {
         $route->get('', 'OAuthController@index');
         $route->post('/connect', 'OAuthController@connect');
         $route->post('/disconnect', 'OAuthController@disconnect');
+    }
+);
+
+// OAuth2 Server (Engelsystem as identity provider)
+$route->addGroup(
+    '/oauth2',
+    function (RouteCollector $route): void {
+        $route->get('/authorize', 'OAuth2\\AuthorizationController@authorize');
+        $route->post('/authorize', 'OAuth2\\AuthorizationController@processAuthorization');
+        $route->post('/token', 'OAuth2\\TokenController@token');
+        $route->get('/userinfo', 'OAuth2\\UserInfoController@userinfo');
     }
 );
 
@@ -48,6 +59,8 @@ $route->addGroup(
         $route->get('/oauth', 'SettingsController@oauth');
         $route->get('/sessions', 'SettingsController@sessions');
         $route->post('/sessions', 'SettingsController@sessionsDelete');
+        $route->get('/oauth2-applications', 'OAuth2ApplicationsController@index');
+        $route->post('/oauth2-applications/revoke', 'OAuth2ApplicationsController@revoke');
     }
 );
 
@@ -323,6 +336,16 @@ $route->addGroup(
             function (RouteCollector $route): void {
                 $route->get('[/{news_id:\d+}]', 'Admin\\NewsController@edit');
                 $route->post('[/{news_id:\d+}]', 'Admin\\NewsController@save');
+            }
+        );
+
+        // OAuth2 Clients
+        $route->addGroup(
+            '/oauth2-clients',
+            function (RouteCollector $route): void {
+                $route->get('', 'Admin\\OAuth2ClientsController@index');
+                $route->get('/edit[/{client_id:\d+}]', 'Admin\\OAuth2ClientsController@edit');
+                $route->post('/edit[/{client_id:\d+}]', 'Admin\\OAuth2ClientsController@save');
             }
         );
     }

--- a/db/migrations/2026_01_05_000000_create_oauth2_server_tables.php
+++ b/db/migrations/2026_01_05_000000_create_oauth2_server_tables.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateOauthserverTables extends Migration
+{
+    use Reference;
+
+    public function up(): void
+    {
+        // OAuth2 Clients
+        $this->schema->create('oauth2_clients', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->string('identifier', 80)->unique();
+            $table->string('name');
+            $table->text('secret')->nullable();
+            $table->text('redirect_uris');
+            $table->string('grants')->default('authorization_code');
+            $table->text('scopes')->nullable();
+            $table->boolean('confidential')->default(true);
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+
+        // OAuth2 Client AngelType restrictions (pivot table)
+        $this->schema->create('oauth2_client_angel_type', function (Blueprint $table): void {
+            $table->increments('id');
+            $this->references($table, 'oauth2_clients', 'oauth2_client_id');
+            $this->references($table, 'angel_types');
+            $table->unique(['oauth2_client_id', 'angel_type_id']);
+        });
+
+        // OAuth2 Access Tokens
+        $this->schema->create('oauth2_access_tokens', function (Blueprint $table): void {
+            $table->string('id', 100)->primary();
+            $this->references($table, 'oauth2_clients', 'oauth2_client_id');
+            $this->referencesUser($table)->nullable();
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked')->default(false);
+            $table->dateTime('expires_at');
+            $table->timestamps();
+        });
+
+        // OAuth2 Refresh Tokens
+        $this->schema->create('oauth2_refresh_tokens', function (Blueprint $table): void {
+            $table->string('id', 100)->primary();
+            $table->string('access_token_id', 100);
+            $table->boolean('revoked')->default(false);
+            $table->dateTime('expires_at');
+            $table->timestamps();
+
+            $table->foreign('access_token_id')
+                ->references('id')->on('oauth2_access_tokens')
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+        });
+
+        // OAuth2 Authorization Codes
+        $this->schema->create('oauth2_auth_codes', function (Blueprint $table): void {
+            $table->string('id', 100)->primary();
+            $this->references($table, 'oauth2_clients', 'oauth2_client_id');
+            $this->referencesUser($table);
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked')->default(false);
+            $table->dateTime('expires_at');
+            $table->text('redirect_uri');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        $this->schema->drop('oauth2_auth_codes');
+        $this->schema->drop('oauth2_refresh_tokens');
+        $this->schema->drop('oauth2_access_tokens');
+        $this->schema->drop('oauth2_client_angel_type');
+        $this->schema->drop('oauth2_clients');
+    }
+}

--- a/db/migrations/2026_01_05_000000_create_oauth2_server_tables.php
+++ b/db/migrations/2026_01_05_000000_create_oauth2_server_tables.php
@@ -7,7 +7,7 @@ namespace Engelsystem\Migrations;
 use Engelsystem\Database\Migration\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateOauthserverTables extends Migration
+class CreateOauth2ServerTables extends Migration
 {
     use Reference;
 

--- a/db/migrations/2026_01_05_000001_add_oauth2_admin_permission.php
+++ b/db/migrations/2026_01_05_000001_add_oauth2_admin_permission.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+
+class AddOauthadminPermission extends Migration
+{
+    public function up(): void
+    {
+        $connection = $this->schema->getConnection();
+
+        $connection->table('privileges')->insert([
+            'name' => 'oauth2.clients.edit',
+            'description' => 'Manage OAuth2 clients',
+        ]);
+
+        $privilegeId = $connection->table('privileges')
+            ->where('name', 'oauth2.clients.edit')
+            ->value('id');
+
+        // Assign to Developer group (id: 90)
+        $connection->table('group_privileges')->insert([
+            'group_id' => 90,
+            'privilege_id' => $privilegeId,
+        ]);
+    }
+
+    public function down(): void
+    {
+        $connection = $this->schema->getConnection();
+
+        $privilegeId = $connection->table('privileges')
+            ->where('name', 'oauth2.clients.edit')
+            ->value('id');
+
+        if ($privilegeId) {
+            $connection->table('group_privileges')
+                ->where('privilege_id', $privilegeId)
+                ->delete();
+
+            $connection->table('privileges')
+                ->where('id', $privilegeId)
+                ->delete();
+        }
+    }
+}

--- a/db/migrations/2026_01_05_000001_add_oauth2_admin_permission.php
+++ b/db/migrations/2026_01_05_000001_add_oauth2_admin_permission.php
@@ -6,7 +6,7 @@ namespace Engelsystem\Migrations;
 
 use Engelsystem\Database\Migration\Migration;
 
-class AddOauthadminPermission extends Migration
+class AddOauth2AdminPermission extends Migration
 {
     public function up(): void
     {

--- a/includes/sys_menu.php
+++ b/includes/sys_menu.php
@@ -78,6 +78,7 @@ function make_navigation(): array
         'admin/tags'         => ['tag.tags', 'tag.edit'],
         'admin/logs'         => ['log.log', 'admin_log'],
         'admin/config'       => ['config.config', 'config.edit'],
+        'admin/oauth2-clients' => ['OAuth2 Clients', 'oauth2.clients.edit'],
     ];
 
     if (config('autoarrive')) {

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -795,3 +795,139 @@ msgstr "/metrics buckets"
 
 msgid "config.var_dump_server"
 msgstr "var_dump server"
+
+# OAuth2 Server (Identity Provider)
+msgid "oauth2.clients.title"
+msgstr "OAuth2 Clients"
+
+msgid "oauth2.clients.none"
+msgstr "No OAuth2 clients configured."
+
+msgid "oauth2.client.identifier"
+msgstr "Client ID"
+
+msgid "oauth2.client.redirect_uris"
+msgstr "Redirect URIs"
+
+msgid "oauth2.client.angel_types"
+msgstr "Restricted to Angel Types"
+
+msgid "oauth2.client.all_users"
+msgstr "All users"
+
+msgid "oauth2.client.active"
+msgstr "Active"
+
+msgid "oauth2.client.edit"
+msgstr "Edit OAuth2 Client"
+
+msgid "oauth2.client.create"
+msgstr "Create OAuth2 Client"
+
+msgid "oauth2.client.identifier_info"
+msgstr "This is the client_id used by external applications."
+
+msgid "oauth2.client.redirect_uris_info"
+msgstr "One URI per line. These are the allowed callback URLs."
+
+msgid "oauth2.client.grants"
+msgstr "Grant Types"
+
+msgid "oauth2.client.scopes"
+msgstr "Allowed Scopes"
+
+msgid "oauth2.client.scopes_info"
+msgstr "If none selected, all scopes are allowed."
+
+msgid "oauth2.client.angel_types_info"
+msgstr "If selected, only confirmed members of these angel types can use this client. Leave empty to allow all users."
+
+msgid "oauth2.client.confidential"
+msgstr "Confidential Client"
+
+msgid "oauth2.client.confidential_info"
+msgstr "Confidential clients have a secret. Public clients (mobile apps) do not."
+
+msgid "oauth2.client.regenerate_secret"
+msgstr "Regenerate Client Secret"
+
+msgid "oauth2.client.regenerate_secret_info"
+msgstr "Generate a new client secret. The old secret will no longer work."
+
+msgid "oauth2.client.secret_warning"
+msgstr "Client Secret Generated"
+
+msgid "oauth2.client.secret_info"
+msgstr "Copy this secret now! It will not be shown again."
+
+msgid "oauth2.client.saved"
+msgstr "OAuth2 client saved."
+
+msgid "oauth2.client.deleted"
+msgstr "OAuth2 client deleted."
+
+msgid "oauth2.client.delete.confirm"
+msgstr "Really delete OAuth2 client '%s'? All tokens will be revoked."
+
+msgid "oauth2.authorize.title"
+msgstr "Authorize Application"
+
+msgid "oauth2.authorize.request"
+msgstr "The application '%s' would like to access your account."
+
+msgid "oauth2.authorize.scopes_intro"
+msgstr "This application will be able to:"
+
+msgid "oauth2.authorize.approve"
+msgstr "Authorize"
+
+msgid "oauth2.authorize.deny"
+msgstr "Deny"
+
+msgid "oauth2.authorize.info"
+msgstr "You can revoke this access at any time in your settings."
+
+msgid "oauth2.error.session_expired"
+msgstr "Authorization session expired. Please try again."
+
+msgid "oauth2.scope.openid"
+msgstr "Identify you"
+
+msgid "oauth2.scope.profile"
+msgstr "Access your profile (name, username, pronoun)"
+
+msgid "oauth2.scope.email"
+msgstr "Access your email address"
+
+msgid "oauth2.scope.angeltypes"
+msgstr "Access your angel type memberships"
+
+msgid "oauth2.scope.groups"
+msgstr "Access your permission groups"
+
+msgid "oauth2.applications.title"
+msgstr "Authorized Applications"
+
+msgid "oauth2.applications.description"
+msgstr "These applications have been authorized to access your account."
+
+msgid "oauth2.applications.none"
+msgstr "No applications have been authorized to access your account."
+
+msgid "oauth2.applications.authorized"
+msgstr "Last authorized"
+
+msgid "oauth2.applications.permissions"
+msgstr "Permissions"
+
+msgid "oauth2.applications.revoke"
+msgstr "Revoke Access"
+
+msgid "oauth2.applications.revoke.confirm"
+msgstr "Revoke access for '%s'? The application will no longer be able to access your account."
+
+msgid "oauth2.application.revoked"
+msgstr "Application access revoked."
+
+msgid "form.copy"
+msgstr "Copy"

--- a/resources/views/admin/oauth2-clients/edit.twig
+++ b/resources/views/admin/oauth2-clients/edit.twig
@@ -1,0 +1,127 @@
+{% extends 'layouts/app.twig' %}
+{% import 'macros/base.twig' as m %}
+{% import 'macros/form.twig' as f %}
+
+{% block title %}{{ client ? __('oauth2.client.edit') : __('oauth2.client.create') }}{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <h1>
+            {{ m.back(url('/admin/oauth2-clients')) }}
+            {{ block('title') }}
+        </h1>
+
+        {% include 'layouts/parts/messages.twig' %}
+
+        {% if new_secret is defined %}
+            <div class="alert alert-warning">
+                <h5>{{ m.icon('exclamation-triangle') }} {{ __('oauth2.client.secret_warning') }}</h5>
+                <p>{{ __('oauth2.client.secret_info') }}</p>
+                <div class="input-group">
+                    <input type="text" class="form-control font-monospace" value="{{ new_secret }}" readonly id="client-secret">
+                    <button class="btn btn-outline-secondary" type="button" onclick="navigator.clipboard.writeText(document.getElementById('client-secret').value)">
+                        {{ m.icon('clipboard') }} {{ __('form.copy') }}
+                    </button>
+                </div>
+            </div>
+        {% endif %}
+
+        <form method="post">
+            {{ csrf() }}
+
+            <div class="row">
+                <div class="col-lg-6">
+                    {{ f.input('name', __('general.name'), {
+                        'required': true,
+                        'required_icon': true,
+                        'value': f.formData('name', client ? client.name : ''),
+                        'max_length': 255,
+                    }) }}
+
+                    {% if client %}
+                        <div class="mb-3">
+                            <label class="form-label">{{ __('oauth2.client.identifier') }}</label>
+                            <input type="text" class="form-control font-monospace" value="{{ client.identifier }}" readonly>
+                            <div class="form-text">{{ __('oauth2.client.identifier_info') }}</div>
+                        </div>
+                    {% endif %}
+
+                    {{ f.textarea('redirect_uris', __('oauth2.client.redirect_uris'), {
+                        'required': true,
+                        'required_icon': true,
+                        'value': f.formData('redirect_uris', client ? client.redirect_uris|join("\n") : ''),
+                        'rows': 3,
+                        'info': __('oauth2.client.redirect_uris_info'),
+                    }) }}
+
+                    <div class="mb-3">
+                        <label class="form-label">{{ __('oauth2.client.grants') }}</label>
+                        {% for value, label in available_grants %}
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" name="grants[]" value="{{ value }}" id="grant-{{ value }}"
+                                    {{ (client and value in client.getGrantsArray()) or (not client and value == 'authorization_code') ? 'checked' : '' }}>
+                                <label class="form-check-label" for="grant-{{ value }}">{{ label }}</label>
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    {{ f.switch('confidential', __('oauth2.client.confidential'), {
+                        'checked': f.formData('confidential', client ? client.confidential : true),
+                        'info': __('oauth2.client.confidential_info'),
+                    }) }}
+
+                    {% if client and client.confidential %}
+                        {{ f.switch('regenerate_secret', __('oauth2.client.regenerate_secret'), {
+                            'checked': false,
+                            'info': __('oauth2.client.regenerate_secret_info'),
+                        }) }}
+                    {% endif %}
+                </div>
+
+                <div class="col-lg-6">
+                    <div class="mb-3">
+                        <label class="form-label">{{ __('oauth2.client.scopes') }}</label>
+                        <div class="form-text mb-2">{{ __('oauth2.client.scopes_info') }}</div>
+                        {% for value, description in available_scopes %}
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" name="scopes[]" value="{{ value }}" id="scope-{{ value }}"
+                                    {{ client and client.scopes and value in client.scopes ? 'checked' : '' }}
+                                    {{ not client ? 'checked' : '' }}>
+                                <label class="form-check-label" for="scope-{{ value }}">
+                                    <strong>{{ value }}</strong> - {{ description }}
+                                </label>
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">{{ __('oauth2.client.angel_types') }}</label>
+                        <div class="form-text mb-2">{{ __('oauth2.client.angel_types_info') }}</div>
+                        {% for angelType in angel_types %}
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" name="angel_types[]" value="{{ angelType.id }}" id="at-{{ angelType.id }}"
+                                    {{ client and angelType.id in client.angelTypes.pluck('id').toArray() ? 'checked' : '' }}>
+                                <label class="form-check-label" for="at-{{ angelType.id }}">{{ angelType.name }}</label>
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    {{ f.switch('active', __('oauth2.client.active'), {
+                        'checked': f.formData('active', client ? client.active : true),
+                    }) }}
+                </div>
+            </div>
+
+            <div class="row mt-3">
+                <div class="col-md-12">
+                    <div class="btn-group">
+                        {{ f.submit(__('form.save'), {'icon_left': 'save'}) }}
+                        {% if client %}
+                            {{ f.delete(__('form.delete'), {'confirm_title': __('oauth2.client.delete.confirm', [client.name|e])}) }}
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/resources/views/admin/oauth2-clients/index.twig
+++ b/resources/views/admin/oauth2-clients/index.twig
@@ -1,0 +1,72 @@
+{% extends 'layouts/app.twig' %}
+{% import 'macros/base.twig' as m %}
+{% import 'macros/form.twig' as f %}
+
+{% block title %}{{ __('oauth2.clients.title') }}{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <h1>
+            {{ block('title') }}
+            {{ m.add(url('/admin/oauth2-clients/edit')) }}
+        </h1>
+
+        {% include 'layouts/parts/messages.twig' %}
+
+        <div class="row">
+            <div class="col-md-12">
+                {% if clients is empty %}
+                    {{ m.alert(__('oauth2.clients.none'), 'info') }}
+                {% else %}
+                    <div class="table-responsive">
+                        <table class="table table-striped">
+                            <thead>
+                                <tr>
+                                    <th>{{ __('general.name') }}</th>
+                                    <th>{{ __('oauth2.client.identifier') }}</th>
+                                    <th>{{ __('oauth2.client.redirect_uris') }}</th>
+                                    <th>{{ __('oauth2.client.angel_types') }}</th>
+                                    <th>{{ __('oauth2.client.active') }}</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for client in clients %}
+                                    <tr>
+                                        <td>{{ client.name }}</td>
+                                        <td><code>{{ client.identifier }}</code></td>
+                                        <td>
+                                            {% for uri in client.redirect_uris %}
+                                                <small>{{ uri }}</small>{% if not loop.last %}<br>{% endif %}
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% if client.angelTypes is empty %}
+                                                <span class="text-muted">{{ __('oauth2.client.all_users') }}</span>
+                                            {% else %}
+                                                {% for angelType in client.angelTypes %}
+                                                    <span class="badge bg-secondary">{{ angelType.name }}</span>
+                                                {% endfor %}
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ m.iconBool(client.active) }}</td>
+                                        <td>
+                                            <div class="d-flex ms-auto">
+                                                {{ m.edit(url('/admin/oauth2-clients/edit/' ~ client.id)) }}
+                                                <form method="post" class="ps-1">
+                                                    {{ csrf() }}
+                                                    {{ f.hidden('id', client.id) }}
+                                                    {{ f.delete(null, {'size': 'sm', 'confirm_title': __('oauth2.client.delete.confirm', [client.name|e])}) }}
+                                                </form>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/resources/views/pages/oauth2/authorize.twig
+++ b/resources/views/pages/oauth2/authorize.twig
@@ -1,0 +1,64 @@
+{% extends 'layouts/app.twig' %}
+{% import 'macros/base.twig' as m %}
+{% import 'macros/form.twig' as f %}
+
+{% block title %}{{ __('oauth2.authorize.title') }}{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-6 col-lg-5">
+                <div class="card {% if theme.type == 'light' %}bg-light{% else %}bg-secondary{% endif %} mt-5">
+                    <div class="card-header">
+                        <h4 class="mb-0">{{ __('oauth2.authorize.title') }}</h4>
+                    </div>
+                    <div class="card-body {{ theme.type == 'light' ? 'bg-light' : 'bg-secondary' }}">
+                        <p class="lead">
+                            {{ __('oauth2.authorize.request', [client.name]) }}
+                        </p>
+
+                        {% if scopes is not empty %}
+                            <p class="text-muted">{{ __('oauth2.authorize.scopes_intro') }}</p>
+                            <ul class="list-group mb-4">
+                                {% for scope in scopes %}
+                                    <li class="list-group-item">
+                                        {{ m.icon('check-circle') }}
+                                        {% if scope.identifier == 'openid' %}
+                                            {{ __('oauth2.scope.openid') }}
+                                        {% elseif scope.identifier == 'profile' %}
+                                            {{ __('oauth2.scope.profile') }}
+                                        {% elseif scope.identifier == 'email' %}
+                                            {{ __('oauth2.scope.email') }}
+                                        {% elseif scope.identifier == 'angeltypes' %}
+                                            {{ __('oauth2.scope.angeltypes') }}
+                                        {% elseif scope.identifier == 'groups' %}
+                                            {{ __('oauth2.scope.groups') }}
+                                        {% else %}
+                                            {{ scope.identifier }}
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+
+                        <form method="post">
+                            {{ csrf() }}
+
+                            <div class="d-grid gap-2">
+                                <button type="submit" name="approve" value="1" class="btn btn-primary">
+                                    {{ m.icon('check') }} {{ __('oauth2.authorize.approve') }}
+                                </button>
+                                <button type="submit" name="deny" value="1" class="btn btn-secondary">
+                                    {{ m.icon('x') }} {{ __('oauth2.authorize.deny') }}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="card-footer {{ theme.type == 'light' ? 'bg-light' : 'bg-secondary' }} text-muted small">
+                        {{ __('oauth2.authorize.info') }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/resources/views/pages/settings/oauth2-applications.twig
+++ b/resources/views/pages/settings/oauth2-applications.twig
@@ -1,0 +1,72 @@
+{% extends 'layouts/app.twig' %}
+{% import 'macros/base.twig' as m %}
+{% import 'macros/form.twig' as f %}
+
+{% block title %}{{ __('oauth2.applications.title') }}{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 mb-4">
+                {% include 'pages/settings/partials/menu.twig' %}
+            </div>
+            <div class="col-md-9">
+                <h1>{{ block('title') }}</h1>
+
+                {% include 'layouts/parts/messages.twig' %}
+
+                <p class="text-muted">{{ __('oauth2.applications.description') }}</p>
+
+                {% if applications is empty %}
+                    {{ m.alert(__('oauth2.applications.none'), 'info') }}
+                {% else %}
+                    <div class="list-group">
+                        {% for app in applications %}
+                            <div class="list-group-item">
+                                <div class="d-flex w-100 justify-content-between align-items-start">
+                                    <div>
+                                        <h5 class="mb-1">{{ app.client.name }}</h5>
+                                        <p class="mb-1 text-muted small">
+                                            {{ __('oauth2.applications.authorized') }}:
+                                            {{ app.last_used|date(__('Y-m-d H:i')) }}
+                                        </p>
+                                        {% if app.scopes %}
+                                            <p class="mb-1">
+                                                <strong>{{ __('oauth2.applications.permissions') }}:</strong>
+                                                {% for scope in app.scopes %}
+                                                    <span class="badge bg-secondary">
+                                                        {% if scope == 'openid' %}
+                                                            {{ __('oauth2.scope.openid') }}
+                                                        {% elseif scope == 'profile' %}
+                                                            {{ __('oauth2.scope.profile') }}
+                                                        {% elseif scope == 'email' %}
+                                                            {{ __('oauth2.scope.email') }}
+                                                        {% elseif scope == 'angeltypes' %}
+                                                            {{ __('oauth2.scope.angeltypes') }}
+                                                        {% elseif scope == 'groups' %}
+                                                            {{ __('oauth2.scope.groups') }}
+                                                        {% else %}
+                                                            {{ scope }}
+                                                        {% endif %}
+                                                    </span>
+                                                {% endfor %}
+                                            </p>
+                                        {% endif %}
+                                    </div>
+                                    <form method="post" action="{{ url('/settings/oauth2-applications/revoke') }}">
+                                        {{ csrf() }}
+                                        {{ f.hidden('client_id', app.client.id) }}
+                                        <button type="submit" class="btn btn-outline-danger btn-sm"
+                                                onclick="return confirm('{{ __('oauth2.applications.revoke.confirm', [app.client.name|e]) }}')">
+                                            {{ m.icon('x-circle') }} {{ __('oauth2.applications.revoke') }}
+                                        </button>
+                                    </form>
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Controllers/Admin/OAuth2ClientsController.php
+++ b/src/Controllers/Admin/OAuth2ClientsController.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers\Admin;
+
+use Engelsystem\Controllers\BaseController;
+use Engelsystem\Controllers\HasUserNotifications;
+use Engelsystem\Http\Redirector;
+use Engelsystem\Http\Request;
+use Engelsystem\Http\Response;
+use Engelsystem\Models\AngelType;
+use Engelsystem\Models\OAuth2Client;
+use Engelsystem\OAuth2Server\Repository\ScopeRepository;
+use Illuminate\Support\Str;
+use Psr\Log\LoggerInterface;
+
+class OAuth2ClientsController extends BaseController
+{
+    use HasUserNotifications;
+
+    /** @var array<string, string> */
+    protected array $permissions = [
+        'oauth2.clients.edit',
+    ];
+
+    public function __construct(
+        protected LoggerInterface $log,
+        protected OAuth2Client $client,
+        protected AngelType $angelType,
+        protected Redirector $redirect,
+        protected Response $response,
+        protected ScopeRepository $scopeRepository
+    ) {
+    }
+
+    public function index(): Response
+    {
+        $clients = $this->client->with('angelTypes')->orderBy('name')->get();
+
+        return $this->response->withView('admin/oauth2-clients/index.twig', [
+            'clients' => $clients,
+        ]);
+    }
+
+    public function edit(Request $request): Response
+    {
+        $clientId = (int) $request->getAttribute('client_id');
+        $client = $clientId ? $this->client->with('angelTypes')->find($clientId) : null;
+        $angelTypes = $this->angelType->orderBy('name')->get();
+
+        return $this->response->withView('admin/oauth2-clients/edit.twig', [
+            'client' => $client,
+            'angel_types' => $angelTypes,
+            'available_scopes' => $this->scopeRepository->getAvailableScopes(),
+            'available_grants' => $this->getAvailableGrants(),
+        ]);
+    }
+
+    public function save(Request $request): Response
+    {
+        $clientId = (int) $request->getAttribute('client_id');
+
+        /** @var OAuth2Client $client */
+        $client = $clientId ? $this->client->findOrNew($clientId) : new OAuth2Client();
+
+        if ($request->request->has('delete')) {
+            return $this->delete($client);
+        }
+
+        $data = $this->validate($request, [
+            'name' => 'required|max:255',
+            'redirect_uris' => 'required',
+            'grants' => 'required',
+            'scopes' => 'optional',
+            'confidential' => 'optional|checked',
+            'active' => 'optional|checked',
+            'angel_types' => 'optional',
+            'regenerate_secret' => 'optional|checked',
+        ]);
+
+        $client->name = $data['name'];
+        $client->redirect_uris = array_values(array_filter(
+            array_map('trim', explode("\n", $data['redirect_uris']))
+        ));
+        $client->grants = is_array($data['grants'])
+            ? implode(',', $data['grants'])
+            : $data['grants'];
+        $client->scopes = !empty($data['scopes']) ? (array) $data['scopes'] : null;
+        $client->confidential = (bool) ($data['confidential'] ?? false);
+        $client->active = (bool) ($data['active'] ?? false);
+
+        // Generate identifier for new clients
+        if (!$client->identifier) {
+            $client->identifier = Str::random(40);
+        }
+
+        // Generate or regenerate secret
+        $plainSecret = null;
+        if ($client->confidential && (!$client->secret || !empty($data['regenerate_secret']))) {
+            $plainSecret = Str::random(64);
+            $client->secret = password_hash($plainSecret, PASSWORD_DEFAULT);
+        }
+
+        // Clear secret for public clients
+        if (!$client->confidential) {
+            $client->secret = null;
+        }
+
+        $client->save();
+
+        // Sync angel types
+        $angelTypeIds = !empty($data['angel_types']) ? (array) $data['angel_types'] : [];
+        $client->angelTypes()->sync($angelTypeIds);
+
+        $this->log->info(
+            'Saved OAuth2 client "{name}" ({id})',
+            ['name' => $client->name, 'id' => $client->id]
+        );
+
+        $this->addNotification('oauth2.client.saved');
+
+        // Show the new secret if generated
+        if ($plainSecret) {
+            return $this->response->withView('admin/oauth2-clients/edit.twig', [
+                'client' => $client->fresh(['angelTypes']),
+                'angel_types' => $this->angelType->orderBy('name')->get(),
+                'available_scopes' => $this->scopeRepository->getAvailableScopes(),
+                'available_grants' => $this->getAvailableGrants(),
+                'new_secret' => $plainSecret,
+            ]);
+        }
+
+        return $this->redirect->to('/admin/oauth2-clients');
+    }
+
+    protected function delete(OAuth2Client $client): Response
+    {
+        if (!$client->id) {
+            return $this->redirect->to('/admin/oauth2-clients');
+        }
+
+        $name = $client->name;
+        $id = $client->id;
+
+        // Delete related tokens first
+        $client->accessTokens()->delete();
+        $client->angelTypes()->detach();
+        $client->delete();
+
+        $this->log->info('Deleted OAuth2 client "{name}" ({id})', [
+            'name' => $name,
+            'id' => $id,
+        ]);
+
+        $this->addNotification('oauth2.client.deleted');
+
+        return $this->redirect->to('/admin/oauth2-clients');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function getAvailableGrants(): array
+    {
+        return [
+            'authorization_code' => 'Authorization Code',
+            'refresh_token' => 'Refresh Token',
+        ];
+    }
+}

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -66,6 +66,7 @@ class AuthController extends BaseController
     public function loginUser(User $user): Response
     {
         $previousPage = $this->session->get('previous_page');
+        $oauth2Params = $this->session->get('oauth2_auth_request_params');
 
         $this->session->invalidate();
         $this->session->set('user_id', $user->id);
@@ -73,6 +74,11 @@ class AuthController extends BaseController
 
         $user->last_login_at = new Carbon();
         $user->save(['touch' => false]);
+
+        // Redirect back to OAuth2 authorization if there was a pending request
+        if ($oauth2Params) {
+            return $this->redirect->to('/oauth2/authorize?' . http_build_query($oauth2Params));
+        }
 
         return $this->redirect->to($previousPage ?: $this->config->get('home_site'));
     }

--- a/src/Controllers/OAuth2/AuthorizationController.php
+++ b/src/Controllers/OAuth2/AuthorizationController.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers\OAuth2;
+
+use Engelsystem\Controllers\BaseController;
+use Engelsystem\Controllers\HasUserNotifications;
+use Engelsystem\Helpers\Authenticator;
+use Engelsystem\Http\Redirector;
+use Engelsystem\Http\Request;
+use Engelsystem\Http\Response;
+use Engelsystem\Models\OAuth2Client;
+use Engelsystem\OAuth2Server\Entity\UserEntity;
+use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class AuthorizationController extends BaseController
+{
+    use HasUserNotifications;
+
+    public function __construct(
+        protected AuthorizationServer $server,
+        protected Authenticator $auth,
+        protected LoggerInterface $log,
+        protected OAuth2Client $clientModel,
+        protected Redirector $redirect,
+        protected Response $response,
+        protected SessionInterface $session
+    ) {
+    }
+
+    /**
+     * Display authorization consent screen
+     * GET /oauth2/authorize
+     */
+    public function authorize(Request $request): ResponseInterface
+    {
+        $user = $this->auth->user();
+
+        if (!$user) {
+            // Store OAuth request in session and redirect to login
+            $this->session->set('oauth2_auth_request_params', $request->getQueryParams());
+            return $this->redirect->to('/login');
+        }
+
+        try {
+            $authRequest = $this->server->validateAuthorizationRequest($request);
+
+            // Get client model for angeltype check
+            $client = $this->clientModel
+                ->with('angelTypes')
+                ->where('identifier', $authRequest->getClient()->getIdentifier())
+                ->first();
+
+            if (!$client) {
+                throw OAuthServerException::invalidClient($request);
+            }
+
+            // Check angeltype restrictions
+            if (!$this->userCanAccessClient($user, $client)) {
+                $this->log->warning('OAuth2 access denied: user {user} not in required angeltype for client {client}', [
+                    'user' => $user->name,
+                    'client' => $client->name,
+                ]);
+
+                throw OAuthServerException::accessDenied(
+                    'You do not have permission to access this application. ' .
+                    'You must be a confirmed member of one of the required angel types.'
+                );
+            }
+
+            // Store auth request in session for POST
+            $this->session->set('oauth2_auth_request', serialize($authRequest));
+
+            return $this->response->withView('pages/oauth2/authorize.twig', [
+                'client' => $client,
+                'scopes' => $authRequest->getScopes(),
+                'state' => $request->get('state'),
+            ]);
+        } catch (OAuthServerException $e) {
+            $this->log->warning('OAuth2 authorization error: {error}', [
+                'error' => $e->getMessage(),
+                'hint' => $e->getHint(),
+            ]);
+            return $e->generateHttpResponse($this->response);
+        }
+    }
+
+    /**
+     * Process authorization decision
+     * POST /oauth2/authorize
+     */
+    public function processAuthorization(Request $request): ResponseInterface
+    {
+        $user = $this->auth->user();
+
+        if (!$user) {
+            return $this->redirect->to('/login');
+        }
+
+        $serialized = $this->session->get('oauth2_auth_request');
+        if (!$serialized) {
+            $this->addNotification('oauth2.error.session_expired');
+            return $this->redirect->to('/');
+        }
+
+        try {
+            $authRequest = unserialize($serialized);
+            $this->session->remove('oauth2_auth_request');
+
+            if ($request->request->has('approve')) {
+                $authRequest->setUser(new UserEntity($user));
+                $authRequest->setAuthorizationApproved(true);
+
+                $this->log->info('OAuth2 authorization approved for user {user} on client {client}', [
+                    'user' => $user->name,
+                    'client' => $authRequest->getClient()->getIdentifier(),
+                ]);
+            } else {
+                $authRequest->setAuthorizationApproved(false);
+
+                $this->log->info('OAuth2 authorization denied by user {user} for client {client}', [
+                    'user' => $user->name,
+                    'client' => $authRequest->getClient()->getIdentifier(),
+                ]);
+            }
+
+            return $this->server->completeAuthorizationRequest($authRequest, $this->response);
+        } catch (OAuthServerException $e) {
+            $this->log->warning('OAuth2 authorization completion error: {error}', [
+                'error' => $e->getMessage(),
+            ]);
+            return $e->generateHttpResponse($this->response);
+        }
+    }
+
+    /**
+     * Check if user can access this OAuth client based on angeltype restrictions
+     */
+    protected function userCanAccessClient($user, OAuth2Client $client): bool
+    {
+        $requiredAngelTypes = $client->angelTypes;
+
+        // If no restrictions, allow all authenticated users
+        if ($requiredAngelTypes->isEmpty()) {
+            return true;
+        }
+
+        // Check if user is a confirmed member of any required angeltype
+        $userAngelTypeIds = $user->userAngelTypes()
+            ->whereNotNull('confirm_user_id')
+            ->pluck('angel_types.id');
+
+        return $requiredAngelTypes->pluck('id')
+            ->intersect($userAngelTypeIds)
+            ->isNotEmpty();
+    }
+}

--- a/src/Controllers/OAuth2/TokenController.php
+++ b/src/Controllers/OAuth2/TokenController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers\OAuth2;
+
+use Engelsystem\Controllers\BaseController;
+use Engelsystem\Http\Request;
+use Engelsystem\Http\Response;
+use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+
+class TokenController extends BaseController
+{
+    public function __construct(
+        protected AuthorizationServer $server,
+        protected LoggerInterface $log,
+        protected Response $response
+    ) {
+    }
+
+    /**
+     * Handle token requests
+     * POST /oauth2/token
+     */
+    public function token(Request $request): ResponseInterface
+    {
+        try {
+            // Use a proper PSR-7 response that handles streams correctly
+            $psrResponse = new \Nyholm\Psr7\Response();
+            $psrResponse = $this->server->respondToAccessTokenRequest($request, $psrResponse);
+
+            // Convert back to Engelsystem Response
+            return $this->response
+                ->withStatus($psrResponse->getStatusCode())
+                ->withHeader('Content-Type', 'application/json')
+                ->withContent((string) $psrResponse->getBody());
+        } catch (OAuthServerException $e) {
+            $this->log->warning('OAuth2 token error: {error}', [
+                'error' => $e->getMessage(),
+                'hint' => $e->getHint(),
+            ]);
+
+            $psrResponse = new \Nyholm\Psr7\Response();
+            $psrResponse = $e->generateHttpResponse($psrResponse);
+
+            return $this->response
+                ->withStatus($psrResponse->getStatusCode())
+                ->withHeader('Content-Type', 'application/json')
+                ->withContent((string) $psrResponse->getBody());
+        } catch (\Exception $e) {
+            $this->log->error('OAuth2 token exception: {error}', [
+                'error' => $e->getMessage(),
+            ]);
+
+            $oauthException = new OAuthServerException(
+                'An unexpected error occurred',
+                0,
+                'server_error',
+                500
+            );
+
+            $psrResponse = new \Nyholm\Psr7\Response();
+            $psrResponse = $oauthException->generateHttpResponse($psrResponse);
+
+            return $this->response
+                ->withStatus($psrResponse->getStatusCode())
+                ->withHeader('Content-Type', 'application/json')
+                ->withContent((string) $psrResponse->getBody());
+        }
+    }
+}

--- a/src/Controllers/OAuth2/UserInfoController.php
+++ b/src/Controllers/OAuth2/UserInfoController.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers\OAuth2;
+
+use Engelsystem\Controllers\BaseController;
+use Engelsystem\Http\Request;
+use Engelsystem\Http\Response;
+use Engelsystem\Models\OAuth2AccessToken;
+use Engelsystem\Models\User\User;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\ResourceServer;
+use Psr\Log\LoggerInterface;
+
+class UserInfoController extends BaseController
+{
+    public function __construct(
+        protected ResourceServer $resourceServer,
+        protected LoggerInterface $log,
+        protected Response $response,
+        protected OAuth2AccessToken $accessTokenModel,
+        protected User $userModel
+    ) {
+    }
+
+    /**
+     * Return user information based on the access token
+     * GET /oauth2/userinfo
+     */
+    public function userinfo(Request $request): Response
+    {
+        try {
+            // Validate the access token
+            $request = $this->resourceServer->validateAuthenticatedRequest($request);
+
+            $tokenId = $request->getAttribute('oauth_access_token_id');
+            $userId = $request->getAttribute('oauth_user_id');
+            $scopes = $request->getAttribute('oauth_scopes', []);
+
+            // Get the user
+            $user = $this->userModel->find($userId);
+
+            if (!$user) {
+                return $this->errorResponse('User not found', 404);
+            }
+
+            $userInfo = $this->buildUserInfo($user, $scopes);
+
+            return $this->response
+                ->withHeader('Content-Type', 'application/json')
+                ->withContent(json_encode($userInfo));
+        } catch (OAuthServerException $e) {
+            $this->log->warning('OAuth2 userinfo error: {error}', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->response
+                ->withStatus(401)
+                ->withHeader('WWW-Authenticate', 'Bearer error="invalid_token"')
+                ->withHeader('Content-Type', 'application/json')
+                ->withContent(json_encode([
+                    'error' => 'invalid_token',
+                    'error_description' => $e->getMessage(),
+                ]));
+        } catch (\Exception $e) {
+            $this->log->error('OAuth2 userinfo exception: {error}', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->errorResponse('Internal server error', 500);
+        }
+    }
+
+    /**
+     * Build user info response based on granted scopes
+     *
+     * @param array<string> $scopes
+     * @return array<string, mixed>
+     */
+    protected function buildUserInfo(User $user, array $scopes): array
+    {
+        // 'sub' is always included (required by OIDC)
+        $info = [
+            'sub' => (string) $user->id,
+        ];
+
+        if (in_array('profile', $scopes, true)) {
+            $info['name'] = $user->displayName;
+            $info['preferred_username'] = $user->name;
+
+            if ($user->personalData && $user->personalData->pronoun) {
+                $info['pronoun'] = $user->personalData->pronoun;
+            }
+
+            if ($user->personalData) {
+                if ($user->personalData->first_name) {
+                    $info['given_name'] = $user->personalData->first_name;
+                }
+                if ($user->personalData->last_name) {
+                    $info['family_name'] = $user->personalData->last_name;
+                }
+            }
+        }
+
+        if (in_array('email', $scopes, true)) {
+            $info['email'] = $user->email;
+        }
+
+        if (in_array('angeltypes', $scopes, true)) {
+            $info['angeltypes'] = $user->userAngelTypes()
+                ->whereNotNull('confirm_user_id')
+                ->get()
+                ->map(fn($angelType) => [
+                    'id' => $angelType->id,
+                    'name' => $angelType->name,
+                    'supporter' => (bool) $angelType->pivot->supporter,
+                ])
+                ->toArray();
+        }
+
+        if (in_array('groups', $scopes, true)) {
+            $info['groups'] = $user->groups->pluck('name')->toArray();
+        }
+
+        return $info;
+    }
+
+    protected function errorResponse(string $message, int $status): Response
+    {
+        return $this->response
+            ->withStatus($status)
+            ->withHeader('Content-Type', 'application/json')
+            ->withContent(json_encode([
+                'error' => 'server_error',
+                'error_description' => $message,
+            ]));
+    }
+}

--- a/src/Controllers/OAuth2ApplicationsController.php
+++ b/src/Controllers/OAuth2ApplicationsController.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers;
+
+use Carbon\Carbon;
+use Engelsystem\Helpers\Authenticator;
+use Engelsystem\Http\Redirector;
+use Engelsystem\Http\Request;
+use Engelsystem\Http\Response;
+use Engelsystem\Models\OAuth2AccessToken;
+use Psr\Log\LoggerInterface;
+
+class OAuth2ApplicationsController extends BaseController
+{
+    use HasUserNotifications;
+
+    /** @var string[] */
+    protected array $permissions = [
+        'user_settings',
+    ];
+
+    public function __construct(
+        protected Authenticator $auth,
+        protected LoggerInterface $log,
+        protected OAuth2AccessToken $accessTokenModel,
+        protected Redirector $redirect,
+        protected Response $response
+    ) {
+    }
+
+    /**
+     * List authorized OAuth2 applications for the current user
+     * GET /settings/oauth2-applications
+     */
+    public function index(): Response
+    {
+        $user = $this->auth->user();
+
+        // Get all active access tokens grouped by client
+        $tokens = $this->accessTokenModel
+            ->with('client')
+            ->where('user_id', $user->id)
+            ->where('revoked', false)
+            ->where('expires_at', '>', Carbon::now())
+            ->get()
+            ->groupBy('oauth2_client_id');
+
+        // Build application list with aggregated info
+        $applications = [];
+        foreach ($tokens as $clientTokens) {
+            $firstToken = $clientTokens->first();
+            if (!$firstToken->client) {
+                continue;
+            }
+
+            $applications[] = [
+                'client' => $firstToken->client,
+                'scopes' => $this->aggregateScopes($clientTokens),
+                'token_count' => $clientTokens->count(),
+                'last_used' => $clientTokens->max('created_at'),
+            ];
+        }
+
+        return $this->response->withView('pages/settings/oauth2-applications.twig', [
+            'applications' => $applications,
+        ]);
+    }
+
+    /**
+     * Revoke all tokens for an application
+     * POST /settings/oauth2-applications/revoke
+     */
+    public function revoke(Request $request): Response
+    {
+        $user = $this->auth->user();
+
+        $data = $this->validate($request, [
+            'client_id' => 'required|int',
+        ]);
+
+        $clientId = (int) $data['client_id'];
+
+        // Revoke all access tokens for this client and user
+        $tokens = $this->accessTokenModel
+            ->where('user_id', $user->id)
+            ->where('oauth2_client_id', $clientId)
+            ->where('revoked', false)
+            ->get();
+
+        foreach ($tokens as $token) {
+            $token->revoke();
+        }
+
+        $this->log->info('User {user} revoked OAuth2 access for client {client_id}', [
+            'user' => $user->name,
+            'client_id' => $clientId,
+        ]);
+
+        $this->addNotification('oauth2.application.revoked');
+
+        return $this->redirect->to('/settings/oauth2-applications');
+    }
+
+    /**
+     * Aggregate scopes from multiple tokens
+     *
+     * @return array<string>
+     */
+    protected function aggregateScopes(\Illuminate\Support\Collection $tokens): array
+    {
+        $scopes = [];
+        foreach ($tokens as $token) {
+            if (is_array($token->scopes)) {
+                $scopes = array_merge($scopes, $token->scopes);
+            }
+        }
+        return array_unique($scopes);
+    }
+}

--- a/src/Models/OAuth2AccessToken.php
+++ b/src/Models/OAuth2AccessToken.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Models;
+
+use Carbon\Carbon;
+use Engelsystem\Models\User\User;
+use Engelsystem\Models\User\UsesUserModel;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+/**
+ * @property string                                  $id
+ * @property int                                     $oauth2_client_id
+ * @property int|null                                $user_id
+ * @property array|null                              $scopes
+ * @property bool                                    $revoked
+ * @property Carbon                                  $expires_at
+ * @property Carbon|null                             $created_at
+ * @property Carbon|null                             $updated_at
+ *
+ * @property-read OAuth2Client                       $client
+ * @property-read User|null                          $user
+ * @property-read Collection<int, OAuth2RefreshToken> $refreshTokens
+ *
+ * @method static QueryBuilder|OAuth2AccessToken[] whereId($value)
+ * @method static QueryBuilder|OAuth2AccessToken[] whereUserId($value)
+ * @method static QueryBuilder|OAuth2AccessToken[] whereRevoked($value)
+ */
+class OAuth2AccessToken extends BaseModel
+{
+    use HasFactory;
+    use UsesUserModel;
+
+    /** @var string */
+    public $table = 'oauth2_access_tokens'; // phpcs:ignore
+
+    /** @var bool */
+    public $timestamps = true; // phpcs:ignore
+
+    /** @var bool */
+    public $incrementing = false; // phpcs:ignore
+
+    /** @var string */
+    protected $keyType = 'string'; // phpcs:ignore
+
+    /** @var array<string> */
+    protected $fillable = [ // phpcs:ignore
+        'id',
+        'oauth2_client_id',
+        'user_id',
+        'scopes',
+        'revoked',
+        'expires_at',
+    ];
+
+    /** @var array<string, string> */
+    protected $casts = [ // phpcs:ignore
+        'oauth2_client_id' => 'integer',
+        'user_id' => 'integer',
+        'scopes' => 'array',
+        'revoked' => 'boolean',
+        'expires_at' => 'datetime',
+    ];
+
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(OAuth2Client::class, 'oauth2_client_id');
+    }
+
+    public function refreshTokens(): HasMany
+    {
+        return $this->hasMany(OAuth2RefreshToken::class, 'access_token_id');
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at->isPast();
+    }
+
+    public function isValid(): bool
+    {
+        return !$this->revoked && !$this->isExpired();
+    }
+
+    public function revoke(): void
+    {
+        $this->revoked = true;
+        $this->save();
+
+        $this->refreshTokens()->update(['revoked' => true]);
+    }
+}

--- a/src/Models/OAuth2AuthCode.php
+++ b/src/Models/OAuth2AuthCode.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Models;
+
+use Carbon\Carbon;
+use Engelsystem\Models\User\User;
+use Engelsystem\Models\User\UsesUserModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+/**
+ * @property string           $id
+ * @property int              $oauth2_client_id
+ * @property int              $user_id
+ * @property array|null       $scopes
+ * @property bool             $revoked
+ * @property Carbon           $expires_at
+ * @property string           $redirect_uri
+ * @property Carbon|null      $created_at
+ * @property Carbon|null      $updated_at
+ *
+ * @property-read OAuth2Client $client
+ * @property-read User         $user
+ *
+ * @method static QueryBuilder|OAuth2AuthCode[] whereId($value)
+ * @method static QueryBuilder|OAuth2AuthCode[] whereUserId($value)
+ * @method static QueryBuilder|OAuth2AuthCode[] whereRevoked($value)
+ */
+class OAuth2AuthCode extends BaseModel
+{
+    use HasFactory;
+    use UsesUserModel;
+
+    /** @var string */
+    public $table = 'oauth2_auth_codes'; // phpcs:ignore
+
+    /** @var bool */
+    public $timestamps = true; // phpcs:ignore
+
+    /** @var bool */
+    public $incrementing = false; // phpcs:ignore
+
+    /** @var string */
+    protected $keyType = 'string'; // phpcs:ignore
+
+    /** @var array<string> */
+    protected $fillable = [ // phpcs:ignore
+        'id',
+        'oauth2_client_id',
+        'user_id',
+        'scopes',
+        'revoked',
+        'expires_at',
+        'redirect_uri',
+    ];
+
+    /** @var array<string, string> */
+    protected $casts = [ // phpcs:ignore
+        'oauth2_client_id' => 'integer',
+        'user_id' => 'integer',
+        'scopes' => 'array',
+        'revoked' => 'boolean',
+        'expires_at' => 'datetime',
+    ];
+
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(OAuth2Client::class, 'oauth2_client_id');
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at->isPast();
+    }
+
+    public function isValid(): bool
+    {
+        return !$this->revoked && !$this->isExpired();
+    }
+
+    public function revoke(): void
+    {
+        $this->revoked = true;
+        $this->save();
+    }
+}

--- a/src/Models/OAuth2Client.php
+++ b/src/Models/OAuth2Client.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+/**
+ * @property int                                   $id
+ * @property string                                $identifier
+ * @property string                                $name
+ * @property string|null                           $secret
+ * @property array                                 $redirect_uris
+ * @property string                                $grants
+ * @property array|null                            $scopes
+ * @property bool                                  $confidential
+ * @property bool                                  $active
+ * @property Carbon|null                           $created_at
+ * @property Carbon|null                           $updated_at
+ *
+ * @property-read Collection<int, AngelType>       $angelTypes
+ * @property-read Collection<int, OAuth2AccessToken> $accessTokens
+ *
+ * @method static QueryBuilder|OAuth2Client[] whereId($value)
+ * @method static QueryBuilder|OAuth2Client[] whereIdentifier($value)
+ * @method static QueryBuilder|OAuth2Client[] whereName($value)
+ * @method static QueryBuilder|OAuth2Client[] whereActive($value)
+ */
+class OAuth2Client extends BaseModel
+{
+    use HasFactory;
+
+    /** @var string */
+    public $table = 'oauth2_clients'; // phpcs:ignore
+
+    /** @var bool */
+    public $timestamps = true; // phpcs:ignore
+
+    /** @var array<string> */
+    protected $fillable = [ // phpcs:ignore
+        'identifier',
+        'name',
+        'secret',
+        'redirect_uris',
+        'grants',
+        'scopes',
+        'confidential',
+        'active',
+    ];
+
+    /** @var array<string, string> */
+    protected $casts = [ // phpcs:ignore
+        'redirect_uris' => 'array',
+        'scopes' => 'array',
+        'confidential' => 'boolean',
+        'active' => 'boolean',
+    ];
+
+    /** @var array<string> */
+    protected $hidden = ['secret']; // phpcs:ignore
+
+    public function angelTypes(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            AngelType::class,
+            'oauth2_client_angel_type',
+            'oauth2_client_id',
+            'angel_type_id'
+        );
+    }
+
+    public function accessTokens(): HasMany
+    {
+        return $this->hasMany(OAuth2AccessToken::class, 'oauth2_client_id');
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getGrantsArray(): array
+    {
+        return array_map('trim', explode(',', $this->grants));
+    }
+
+    public function hasGrant(string $grant): bool
+    {
+        return in_array($grant, $this->getGrantsArray(), true);
+    }
+
+    public function isValidRedirectUri(string $uri): bool
+    {
+        return in_array($uri, $this->redirect_uris, true);
+    }
+}

--- a/src/Models/OAuth2RefreshToken.php
+++ b/src/Models/OAuth2RefreshToken.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+/**
+ * @property string           $id
+ * @property string           $access_token_id
+ * @property bool             $revoked
+ * @property Carbon           $expires_at
+ * @property Carbon|null      $created_at
+ * @property Carbon|null      $updated_at
+ *
+ * @property-read OAuth2AccessToken $accessToken
+ *
+ * @method static QueryBuilder|OAuth2RefreshToken[] whereId($value)
+ * @method static QueryBuilder|OAuth2RefreshToken[] whereAccessTokenId($value)
+ * @method static QueryBuilder|OAuth2RefreshToken[] whereRevoked($value)
+ */
+class OAuth2RefreshToken extends BaseModel
+{
+    use HasFactory;
+
+    /** @var string */
+    public $table = 'oauth2_refresh_tokens'; // phpcs:ignore
+
+    /** @var bool */
+    public $timestamps = true; // phpcs:ignore
+
+    /** @var bool */
+    public $incrementing = false; // phpcs:ignore
+
+    /** @var string */
+    protected $keyType = 'string'; // phpcs:ignore
+
+    /** @var array<string> */
+    protected $fillable = [ // phpcs:ignore
+        'id',
+        'access_token_id',
+        'revoked',
+        'expires_at',
+    ];
+
+    /** @var array<string, string> */
+    protected $casts = [ // phpcs:ignore
+        'revoked' => 'boolean',
+        'expires_at' => 'datetime',
+    ];
+
+    public function accessToken(): BelongsTo
+    {
+        return $this->belongsTo(OAuth2AccessToken::class, 'access_token_id');
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at->isPast();
+    }
+
+    public function isValid(): bool
+    {
+        return !$this->revoked && !$this->isExpired();
+    }
+
+    public function revoke(): void
+    {
+        $this->revoked = true;
+        $this->save();
+    }
+}

--- a/src/OAuth2Server/Entity/AccessTokenEntity.php
+++ b/src/OAuth2Server/Entity/AccessTokenEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Entity;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
+
+class AccessTokenEntity implements AccessTokenEntityInterface
+{
+    use AccessTokenTrait;
+    use EntityTrait;
+    use TokenEntityTrait;
+}

--- a/src/OAuth2Server/Entity/AuthCodeEntity.php
+++ b/src/OAuth2Server/Entity/AuthCodeEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Entity;
+
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AuthCodeTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
+
+class AuthCodeEntity implements AuthCodeEntityInterface
+{
+    use AuthCodeTrait;
+    use EntityTrait;
+    use TokenEntityTrait;
+}

--- a/src/OAuth2Server/Entity/ClientEntity.php
+++ b/src/OAuth2Server/Entity/ClientEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Entity;
+
+use Engelsystem\Models\OAuth2Client;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\Traits\ClientTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+
+class ClientEntity implements ClientEntityInterface
+{
+    use ClientTrait;
+    use EntityTrait;
+
+    public function __construct(protected OAuth2Client $model)
+    {
+        $this->identifier = $model->identifier;
+        $this->name = $model->name;
+        $this->redirectUri = $model->redirect_uris;
+        $this->isConfidential = $model->confidential;
+    }
+
+    public function getModel(): OAuth2Client
+    {
+        return $this->model;
+    }
+}

--- a/src/OAuth2Server/Entity/RefreshTokenEntity.php
+++ b/src/OAuth2Server/Entity/RefreshTokenEntity.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Entity;
+
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\RefreshTokenTrait;
+
+class RefreshTokenEntity implements RefreshTokenEntityInterface
+{
+    use EntityTrait;
+    use RefreshTokenTrait;
+}

--- a/src/OAuth2Server/Entity/ScopeEntity.php
+++ b/src/OAuth2Server/Entity/ScopeEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Entity;
+
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\ScopeTrait;
+
+class ScopeEntity implements ScopeEntityInterface
+{
+    use EntityTrait;
+    use ScopeTrait;
+
+    public function __construct(string $identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->getIdentifier();
+    }
+}

--- a/src/OAuth2Server/Entity/UserEntity.php
+++ b/src/OAuth2Server/Entity/UserEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Entity;
+
+use Engelsystem\Models\User\User;
+use League\OAuth2\Server\Entities\UserEntityInterface;
+
+class UserEntity implements UserEntityInterface
+{
+    public function __construct(protected User $user)
+    {
+    }
+
+    public function getIdentifier(): string
+    {
+        return (string) $this->user->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+}

--- a/src/OAuth2Server/OAuth2ServerServiceProvider.php
+++ b/src/OAuth2Server/OAuth2ServerServiceProvider.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server;
+
+use DateInterval;
+use Engelsystem\Config\Config;
+use Engelsystem\Container\ServiceProvider;
+use Engelsystem\OAuth2Server\Repository\AccessTokenRepository;
+use Engelsystem\OAuth2Server\Repository\AuthCodeRepository;
+use Engelsystem\OAuth2Server\Repository\ClientRepository;
+use Engelsystem\OAuth2Server\Repository\RefreshTokenRepository;
+use Engelsystem\OAuth2Server\Repository\ScopeRepository;
+use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\Grant\AuthCodeGrant;
+use League\OAuth2\Server\Grant\RefreshTokenGrant;
+use League\OAuth2\Server\ResourceServer;
+
+class OAuth2ServerServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        /** @var Config $config */
+        $config = $this->app->get('config');
+
+        // Check if OAuth2 server is enabled
+        if (!$config->get('oauth2_server.enabled', false)) {
+            return;
+        }
+
+        $this->registerAuthorizationServer($config);
+        $this->registerResourceServer($config);
+    }
+
+    protected function registerAuthorizationServer(Config $config): void
+    {
+        $privateKeyPath = $config->get('oauth2_server.private_key');
+        $encryptionKey = $config->get('oauth2_server.encryption_key');
+
+        if (!$privateKeyPath || !$encryptionKey) {
+            return;
+        }
+
+        // Create repositories
+        $clientRepository = $this->app->make(ClientRepository::class);
+        $accessTokenRepository = $this->app->make(AccessTokenRepository::class);
+        $scopeRepository = $this->app->make(ScopeRepository::class);
+        $authCodeRepository = $this->app->make(AuthCodeRepository::class);
+        $refreshTokenRepository = $this->app->make(RefreshTokenRepository::class);
+
+        // Create authorization server
+        $server = new AuthorizationServer(
+            $clientRepository,
+            $accessTokenRepository,
+            $scopeRepository,
+            new CryptKey($privateKeyPath, null, false),
+            $encryptionKey
+        );
+
+        // Configure auth code grant
+        $authCodeTtl = new DateInterval('PT10M'); // 10 minutes
+        $authCodeGrant = new AuthCodeGrant(
+            $authCodeRepository,
+            $refreshTokenRepository,
+            $authCodeTtl
+        );
+
+        $refreshTokenTtl = $config->get('oauth2_server.refresh_token_ttl', 2592000); // 30 days
+        $authCodeGrant->setRefreshTokenTTL(new DateInterval('PT' . $refreshTokenTtl . 'S'));
+
+        $accessTokenTtl = $config->get('oauth2_server.access_token_ttl', 3600); // 1 hour
+        $server->enableGrantType(
+            $authCodeGrant,
+            new DateInterval('PT' . $accessTokenTtl . 'S')
+        );
+
+        // Configure refresh token grant
+        $refreshTokenGrant = new RefreshTokenGrant($refreshTokenRepository);
+        $refreshTokenGrant->setRefreshTokenTTL(new DateInterval('PT' . $refreshTokenTtl . 'S'));
+
+        $server->enableGrantType(
+            $refreshTokenGrant,
+            new DateInterval('PT' . $accessTokenTtl . 'S')
+        );
+
+        $this->app->instance(AuthorizationServer::class, $server);
+    }
+
+    protected function registerResourceServer(Config $config): void
+    {
+        $publicKeyPath = $config->get('oauth2_server.public_key');
+
+        if (!$publicKeyPath) {
+            return;
+        }
+
+        $accessTokenRepository = $this->app->make(AccessTokenRepository::class);
+
+        $server = new ResourceServer(
+            $accessTokenRepository,
+            new CryptKey($publicKeyPath, null, false)
+        );
+
+        $this->app->instance(ResourceServer::class, $server);
+    }
+}

--- a/src/OAuth2Server/Repository/AccessTokenRepository.php
+++ b/src/OAuth2Server/Repository/AccessTokenRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Repository;
+
+use Engelsystem\Models\OAuth2AccessToken;
+use Engelsystem\OAuth2Server\Entity\AccessTokenEntity;
+use Engelsystem\OAuth2Server\Entity\ClientEntity;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+
+class AccessTokenRepository implements AccessTokenRepositoryInterface
+{
+    public function __construct(protected OAuth2AccessToken $accessToken)
+    {
+    }
+
+    /**
+     * @param ScopeEntityInterface[] $scopes
+     */
+    public function getNewToken(
+        ClientEntityInterface $clientEntity,
+        array $scopes,
+        mixed $userIdentifier = null
+    ): AccessTokenEntityInterface {
+        $token = new AccessTokenEntity();
+        $token->setClient($clientEntity);
+
+        foreach ($scopes as $scope) {
+            $token->addScope($scope);
+        }
+
+        if ($userIdentifier !== null) {
+            $token->setUserIdentifier($userIdentifier);
+        }
+
+        return $token;
+    }
+
+    public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity): void
+    {
+        $client = $accessTokenEntity->getClient();
+        $clientId = null;
+
+        if ($client instanceof ClientEntity) {
+            $clientId = $client->getModel()->id;
+        }
+
+        $this->accessToken->create([
+            'id' => $accessTokenEntity->getIdentifier(),
+            'oauth2_client_id' => $clientId,
+            'user_id' => $accessTokenEntity->getUserIdentifier(),
+            'scopes' => array_map(
+                fn(ScopeEntityInterface $scope) => $scope->getIdentifier(),
+                $accessTokenEntity->getScopes()
+            ),
+            'expires_at' => $accessTokenEntity->getExpiryDateTime(),
+            'revoked' => false,
+        ]);
+    }
+
+    public function revokeAccessToken(mixed $tokenId): void
+    {
+        $token = $this->accessToken->find($tokenId);
+
+        if ($token) {
+            $token->revoke();
+        }
+    }
+
+    public function isAccessTokenRevoked(mixed $tokenId): bool
+    {
+        $token = $this->accessToken->find($tokenId);
+
+        return $token === null || $token->revoked;
+    }
+}

--- a/src/OAuth2Server/Repository/AuthCodeRepository.php
+++ b/src/OAuth2Server/Repository/AuthCodeRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Repository;
+
+use Engelsystem\Models\OAuth2AuthCode;
+use Engelsystem\OAuth2Server\Entity\AuthCodeEntity;
+use Engelsystem\OAuth2Server\Entity\ClientEntity;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
+
+class AuthCodeRepository implements AuthCodeRepositoryInterface
+{
+    public function __construct(protected OAuth2AuthCode $authCode)
+    {
+    }
+
+    public function getNewAuthCode(): AuthCodeEntityInterface
+    {
+        return new AuthCodeEntity();
+    }
+
+    public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity): void
+    {
+        $client = $authCodeEntity->getClient();
+        $clientId = null;
+
+        if ($client instanceof ClientEntity) {
+            $clientId = $client->getModel()->id;
+        }
+
+        $this->authCode->create([
+            'id' => $authCodeEntity->getIdentifier(),
+            'oauth2_client_id' => $clientId,
+            'user_id' => $authCodeEntity->getUserIdentifier(),
+            'scopes' => array_map(
+                fn(ScopeEntityInterface $scope) => $scope->getIdentifier(),
+                $authCodeEntity->getScopes()
+            ),
+            'expires_at' => $authCodeEntity->getExpiryDateTime(),
+            'redirect_uri' => $authCodeEntity->getRedirectUri(),
+            'revoked' => false,
+        ]);
+    }
+
+    public function revokeAuthCode(mixed $codeId): void
+    {
+        $code = $this->authCode->find($codeId);
+
+        if ($code) {
+            $code->revoke();
+        }
+    }
+
+    public function isAuthCodeRevoked(mixed $codeId): bool
+    {
+        $code = $this->authCode->find($codeId);
+
+        return $code === null || $code->revoked;
+    }
+}

--- a/src/OAuth2Server/Repository/ClientRepository.php
+++ b/src/OAuth2Server/Repository/ClientRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Repository;
+
+use Engelsystem\Models\OAuth2Client;
+use Engelsystem\OAuth2Server\Entity\ClientEntity;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+
+class ClientRepository implements ClientRepositoryInterface
+{
+    public function __construct(protected OAuth2Client $client)
+    {
+    }
+
+    public function getClientEntity(mixed $clientIdentifier): ?ClientEntity
+    {
+        $client = $this->client
+            ->where('identifier', (string) $clientIdentifier)
+            ->where('active', true)
+            ->first();
+
+        if (!$client) {
+            return null;
+        }
+
+        return new ClientEntity($client);
+    }
+
+    public function validateClient(mixed $clientIdentifier, mixed $clientSecret, mixed $grantType): bool
+    {
+        $entity = $this->getClientEntity($clientIdentifier);
+
+        if (!$entity) {
+            return false;
+        }
+
+        $model = $entity->getModel();
+
+        // Check grant type is allowed
+        if ($grantType !== null && !$model->hasGrant($grantType)) {
+            return false;
+        }
+
+        // Public clients don't need secret validation
+        if (!$model->confidential) {
+            return true;
+        }
+
+        // Validate secret for confidential clients
+        if ($clientSecret === null) {
+            return false;
+        }
+
+        return password_verify($clientSecret, $model->secret ?? '');
+    }
+}

--- a/src/OAuth2Server/Repository/RefreshTokenRepository.php
+++ b/src/OAuth2Server/Repository/RefreshTokenRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Repository;
+
+use Engelsystem\Models\OAuth2RefreshToken;
+use Engelsystem\OAuth2Server\Entity\RefreshTokenEntity;
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+
+class RefreshTokenRepository implements RefreshTokenRepositoryInterface
+{
+    public function __construct(protected OAuth2RefreshToken $refreshToken)
+    {
+    }
+
+    public function getNewRefreshToken(): ?RefreshTokenEntityInterface
+    {
+        return new RefreshTokenEntity();
+    }
+
+    public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity): void
+    {
+        $this->refreshToken->create([
+            'id' => $refreshTokenEntity->getIdentifier(),
+            'access_token_id' => $refreshTokenEntity->getAccessToken()->getIdentifier(),
+            'expires_at' => $refreshTokenEntity->getExpiryDateTime(),
+            'revoked' => false,
+        ]);
+    }
+
+    public function revokeRefreshToken(mixed $tokenId): void
+    {
+        $token = $this->refreshToken->find($tokenId);
+
+        if ($token) {
+            $token->revoke();
+        }
+    }
+
+    public function isRefreshTokenRevoked(mixed $tokenId): bool
+    {
+        $token = $this->refreshToken->find($tokenId);
+
+        if ($token === null) {
+            return true;
+        }
+
+        if ($token->revoked) {
+            return true;
+        }
+
+        // Also check if the associated access token is revoked
+        $accessToken = $token->accessToken;
+
+        return $accessToken === null || $accessToken->revoked;
+    }
+}

--- a/src/OAuth2Server/Repository/ScopeRepository.php
+++ b/src/OAuth2Server/Repository/ScopeRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Repository;
+
+use Engelsystem\OAuth2Server\Entity\ClientEntity;
+use Engelsystem\OAuth2Server\Entity\ScopeEntity;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
+
+class ScopeRepository implements ScopeRepositoryInterface
+{
+    /**
+     * Available scopes and their descriptions
+     */
+    public const SCOPES = [
+        'openid' => 'OpenID Connect identifier',
+        'profile' => 'User profile (name, username, pronoun)',
+        'email' => 'Email address',
+        'angeltypes' => 'Angel type memberships',
+        'groups' => 'User permission groups',
+    ];
+
+    public function getScopeEntityByIdentifier(mixed $identifier): ?ScopeEntityInterface
+    {
+        if (!array_key_exists((string) $identifier, self::SCOPES)) {
+            return null;
+        }
+
+        return new ScopeEntity((string) $identifier);
+    }
+
+    /**
+     * @param ScopeEntityInterface[] $scopes
+     * @return ScopeEntityInterface[]
+     */
+    public function finalizeScopes(
+        array $scopes,
+        mixed $grantType,
+        ClientEntityInterface $clientEntity,
+        mixed $userIdentifier = null,
+        ?string $authCodeId = null
+    ): array {
+        // Filter scopes to only those allowed by the client
+        if ($clientEntity instanceof ClientEntity) {
+            $allowedScopes = $clientEntity->getModel()->scopes;
+
+            if ($allowedScopes !== null) {
+                $scopes = array_filter(
+                    $scopes,
+                    fn(ScopeEntityInterface $scope) => in_array($scope->getIdentifier(), $allowedScopes, true)
+                );
+            }
+        }
+
+        return array_values($scopes);
+    }
+
+    /**
+     * Get all available scopes with descriptions
+     *
+     * @return array<string, string>
+     */
+    public function getAvailableScopes(): array
+    {
+        return self::SCOPES;
+    }
+}

--- a/src/OAuth2Server/Repository/UserRepository.php
+++ b/src/OAuth2Server/Repository/UserRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\OAuth2Server\Repository;
+
+use Engelsystem\Helpers\Authenticator;
+use Engelsystem\Models\User\User;
+use Engelsystem\OAuth2Server\Entity\UserEntity;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\UserEntityInterface;
+use League\OAuth2\Server\Repositories\UserRepositoryInterface;
+
+class UserRepository implements UserRepositoryInterface
+{
+    public function __construct(
+        protected User $user,
+        protected Authenticator $auth
+    ) {
+    }
+
+    public function getUserEntityByUserCredentials(
+        mixed $username,
+        mixed $password,
+        mixed $grantType,
+        ClientEntityInterface $clientEntity
+    ): ?UserEntityInterface {
+        // For authorization code flow, we don't use password grant
+        // This method is only used for password grant which we don't support
+        return null;
+    }
+
+    /**
+     * Get a user entity by user ID
+     */
+    public function getUserById(int $userId): ?UserEntity
+    {
+        $user = $this->user->find($userId);
+
+        if (!$user) {
+            return null;
+        }
+
+        return new UserEntity($user);
+    }
+}

--- a/tests/Unit/Middleware/VerifyCsrfTokenTest.php
+++ b/tests/Unit/Middleware/VerifyCsrfTokenTest.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -148,8 +147,6 @@ class VerifyCsrfTokenTest extends TestCase
         $response = $this->getMockForAbstractClass(ResponseInterface::class);
         /** @var SessionInterface|MockObject $session */
         $session = $this->getMockForAbstractClass(SessionInterface::class);
-        /** @var UriInterface|MockObject $uri */
-        $uri = $this->getMockForAbstractClass(UriInterface::class);
 
         $middleware = new VerifyCsrfToken($session);
 
@@ -162,11 +159,7 @@ class VerifyCsrfTokenTest extends TestCase
             ->willReturn('POST');
 
         $request->expects($this->exactly(3))
-            ->method('getUri')
-            ->willReturn($uri);
-
-        $uri->expects($this->exactly(3))
-            ->method('getPath')
+            ->method('getRequestTarget')
             ->willReturnOnConsecutiveCalls(
                 '/oauth2/token',
                 '/oauth2/token/',

--- a/tests/Unit/Middleware/VerifyCsrfTokenTest.php
+++ b/tests/Unit/Middleware/VerifyCsrfTokenTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -36,12 +37,16 @@ class VerifyCsrfTokenTest extends TestCase
         /** @var VerifyCsrfToken|MockObject $middleware */
         $middleware = $this->getMockBuilder(VerifyCsrfToken::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['tokensMatch'])
+            ->onlyMethods(['tokensMatch', 'isExempt'])
             ->getMock();
 
         $middleware->expects($this->exactly(2))
             ->method('tokensMatch')
             ->willReturnOnConsecutiveCalls(true, false);
+
+        $middleware->expects($this->exactly(2))
+            ->method('isExempt')
+            ->willReturn(false);
 
         // Results in true, false, false
         $request->expects($this->exactly(3))
@@ -76,11 +81,15 @@ class VerifyCsrfTokenTest extends TestCase
         /** @var VerifyCsrfToken|MockObject $middleware */
         $middleware = $this->getMockBuilder(VerifyCsrfToken::class)
             ->setConstructorArgs([$session])
-            ->onlyMethods(['isReading'])
+            ->onlyMethods(['isReading', 'isExempt'])
             ->getMock();
 
         $middleware->expects($this->atLeastOnce())
             ->method('isReading')
+            ->willReturn(false);
+
+        $middleware->expects($this->atLeastOnce())
+            ->method('isExempt')
             ->willReturn(false);
 
         $handler->expects($this->exactly(3))
@@ -122,6 +131,53 @@ class VerifyCsrfTokenTest extends TestCase
         // Header and POST tokens
         $middleware->process($request, $handler);
         // No tokens
+        $this->expectException(HttpAuthExpired::class);
+        $middleware->process($request, $handler);
+    }
+
+    /**
+     * @covers \Engelsystem\Middleware\VerifyCsrfToken::isExempt
+     */
+    public function testIsExempt(): void
+    {
+        /** @var ServerRequestInterface|MockObject $request */
+        $request = $this->getMockForAbstractClass(ServerRequestInterface::class);
+        /** @var RequestHandlerInterface|MockObject $handler */
+        $handler = $this->getMockForAbstractClass(RequestHandlerInterface::class);
+        /** @var ResponseInterface|MockObject $response */
+        $response = $this->getMockForAbstractClass(ResponseInterface::class);
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockForAbstractClass(SessionInterface::class);
+        /** @var UriInterface|MockObject $uri */
+        $uri = $this->getMockForAbstractClass(UriInterface::class);
+
+        $middleware = new VerifyCsrfToken($session);
+
+        $handler->expects($this->exactly(2))
+            ->method('handle')
+            ->willReturn($response);
+
+        $request->expects($this->exactly(3))
+            ->method('getMethod')
+            ->willReturn('POST');
+
+        $request->expects($this->exactly(3))
+            ->method('getUri')
+            ->willReturn($uri);
+
+        $uri->expects($this->exactly(3))
+            ->method('getPath')
+            ->willReturnOnConsecutiveCalls(
+                '/oauth2/token',
+                '/oauth2/token/',
+                '/other/path'
+            );
+
+        // Exempt path - should pass without token check
+        $middleware->process($request, $handler);
+        // Exempt path with trailing slash - should pass
+        $middleware->process($request, $handler);
+        // Non-exempt path - should throw exception (no token)
         $this->expectException(HttpAuthExpired::class);
         $middleware->process($request, $handler);
     }


### PR DESCRIPTION
## Summary

This PR adds OAuth2 Authorization Server support to Engelsystem, enabling it to act as an SSO identity provider for external tools like Grafana, Prometheus, and other services.

**Implements #882**

### Features
- **Authorization Code Grant** with Refresh Token support using [league/oauth2-server](https://oauth2.thephpleague.com/) v8.5
- **Available scopes**: `openid`, `profile`, `email`, `angeltypes`, `groups`
- **Angeltype-based access restrictions** - clients can be restricted to confirmed members of specific angel types
- **Admin interface** for managing OAuth2 clients at `/admin/oauth2-clients`
- **User settings page** to view and revoke authorized applications at `/settings/oauth2-applications`
- **UserInfo endpoint** at `/oauth2/userinfo` for retrieving user profile data

### Configuration

Add to `config/config.php`:
```php
'oauth2_server' => [
    'enabled' => true,
    'private_key' => '/path/to/oauth-private.key',
    'public_key' => '/path/to/oauth-public.key',
    'encryption_key' => env('OAUTH2_ENCRYPTION_KEY', ''),
],
```

Generate keys:
```bash
openssl genrsa -out storage/oauth-private.key 2048
openssl rsa -in storage/oauth-private.key -pubout -out storage/oauth-public.key
chmod 600 storage/oauth-private.key
php -r "echo bin2hex(random_bytes(32));"  # For encryption key
```

### Technical Notes

- Uses `league/oauth2-server` v8.x due to `psr/http-message ^1.1` constraint in the codebase
- Upgrading to v9.x would require `psr/http-message ^2.0`, which needs Symfony HTTP Foundation updates
- CSRF token verification is exempt for `/oauth2/token` endpoint per OAuth2 specification

## Test plan

- [x] Run database migrations
- [x] Configure OAuth2 keys in config
- [x] Create an OAuth2 client via admin interface
- [x] Test authorization flow with an external application
- [ ] Verify token refresh works
- [ ] Test revoking application access from user settings
- [ ] Verify angeltype restrictions work correctly