### PR TITLE
fix: use content-based width for shift calendar time column

### DIFF
--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -273,12 +273,14 @@ table.table-sticky-header thead {
       border-top: 2px solid $table-border-color;
       font-size: 0.9em;
       padding-left: 5px;
+      padding-right: 5px;
     }
 
     .tick.day {
       border-top: 2px solid $primary;
       font-size: 0.9em;
       padding-left: 5px;
+      padding-right: 5px;
     }
 
     .tick.now {
@@ -292,9 +294,9 @@ table.table-sticky-header thead {
     z-index: $zindex-sticky + 1;
     border-right: 1px solid $table-border-color;
     flex-grow: 0;
-    min-width: 50px;
-    width: 50px;
     flex-shrink: 0;
+    width: max-content;
+    min-width: max-content;
   }
 
   .shift-card {


### PR DESCRIPTION
The time column in the shift calendar had a fixed 50px width which caused date and time labels to be cut off, particularly with longer locale-specific date formats.

This changes the column to use `max-content` sizing so it adapts to whatever content it needs to display.