### PR TITLE
feat: add calendar subscription URL for iCal export

### DIFF
--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -382,7 +382,6 @@ function view_user_shifts()
                 'msg'  => msg(),
                 'tag_id'  => $tagId,
                 'shifts_table'  => $shiftCalendarRenderer->render(),
-                'ical_text'     => div('mt-3', ical_hint()),
                 'filter'        => __('Filter shifts'),
                 'filter_toggle' => __('shifts.filter.toggle'),
                 'expand_toggle_title' => __('shifts.toggle.title'),
@@ -405,27 +404,6 @@ function view_user_shifts()
             ]),
         ]),
     ]);
-}
-
-/**
- * Returns a hint for the user how the ical feature works.
- *
- * @return string
- */
-function ical_hint()
-{
-    $user = auth()->user();
-    if (!auth()->can('ical')) {
-        return '';
-    }
-
-    return heading(__('iCal export and API') . ' ' . button_help('user/ical'), 2)
-        . '<p>' . sprintf(
-            __('Export your own shifts formatted as <a href="%s" target="_blank">iCal</a> or <a href="%s" target="_blank">JSON</a> (please keep the link secret, otherwise you have to reset the api key <a href="%s">in your settings</a>).'),
-            url('/ical', ['key' => $user->api_key]),
-            url('/shifts-json-export', ['key' => $user->api_key]),
-            url('/settings/api')
-        ) . '</p>';
 }
 
 /**

--- a/includes/sys_template.php
+++ b/includes/sys_template.php
@@ -328,16 +328,22 @@ function render_table($columns, $rows, $data = true)
  * @param string $id
  * @return string
  */
-function button($href, $label, $class = '', $id = '', $title = '', $disabled = false)
+function button($href, $label, $class = '', $id = '', $title = '', $disabled = false, $dataAttrs = [])
 {
     if (!Str::contains(str_replace(['btn-sm', 'btn-xl'], '', $class), 'btn-')) {
         $class = 'btn-secondary' . ($class ? ' ' . $class : '');
     }
 
     $idAttribute = $id ? 'id="' . $id . '"' : '';
+    $dataAttributes = '';
+    foreach ($dataAttrs as $key => $value) {
+        $dataAttributes .= sprintf(' data-%s="%s"', $key, htmlspecialchars($value));
+    }
 
     return '<a ' . $idAttribute . ' href="' . $href
-        . '" class="btn ' . $class . ($disabled ? ' disabled' : '') . '" title="' . $title . '">' . $label . '</a>';
+        . '" class="btn ' . $class . ($disabled ? ' disabled' : '') . '" title="' . $title . '"' . $dataAttributes . '>'
+        . $label
+        . '</a>';
 }
 
 /**

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -754,13 +754,13 @@ function User_view(
                                 'js-link-remove' => 'true',
                                 'bs-toggle' => 'popover',
                                 'bs-placement' => 'bottom',
-                                'bs-content' => '
+                                'bs-content' =>  __('settings.api.ical_feed') . ':<br>
                                     <code>' . url('/ical', ['key' => $user_source->api_key]) . '</code><br>
                                     <a
                                         href="' . url('/ical', ['key' => $user_source->api_key]) . '"
                                         class="btn btn-secondary btn-sm mt-3"
                                     >
-                                        ' . __('Open') . '
+                                        ' . __('Download iCal') . '
                                     </a>
                                 ',
                                 'bs-html' => 'true',

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -745,7 +745,26 @@ function User_view(
                         ),
                         $auth->can('ical') ? button(
                             url('/ical', ['key' => $user_source->api_key]),
-                            icon('calendar-week') . __('iCal Export')
+                            icon('calendar-week') . __('iCal Export'),
+                            '',
+                            '',
+                            '',
+                            false,
+                            [
+                                'js-link-remove' => 'true',
+                                'bs-toggle' => 'popover',
+                                'bs-placement' => 'bottom',
+                                'bs-content' => '
+                                    <code>' . url('/ical', ['key' => $user_source->api_key]) . '</code><br>
+                                    <a
+                                        href="' . url('/ical', ['key' => $user_source->api_key]) . '"
+                                        class="btn btn-secondary btn-sm mt-3"
+                                    >
+                                        ' . __('Open') . '
+                                    </a>
+                                ',
+                                'bs-html' => 'true',
+                            ],
                         ) : '',
                         $auth->can('shifts_json_export') ? button(
                             url('/shifts-json-export', ['key' => $user_source->api_key]),

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -760,7 +760,7 @@ function User_view(
                                         href="' . url('/ical', ['key' => $user_source->api_key]) . '"
                                         class="btn btn-secondary btn-sm mt-3"
                                     >
-                                        ' . __('Download iCal') . '
+                                        ' . __('settings.api.ical_download') . '
                                     </a>
                                 ',
                                 'bs-html' => 'true',

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -831,7 +831,6 @@ function User_view(
                     url('/user-shifts')
                 ), true, true)
                 : '',
-            $its_me ? ical_hint() : '',
         ]
     );
 }

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -685,6 +685,7 @@ function User_view(
         $needs_ifsg_certificate = $needs_ifsg_certificate || $angeltype->requires_ifsg_certificate;
     }
     $my_shifts_title = $its_me ? __('profile.my_shifts') : __('general.shifts');
+    $iCalUrl = url('/ical', ['key' => $user_source->api_key]);
 
     $self_worklog = config('enable_self_worklog') || !$its_me;
 
@@ -744,7 +745,7 @@ function User_view(
                             icon('person-fill-gear') . __('settings.settings')
                         ),
                         $auth->can('ical') ? button(
-                            url('/ical', ['key' => $user_source->api_key]),
+                            $iCalUrl,
                             icon('calendar-week') . __('iCal Export'),
                             '',
                             '',
@@ -755,13 +756,7 @@ function User_view(
                                 'bs-toggle' => 'popover',
                                 'bs-placement' => 'bottom',
                                 'bs-content' =>  __('settings.api.ical_feed') . ':<br>
-                                    <code>' . url('/ical', ['key' => $user_source->api_key]) . '</code><br>
-                                    <a
-                                        href="' . url('/ical', ['key' => $user_source->api_key]) . '"
-                                        class="btn btn-secondary btn-sm mt-3"
-                                    >
-                                        ' . __('settings.api.ical_download') . '
-                                    </a>
+                                    <code><a href="' . $iCalUrl . '">' . $iCalUrl . '</a></code>
                                 ',
                                 'bs-html' => 'true',
                             ],

--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -271,6 +271,14 @@ ready(() => {
 });
 
 /**
+ * Remove links from popover buttons
+ */
+ready(() => {
+  // biome-ignore lint/suspicious/useIterableCallbackReturn: ...
+  document.querySelectorAll('[data-js-link-remove="true"]').forEach((element) => (element.href = '#'));
+});
+
+/**
  * Init Bootstrap Tooltips
  */
 ready(() => {

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -453,6 +453,10 @@ code {
   @include border-radius($input-border-radius);
 }
 
+code a {
+  color: inherit;
+}
+
 @keyframes pulse {
   0% {
     transform: rotate(0deg);

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1775,6 +1775,12 @@ msgstr "JSON Schichten Export anzeigen"
 msgid "settings.api.ical_show"
 msgstr "iCal export anzeigen"
 
+msgid "settings.api.ical_download"
+msgstr "Herunterladen"
+
+msgid "settings.api.ical_subscribe"
+msgstr "Abonnieren"
+
 msgid "settings.api.news_show"
 msgstr "News feeds anzeigen"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1169,8 +1169,11 @@ msgstr "%s hat genug gemacht."
 msgid "iCal Export"
 msgstr "iCal Export"
 
-msgid "Open"
-msgstr "Öffnen"
+msgid "Download iCal"
+msgstr "iCal herunterladen"
+
+msgid "settings.api.ical_feed"
+msgstr "Abonnement Link"
 
 msgid "JSON Export"
 msgstr "JSON Export"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1768,7 +1768,7 @@ msgid "settings.api.ical_download"
 msgstr "iCal herunterladen"
 
 msgid "settings.api.ical_feed"
-msgstr "Abonnement Link"
+msgstr "Kalender abonnement Link"
 
 msgid "settings.api.news_show"
 msgstr "News feeds anzeigen"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1157,12 +1157,6 @@ msgstr "%s hat genug gemacht."
 msgid "iCal Export"
 msgstr "iCal Export"
 
-msgid "Download iCal"
-msgstr "iCal herunterladen"
-
-msgid "settings.api.ical_feed"
-msgstr "Abonnement Link"
-
 msgid "JSON Export"
 msgstr "JSON Export"
 
@@ -1769,8 +1763,12 @@ msgstr "JSON Schichten Export anzeigen"
 msgid "settings.api.ical_show"
 msgstr "iCal export anzeigen"
 
+
+msgid "settings.api.ical_download"
+msgstr "iCal herunterladen"
+
 msgid "settings.api.ical_feed"
-msgstr "iCal Feed"
+msgstr "Abonnement Link"
 
 msgid "settings.api.news_show"
 msgstr "News feeds anzeigen"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1169,6 +1169,9 @@ msgstr "%s hat genug gemacht."
 msgid "iCal Export"
 msgstr "iCal Export"
 
+msgid "Open"
+msgstr "Öffnen"
+
 msgid "JSON Export"
 msgstr "JSON Export"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1775,11 +1775,8 @@ msgstr "JSON Schichten Export anzeigen"
 msgid "settings.api.ical_show"
 msgstr "iCal export anzeigen"
 
-msgid "settings.api.ical_download"
-msgstr "Herunterladen"
-
-msgid "settings.api.ical_subscribe"
-msgstr "Abonnieren"
+msgid "settings.api.ical_feed"
+msgstr "iCal Feed"
 
 msgid "settings.api.news_show"
 msgstr "News feeds anzeigen"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -804,18 +804,6 @@ msgstr "nächste 4h"
 msgid "next 8h"
 msgstr "nächste 8h"
 
-msgid "iCal export and API"
-msgstr "iCal Export und API"
-
-msgid ""
-"Export your own shifts formatted as <a href=\"%s\" target=\"_blank\">iCal</a> or "
-"<a href=\"%s\" target=\"_blank\">JSON</a> (please keep the link secret, otherwise you have to reset the api key "
-"<a href=\"%s\">in your settings</a>)."
-msgstr ""
-"Exportiere Deine Schichten im <a href=\"%s\" target=\"_blank\">iCal</a> oder <a href=\"%s"
-"\" target=\"_blank\">JSON</a> Format (Link bitte geheimhalten, sonst musst du den API-Key in "
-"<a href=\"%s\">deinen Einstellungen</a> zurücksetzen)."
-
 msgid "Per page"
 msgstr "Pro Seite"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -586,11 +586,8 @@ msgstr "Show JSON shifts export"
 msgid "settings.api.ical_show"
 msgstr "Show iCal export"
 
-msgid "settings.api.ical_download"
-msgstr "Download"
-
-msgid "settings.api.ical_subscribe"
-msgstr "Subscribe"
+msgid "settings.api.ical_feed"
+msgstr "iCal Feed"
 
 msgid "settings.api.news_show"
 msgstr "Show news feeds"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -587,7 +587,7 @@ msgid "settings.api.ical_show"
 msgstr "Show iCal export"
 
 msgid "settings.api.ical_feed"
-msgstr "iCal Feed"
+msgstr "Subscription feed"
 
 msgid "settings.api.news_show"
 msgstr "Show news feeds"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -589,6 +589,9 @@ msgstr "Show iCal export"
 msgid "settings.api.ical_feed"
 msgstr "Subscription feed"
 
+msgid "settings.api.ical_download"
+msgstr "Download iCal"
+
 msgid "settings.api.news_show"
 msgstr "Show news feeds"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -586,6 +586,12 @@ msgstr "Show JSON shifts export"
 msgid "settings.api.ical_show"
 msgstr "Show iCal export"
 
+msgid "settings.api.ical_download"
+msgstr "Download"
+
+msgid "settings.api.ical_subscribe"
+msgstr "Subscribe"
+
 msgid "settings.api.news_show"
 msgstr "Show news feeds"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -587,7 +587,7 @@ msgid "settings.api.ical_show"
 msgstr "Show iCal export"
 
 msgid "settings.api.ical_feed"
-msgstr "Subscription feed"
+msgstr "Calendar subscription feed"
 
 msgid "settings.api.ical_download"
 msgstr "Download iCal"

--- a/resources/views/pages/settings/api.twig
+++ b/resources/views/pages/settings/api.twig
@@ -73,7 +73,10 @@
 
             {% if can('ical') %}
                 <p id="ical_hide" class="collapse" data-bs-parent="#exports_hide">
+                    {{ __('settings.api.ical_download') }}:<br>
                     <code>{{ url('/ical', {'key': user.api_key}) }}</code>
+                    <br>{{ __('settings.api.ical_subscribe') }}:<br>
+                    <code>{{ url('/ical', {'key': user.api_key, 'subscribe': 1}) }}</code>
                 </p>
             {% endif %}
 

--- a/resources/views/pages/settings/api.twig
+++ b/resources/views/pages/settings/api.twig
@@ -73,10 +73,8 @@
 
             {% if can('ical') %}
                 <p id="ical_hide" class="collapse" data-bs-parent="#exports_hide">
-                    {{ __('settings.api.ical_download') }}:<br>
+                    {{ __('settings.api.ical_feed') }}:<br>
                     <code>{{ url('/ical', {'key': user.api_key}) }}</code>
-                    <br>{{ __('settings.api.ical_subscribe') }}:<br>
-                    <code>{{ url('/ical', {'key': user.api_key, 'subscribe': 1}) }}</code>
                 </p>
             {% endif %}
 

--- a/resources/views/pages/settings/api.twig
+++ b/resources/views/pages/settings/api.twig
@@ -77,7 +77,7 @@
                     {{ __('settings.api.ical_feed') }}:<br>
                     <code>{{ url('/ical', {'key': user.api_key}) }}</code>
                     <br>
-                    {{ m.button(__('Download export'), url('/ical', {'key': user.api_key}, {'size': 'sm'})) }}
+                    {{ m.button(__('settings.api.ical_download'), url('/ical', {'key': user.api_key}, {'size': 'sm'})) }}
                 </p>
             {% endif %}
 

--- a/resources/views/pages/settings/api.twig
+++ b/resources/views/pages/settings/api.twig
@@ -1,5 +1,6 @@
 {% extends 'pages/settings/settings.twig' %}
 {% import 'macros/form.twig' as f %}
+{% import 'macros/base.twig' as m %}
 
 {% block title %}{{ __('settings.api') }}{% endblock %}
 
@@ -75,6 +76,8 @@
                 <p id="ical_hide" class="collapse" data-bs-parent="#exports_hide">
                     {{ __('settings.api.ical_feed') }}:<br>
                     <code>{{ url('/ical', {'key': user.api_key}) }}</code>
+                    <br>
+                    {{ m.button(__('Download export'), url('/ical', {'key': user.api_key}, {'size': 'sm'})) }}
                 </p>
             {% endif %}
 

--- a/resources/views/pages/user-shifts.html
+++ b/resources/views/pages/user-shifts.html
@@ -106,4 +106,3 @@
     <div class="col-md-10 offset-md-1 mb-3 text-end">%tags%</div>
 </div>
 %msg% %shifts_table%
-<div class="d-print-none">%ical_text%</div>

--- a/src/Controllers/FeedController.php
+++ b/src/Controllers/FeedController.php
@@ -61,10 +61,18 @@ class FeedController extends BaseController
             $timezoneTransitionStart = Carbon::now()->startOfDay()->utc()->isoFormat('YYYYMMDDTHHmmss');
         }
 
-        return $this->withEtag($shifts)
-            ->withHeader('content-type', 'text/calendar; charset=utf-8')
-            ->withHeader('content-disposition', 'attachment; filename=shifts.ics')
-            ->withView('api/ical', ['shiftEntries' => $shifts, 'timezoneTransitionStart' => $timezoneTransitionStart]);
+        $response = $this->withEtag($shifts)
+            ->withHeader('content-type', 'text/calendar; charset=utf-8');
+
+        // When not subscribing, force download instead of opening in browser
+        if (!$this->request->get('subscribe')) {
+            $response = $response->withHeader('content-disposition', 'attachment; filename=shifts.ics');
+        }
+
+        return $response->withView(
+            'api/ical',
+            ['shiftEntries' => $shifts, 'timezoneTransitionStart' => $timezoneTransitionStart]
+        );
     }
 
     public function shifts(): Response

--- a/src/Controllers/FeedController.php
+++ b/src/Controllers/FeedController.php
@@ -64,11 +64,6 @@ class FeedController extends BaseController
         $response = $this->withEtag($shifts)
             ->withHeader('content-type', 'text/calendar; charset=utf-8');
 
-        // When not subscribing, force download instead of opening in browser
-        if (!$this->request->get('subscribe')) {
-            $response = $response->withHeader('content-disposition', 'attachment; filename=shifts.ics');
-        }
-
         return $response->withView(
             'api/ical',
             ['shiftEntries' => $shifts, 'timezoneTransitionStart' => $timezoneTransitionStart]

--- a/tests/Unit/Controllers/FeedControllerTest.php
+++ b/tests/Unit/Controllers/FeedControllerTest.php
@@ -98,13 +98,12 @@ class FeedControllerTest extends ControllerTest
         $user = User::factory()->create(['api_key' => 'fo0']);
         ShiftEntry::factory(3)->create(['user_id' => $user->id]);
 
-        $this->response->expects($this->exactly(2))
-            ->method('withHeader')
-            ->withConsecutive(
-                ['content-type', 'text/calendar; charset=utf-8'],
-                ['content-disposition', 'attachment; filename=shifts.ics']
-            )
-            ->willReturn($this->response);
+        $this->setExpects(
+            $this->response,
+            'withHeader',
+            ['content-type', 'text/calendar; charset=utf-8'],
+            $this->response
+        );
 
         $this->setExpects($this->response, 'setEtag', null, $this->response);
 
@@ -141,13 +140,12 @@ class FeedControllerTest extends ControllerTest
 
         User::factory()->create(['api_key' => 'fo0']);
 
-        $this->response->expects($this->exactly(2))
-            ->method('withHeader')
-            ->withConsecutive(
-                ['content-type', 'text/calendar; charset=utf-8'],
-                ['content-disposition', 'attachment; filename=shifts.ics']
-            )
-            ->willReturn($this->response);
+        $this->setExpects(
+            $this->response,
+            'withHeader',
+            ['content-type', 'text/calendar; charset=utf-8'],
+            $this->response
+        );
 
         $this->setExpects($this->response, 'setEtag', null, $this->response);
 

--- a/tests/Unit/Controllers/FeedControllerTest.php
+++ b/tests/Unit/Controllers/FeedControllerTest.php
@@ -95,15 +95,16 @@ class FeedControllerTest extends ControllerTest
         $controller = new FeedController($this->auth, $this->request, $this->response, $this->url);
 
         /** @var User $user */
-        $user = User::factory()->create(['api_key' => 'fo0']);
+        $user = User::factory()->create(['api_key' => 'fo0', 'name' => 'testuser']);
         ShiftEntry::factory(3)->create(['user_id' => $user->id]);
 
-        $this->setExpects(
-            $this->response,
-            'withHeader',
-            ['content-type', 'text/calendar; charset=utf-8'],
-            $this->response
-        );
+        $this->response->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['content-type', 'text/calendar; charset=utf-8'],
+                ['content-disposition', 'inline; filename=EngelsystemDEV-testuser-shifts.ics']
+            )
+            ->willReturn($this->response);
 
         $this->setExpects($this->response, 'setEtag', null, $this->response);
 
@@ -138,14 +139,15 @@ class FeedControllerTest extends ControllerTest
         );
         $controller = new FeedController($this->auth, $this->request, $this->response, $this->url);
 
-        User::factory()->create(['api_key' => 'fo0']);
+        User::factory()->create(['api_key' => 'fo0', 'name' => 'emptyuser']);
 
-        $this->setExpects(
-            $this->response,
-            'withHeader',
-            ['content-type', 'text/calendar; charset=utf-8'],
-            $this->response
-        );
+        $this->response->expects($this->exactly(2))
+            ->method('withHeader')
+            ->withConsecutive(
+                ['content-type', 'text/calendar; charset=utf-8'],
+                ['content-disposition', 'inline; filename=EngelsystemDEV-emptyuser-shifts.ics']
+            )
+            ->willReturn($this->response);
 
         $this->setExpects($this->response, 'setEtag', null, $this->response);
 
@@ -294,6 +296,7 @@ class FeedControllerTest extends ControllerTest
         $this->config->set([
             'display_news' => 10,
             'timezone' => 'UTC',
+            'app_name' => 'Engelsystem DEV',
         ]);
         $this->auth = $this->createMock(Authenticator::class);
         $this->url = $this->createMock(UrlGenerator::class);

--- a/tests/Unit/Controllers/FeedControllerTest.php
+++ b/tests/Unit/Controllers/FeedControllerTest.php
@@ -95,7 +95,7 @@ class FeedControllerTest extends ControllerTestCase
         $controller = new FeedController($this->auth, $this->request, $this->response, $this->url);
 
         /** @var User $user */
-        $user = User::factory()->create(['api_key' => 'fo0']);
+        $user = User::factory()->create(['api_key' => 'fo0', 'name' => 'testuser']);
         ShiftEntry::factory(3)->create(['user_id' => $user->id]);
 
         $matcher = $this->exactly(2);
@@ -107,7 +107,7 @@ class FeedControllerTest extends ControllerTestCase
                 }
                 if ($matcher->numberOfInvocations() === 2) {
                     $this->assertSame('content-disposition', $parameters[0]);
-                    $this->assertSame('attachment; filename=shifts.ics', $parameters[1]);
+                    $this->assertSame('inline; filename=EngelsystemDEV-testuser-shifts.ics', $parameters[1]);
                 }
                 return $this->response;
             });
@@ -142,7 +142,7 @@ class FeedControllerTest extends ControllerTestCase
         );
         $controller = new FeedController($this->auth, $this->request, $this->response, $this->url);
 
-        User::factory()->create(['api_key' => 'fo0']);
+        User::factory()->create(['api_key' => 'fo0', 'name' => 'emptyuser']);
 
         $matcher = $this->exactly(2);
         $this->response->expects($matcher)
@@ -153,7 +153,7 @@ class FeedControllerTest extends ControllerTestCase
                 }
                 if ($matcher->numberOfInvocations() === 2) {
                     $this->assertSame('content-disposition', $parameters[0]);
-                    $this->assertSame('attachment; filename=shifts.ics', $parameters[1]);
+                    $this->assertSame('inline; filename=EngelsystemDEV-emptyuser-shifts.ics', $parameters[1]);
                 }
                 return $this->response;
             });
@@ -295,6 +295,7 @@ class FeedControllerTest extends ControllerTestCase
         $this->config->set([
             'display_news' => 10,
             'timezone' => 'UTC',
+            'app_name' => 'Engelsystem DEV',
         ]);
         $this->auth = $this->createMock(Authenticator::class);
         $this->url = $this->createMock(UrlGenerator::class);


### PR DESCRIPTION
Adds a `content-disposition: inline` header for the iCal endpoint with file name containing engelsystem and user name.

~~Add a `subscribe` parameter to the iCal endpoint. When set, the Content-Disposition header is omitted, allowing calendar apps to subscribe to the feed instead of downloading it as a file.~~

~~The settings page now shows both URLs: the existing download link plus a new subscription URL that calendar apps can poll for updates.~~

Fixes #413