### PR TITLE
fix: anchor migration classname regex to start of string

### DIFF
--- a/src/Database/Migration/Migrate.php
+++ b/src/Database/Migration/Migrate.php
@@ -154,7 +154,7 @@ class Migrate
     {
         require_once $file;
 
-        $className = Str::studly(preg_replace('/\d+_/', '', $migration));
+        $className = Str::studly(preg_replace('/^(?:\d+_)+/', '', $migration));
         /** @var Migration $class */
         $class = $this->app->make('Engelsystem\\Migrations\\' . $className);
 

--- a/tests/Unit/Database/Migration/MigrateTest.php
+++ b/tests/Unit/Database/Migration/MigrateTest.php
@@ -196,19 +196,20 @@ class MigrateTest extends TestCase
         $this->assertTrue($schema->hasTable('migrations'));
 
         $migrations = $db->table('migrations')->get();
-        $this->assertCount(3, $migrations);
+        $this->assertCount(4, $migrations);
         $this->assertFalse($migrations->contains('migration', 'lock'));
 
         $this->assertTrue($migrations->contains('migration', '2001_04_11_123456_create_lorem_ipsum_table'));
         $this->assertTrue($migrations->contains('migration', '2017_12_24_053300_another_stuff'));
         $this->assertTrue($migrations->contains('migration', '2022_12_22_221222_add_some_feature'));
+        $this->assertTrue($migrations->contains('migration', '2025_01_06_112911_oauth2_server_tables'));
 
         $this->assertTrue($schema->hasTable('lorem_ipsum'));
 
         $migration->run(__DIR__ . '/Stub', Direction::DOWN, true);
 
         $migrations = $db->table('migrations')->get();
-        $this->assertCount(2, $migrations);
+        $this->assertCount(3, $migrations);
 
         $migration->run(__DIR__ . '/Stub', Direction::DOWN);
 

--- a/tests/Unit/Database/Migration/Stub/2025_01_06_112911_oauth2_server_tables.php
+++ b/tests/Unit/Database/Migration/Stub/2025_01_06_112911_oauth2_server_tables.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+
+class Oauth2ServerTables extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        // nope
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        // nope
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes regex that strips timestamp prefix from migration filenames
- Old regex `/\d+_/` removed ALL digit+underscore patterns, breaking migrations like `oauth2_server_tables` (became `oauthserver_tables`)
- New regex `/\A(?:\d+_)+/` anchors to start and matches the timestamp format precisely

Closes #1621