### PR TITLE
fix: filter shifts by user's selected angel types only

### DIFF
--- a/includes/controller/users_controller.php
+++ b/includes/controller/users_controller.php
@@ -389,10 +389,8 @@ function shiftCalendarRendererByShiftFilter(ShiftsFilter $shiftsFilter)
         foreach ($needed_angeltypes[$shift->id] as $needed_angeltype) {
             $taken = 0;
 
-            if (
-                !in_array(ShiftsFilter::FILLED_FILLED, $shiftsFilter->getFilled())
-                && !in_array($needed_angeltype['angel_type_id'], $shiftsFilter->getTypes())
-            ) {
+            // Only count slots for angel types the user has selected
+            if (!in_array($needed_angeltype['angel_type_id'], $shiftsFilter->getTypes())) {
                 continue;
             }
 


### PR DESCRIPTION
When filtering shifts by "Free" occupancy, only count free slots for angel types the user has selected. Previously, shifts were shown as having free slots even when those slots were for angel types the user couldn't fill.

This makes the "Own" angel types + "Free" occupancy filter combination actually show shifts where the user can help.

Fixes #403