### PR TITLE
fix: show all registration validation errors together

### DIFF
--- a/src/Factories/User.php
+++ b/src/Factories/User.php
@@ -154,11 +154,31 @@ class User
             $validationRules['tshirt_size'] = $this->isRequired('tshirt_size') . '|shirt-size';
         }
 
-        $data = $this->validate($rawData, $validationRules);
+        // Run validation but don't throw yet - collect all errors first
+        $this->validator->validate($rawData, $validationRules);
+        $data = $this->validator->getData();
 
-        // additional validations
-        $this->validateUniqueUsername($data['username']);
-        $this->validateUniqueEmail($data['email']);
+        // Check uniqueness for fields that passed basic validation
+        if (isset($data['username']) && EngelsystemUser::whereName($data['username'])->exists()) {
+            $this->validator->addErrors(['username' => ['settings.profile.nick.already-taken']]);
+        }
+
+        if (isset($data['email']) && EngelsystemUser::whereEmail($data['email'])->exists()) {
+            $this->validator->addErrors(['email' => ['settings.profile.email.already-taken']]);
+        }
+
+        if (
+            $isPasswordEnabled
+            && isset($data['password'])
+            && $rawData['password'] !== $rawData['password_confirmation']
+        ) {
+            $this->validator->addErrors(['password' => ['settings.password.confirmation-does-not-match']]);
+        }
+
+        // Now throw if ANY validation errors occurred
+        if (!empty($this->validator->getErrors())) {
+            throw new ValidationException($this->validator);
+        }
 
         // simplified e-mail preferences
         if ($data['email_system']) {
@@ -167,49 +187,7 @@ class User
             $data['email_news'] = true;
         }
 
-        if ($isPasswordEnabled) {
-            // Finally, validate that password matches password_confirmation.
-            // The respect keyValue validation does not seem to work.
-            $this->validatePasswordMatchesConfirmation($rawData);
-        }
-
         return $data;
-    }
-
-    /**
-     * @param Array<string, mixed> $rawData
-     */
-    private function validatePasswordMatchesConfirmation(array $rawData): void
-    {
-        if ($rawData['password'] !== $rawData['password_confirmation']) {
-            throw new ValidationException(
-                (new Validator())->addErrors(['password' => [
-                    'settings.password.confirmation-does-not-match',
-                ]])
-            );
-        }
-    }
-
-    private function validateUniqueUsername(string $username): void
-    {
-        if (EngelsystemUser::whereName($username)->exists()) {
-            throw new ValidationException(
-                (new Validator())->addErrors(['username' => [
-                    'settings.profile.nick.already-taken',
-                ]])
-            );
-        }
-    }
-
-    private function validateUniqueEmail(string $email): void
-    {
-        if (EngelsystemUser::whereEmail($email)->exists()) {
-            throw new ValidationException(
-                (new Validator())->addErrors(['email' => [
-                    'settings.profile.email.already-taken',
-                ]])
-            );
-        }
     }
 
     /**
@@ -349,16 +327,5 @@ class User
         }
 
         return $assignedAngelTypeNames;
-    }
-
-    private function validate(array $rawData, array $rules): array
-    {
-        $isValid = $this->validator->validate($rawData, $rules);
-
-        if (!$isValid) {
-            throw new ValidationException($this->validator);
-        }
-
-        return $this->validator->getData();
     }
 }

--- a/tests/Unit/Factories/UserTest.php
+++ b/tests/Unit/Factories/UserTest.php
@@ -284,7 +284,7 @@ class UserTest extends ServiceProviderTest
         $this->assertDataRaisesValidationException(
             [
                 'username' => 'fritz',
-                'email' => 'fritz@example.com',
+                'email' => 'different@example.com',  // Use different email to only test username uniqueness
                 'password' => 's3cret',
                 'password_confirmation' => 's3cret',
             ],
@@ -312,6 +312,33 @@ class UserTest extends ServiceProviderTest
                 'password_confirmation' => 's3cret',
             ],
             [
+                'email' => [
+                    'settings.profile.email.already-taken',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @covers \Engelsystem\Factories\User
+     */
+    public function testUsernameAndEmailAlreadyTaken(): void
+    {
+        SignUpConfig::setMinimumConfig($this->config);
+        $this->createFritz();
+
+        // Both username and email are taken - both errors should show together
+        $this->assertDataRaisesValidationException(
+            [
+                'username' => 'fritz',
+                'email' => 'fritz@example.com',
+                'password' => 's3cret',
+                'password_confirmation' => 's3cret',
+            ],
+            [
+                'username' => [
+                    'settings.profile.nick.already-taken',
+                ],
                 'email' => [
                     'settings.profile.email.already-taken',
                 ],


### PR DESCRIPTION
Changed validator to collect all errors before throwing, so users see all validation problems at once instead of one at a time.

Fixes #1444