### PR TITLE
fix: simplify navbar fix for wide content

### DIFF
--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -65,13 +65,12 @@ $navbar-height: 3.125rem;
 
 body {
   padding-top: 70px;
-  // Prevent horizontal scroll at body level so fixed navbar stays in place
-  overflow-x: clip;
 }
 
-#content {
-  // Allow wide content (e.g., shift calendar) to scroll horizontally within the content area
-  overflow-x: auto;
+// Keep navbar fixed at viewport width even when content is wider
+.navbar.fixed-top {
+  max-width: 100vw;
+  overflow-x: clip;
 }
 
 .footer a {


### PR DESCRIPTION
## Summary
- Replaces body/content overflow approach with direct navbar constraint
- Previous fix (#1624) caused dropdown clipping and unwanted scroll from Bootstrap row negative margins
- New approach: constrain navbar to viewport width directly

## Changes
```scss
.navbar.fixed-top {
  max-width: 100vw;
  overflow-x: clip;
}
```

This is much simpler and doesn't affect other elements like dropdowns.

## Testing
Tested on mobile viewport: shift calendar scrolls horizontally while navbar stays fixed at viewport width. Verified dropdowns (e.g., user selector on angeltype page) are not clipped. Desktop behavior unchanged.

Fixes #1620