### PR TITLE
fix: keep navbar fixed when content overflows horizontally

### DIFF
--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -65,6 +65,13 @@ $navbar-height: 3.125rem;
 
 body {
   padding-top: 70px;
+  // Prevent horizontal scroll at body level so fixed navbar stays in place
+  overflow-x: clip;
+}
+
+#content {
+  // Allow wide content (e.g., shift calendar) to scroll horizontally within the content area
+  overflow-x: auto;
 }
 
 .footer a {


### PR DESCRIPTION
## Summary
- Fixes mobile navbar hamburger menu being pushed/scrolled off-screen when viewing wide content (e.g., shift calendar with many locations)
- Adds `overflow-x: clip` to body to prevent document-level horizontal scrolling
- Adds `overflow-x: auto` to `#content` to allow wide content to scroll within its container

Fixes #1620