### PR TITLE
feat: mobile always show user menu items

### DIFF
--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -222,6 +222,21 @@ table.table-sticky-header thead {
   }
 }
 
+// Expand user dropdown links on mobile devices. Subtraction needed to enforce state when viewport changes
+@media (max-width: map-get($grid-breakpoints, 'xxl') - 0.02px) {
+  .dropdown-user-menu {
+    .dropdown-toggle {
+      pointer-events: none;
+    }
+    .dropdown-toggle::after {
+      display: none;
+    }
+    .dropdown-menu {
+      display: block;
+    }
+  }
+}
+
 /* make selections scrollable and add a max height of 4.5 entries */
 #collapseShiftsFilterSelect .limit-height.selection {
   overflow-y: auto;

--- a/resources/views/layouts/parts/navbar.twig
+++ b/resources/views/layouts/parts/navbar.twig
@@ -112,7 +112,7 @@
                     {{ menuUserHints() }}
 
                     {% include "layouts/parts/language_dropdown.twig" %}
-                    <li class="nav-item dropdown">
+                    <li class="nav-item dropdown dropdown-user-menu">
                         <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             {{ m.angel() }} {{ user.displayName }}
                         </a>


### PR DESCRIPTION
During Kongress I was constantly confused why I had to open "two" menus on mobile to find the "My shifts" link.
A dropdown in a dropdown? Why?

Trying to fix this with this PR. 

You can argue "why only the users menu". This was the most painful for me. Maybe language should be expanded too? I don't have an opinion on that.

Happy to adjust this.



### Before

<img width="450" height="966" alt="image" src="https://github.com/user-attachments/assets/6f6d2604-9293-4a9c-80a3-ac8b6dc8d16c" />

Then click...

<img width="453" height="970" alt="image" src="https://github.com/user-attachments/assets/d575e06e-fa7f-47b6-8550-8d0681e2ead8" />



### After

<img width="461" height="971" alt="image" src="https://github.com/user-attachments/assets/76928395-e4f1-409a-8e16-675fccbfa7de" />
