### PR TITLE
fix: show shifts on initial page load when all shifts are in past

### DIFF
--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -57,16 +57,24 @@ function update_ShiftsFilter_timerange(ShiftsFilter $shiftsFilter, $days)
 {
     $start_time = $shiftsFilter->getStartTime();
     if (is_null($start_time)) {
-        $now = (new DateTime())->format('Y-m-d');
-        if (in_array($now, $days)) {
+        $now = new DateTime();
+        $today = $now->format('Y-m-d');
+        if (in_array($today, $days)) {
             // Today has shifts, use current time
-            $start_time = time();
+            $start_time = $now->getTimestamp();
         } elseif (!empty($days)) {
-            // Today has no shifts, default to first day with shifts
-            $start_time = DateTime::createFromFormat('Y-m-d', $days[0])->getTimestamp();
+            // Today has no shifts, find the next upcoming day with shifts
+            $selectedDay = $days[0];
+            foreach ($days as $day) {
+                if ($day >= $today) {
+                    $selectedDay = $day;
+                    break;
+                }
+            }
+            $start_time = DateTime::createFromFormat('Y-m-d', $selectedDay)->getTimestamp();
         } else {
             // No days with shifts at all
-            $start_time = time();
+            $start_time = $now->getTimestamp();
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes empty shifts view on initial page load when all shifts are in the past
- When today has no shifts, the filter now defaults to the first available day instead of today
- This prevents "No shifts found" until the user clicks Filter

The issue was that the date filter defaulted to today's timestamp, but the dropdown only shows days that actually have shifts. When all shifts are in the past, this caused a mismatch: the UI showed the first day with shifts, but the query filtered by today's date (which had none).

Tested on an instance where all shifts were in the past - shifts now display correctly on initial load.

Fixes #1430