### PR TITLE
show freeloaded time as duration format

### DIFF
--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -382,7 +382,7 @@ function User_view_myshift(Shift $shift, $user_source, $its_me, $supporter)
 
     if ($shift->freeloaded_by) {
         $myshift['duration'] = '<p class="text-danger"><s>'
-            . sprintf('%.2f', ($shift->end->timestamp - $shift->start->timestamp) / 3600) . '&nbsp;h'
+            . Carbon::formatDuration(CarbonInterval::diff($shift->start, $shift->end), __('general.duration'))
             . '</s></p>';
         if (auth()->can('user_shifts_admin') || $supporter) {
             $myshift['comment'] .= '<br />'


### PR DESCRIPTION
Looks like I missed a spot in #1562 Freeloaded shift still show the duration in the old format.
This PR fixes that.

Before:
<img width="444" height="125" src="https://github.com/user-attachments/assets/db959132-588b-43b9-9d09-91ccac9b35ac" />

After:
<img width="454" height="125" src="https://github.com/user-attachments/assets/0d65f877-8fd0-4595-8a3a-9073f0941a34" />
