### PR TITLE
fix: mobile navbar hidden by wide content like shift calendar

### DIFF
--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -67,6 +67,12 @@ body {
   padding-top: 70px;
 }
 
+// Contain wide content within the main content area
+// so it doesn't cause page-level horizontal scroll that affects fixed navbar
+#content {
+  overflow-x: auto;
+}
+
 .footer a {
   color: $text-muted;
 }
@@ -366,8 +372,9 @@ h6,
   line-height: 2;
 }
 
+// Allow shift calendar to scroll horizontally within its container on mobile
 .shift-calendar.table-responsive {
-  overflow-x: inherit;
+  overflow-x: auto;
 }
 
 // Reference links


### PR DESCRIPTION
Fixes: #1620

I clicked around in the local dev app to see if this affecting anything else.
Can test more if there are known pitfalls.

Happy to adjust this.



### BEFORE
<img width="459" height="959" alt="Image" src="https://github.com/user-attachments/assets/15b47153-0fed-417a-bf8c-e3aaecfe90a3" />



### AFTER
<img width="453" height="953" alt="image" src="https://github.com/user-attachments/assets/20d55299-618f-4473-a13a-4f156bd0b076" />




- Add overflow-x: auto to #content to contain wide content
- Change shift-calendar.table-responsive to overflow-x: auto
- Wide content now scrolls within container instead of pushing navbar off-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
