### PR TITLE
feat: send welcome email to newly registered users

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -88,6 +88,8 @@ return [
         ],
 
         'shift.updating' => \Engelsystem\Events\Listener\Shifts::class . '@updatedSendEmail',
+
+        'user.created' => \Engelsystem\Events\Listener\Users::class . '@created',
     ],
 
     'config_options' => [

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -169,10 +169,13 @@ msgid "email.user.welcome.subject"
 msgstr "Willkommen bei %s!"
 
 msgid "email.user.welcome"
-msgstr ""
-"Danke für deine Registrierung! Dein Konto wurde erfolgreich erstellt.\n"
-"\n"
-"Du kannst dich jetzt einloggen und für Schichten eintragen."
+msgstr "Danke für deine Registrierung! Dein Konto wurde erfolgreich erstellt."
+
+msgid "email.user.welcome.can_signup"
+msgstr "Du kannst dich jetzt einloggen und für Schichten eintragen."
+
+msgid "email.user.welcome.arrive_first"
+msgstr "Du kannst dich jetzt einloggen. Um dich für Schichten eintragen zu können, melde dich bitte vor Ort, wenn du angekommen bist."
 
 msgid "password.minimal_length"
 msgstr "Mindestlänge %d Zeichen"

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -165,6 +165,15 @@ msgstr ""
 "zurücksetzen kannst. Bitte benutze die E-Mail-Adresse, die du bei der Anmeldung "
 "verwendet hast."
 
+msgid "email.user.welcome.subject"
+msgstr "Willkommen bei %s!"
+
+msgid "email.user.welcome"
+msgstr ""
+"Danke für deine Registrierung! Dein Konto wurde erfolgreich erstellt.\n"
+"\n"
+"Du kannst dich jetzt einloggen und für Schichten eintragen."
+
 msgid "password.minimal_length"
 msgstr "Mindestlänge %d Zeichen"
 

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -169,13 +169,13 @@ msgid "email.user.welcome.subject"
 msgstr "Willkommen bei %s!"
 
 msgid "email.user.welcome"
-msgstr "Danke für deine Registrierung! Dein Konto wurde erfolgreich erstellt."
+msgstr "Hallo %s, dein Konto wurde erstellt."
 
 msgid "email.user.welcome.can_signup"
 msgstr "Du kannst dich jetzt einloggen und für Schichten eintragen."
 
 msgid "email.user.welcome.arrive_first"
-msgstr "Du kannst dich jetzt einloggen. Um dich für Schichten eintragen zu können, melde dich bitte vor Ort, wenn du angekommen bist."
+msgstr "Du kannst dich jetzt einloggen. Um dich für Schichten eintragen zu können, melde dich bitte vor Ort an."
 
 msgid "password.minimal_length"
 msgstr "Mindestlänge %d Zeichen"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -989,13 +989,13 @@ msgid "email.user.welcome.subject"
 msgstr "Welcome to %s!"
 
 msgid "email.user.welcome"
-msgstr "Thank you for registering! Your account has been created successfully."
+msgstr "Your account has been created."
 
 msgid "email.user.welcome.can_signup"
 msgstr "You can now log in and sign up for shifts."
 
 msgid "email.user.welcome.arrive_first"
-msgstr "You can now log in. Shift signup will be available after you check in at the event."
+msgstr "You can now log in. To sign up for shifts, please check in when you arrive at the event."
 
 msgid "password.minimal_length"
 msgstr "Minimal length %d characters"

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -985,6 +985,15 @@ msgstr ""
 msgid "password.email.message"
 msgstr "Please visit %s to recover your password."
 
+msgid "email.user.welcome.subject"
+msgstr "Welcome to %s!"
+
+msgid "email.user.welcome"
+msgstr ""
+"Thank you for registering! Your account has been created successfully.\n"
+"\n"
+"You can now log in and sign up for shifts."
+
 msgid "password.minimal_length"
 msgstr "Minimal length %d characters"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -989,10 +989,13 @@ msgid "email.user.welcome.subject"
 msgstr "Welcome to %s!"
 
 msgid "email.user.welcome"
-msgstr ""
-"Thank you for registering! Your account has been created successfully.\n"
-"\n"
-"You can now log in and sign up for shifts."
+msgstr "Thank you for registering! Your account has been created successfully."
+
+msgid "email.user.welcome.can_signup"
+msgstr "You can now log in and sign up for shifts."
+
+msgid "email.user.welcome.arrive_first"
+msgstr "You can now log in. Shift signup will be available after you check in at the event."
 
 msgid "password.minimal_length"
 msgstr "Minimal length %d characters"

--- a/resources/views/emails/user-welcome.text.twig
+++ b/resources/views/emails/user-welcome.text.twig
@@ -1,0 +1,3 @@
+{% extends "emails/mail.text.twig" %}
+
+{% block message %}{{ __('email.user.welcome', [config('app_name')]) }}{% endblock %}

--- a/resources/views/emails/user-welcome.text.twig
+++ b/resources/views/emails/user-welcome.text.twig
@@ -1,3 +1,11 @@
 {% extends "emails/mail.text.twig" %}
 
-{% block message %}{{ __('email.user.welcome', [config('app_name')]) }}{% endblock %}
+{% block message %}
+{{ __('email.user.welcome') }}
+
+{% if not config('signup_requires_arrival') or config('autoarrive') %}
+{{ __('email.user.welcome.can_signup') }}
+{% else %}
+{{ __('email.user.welcome.arrive_first') }}
+{% endif %}
+{% endblock %}

--- a/resources/views/emails/user-welcome.text.twig
+++ b/resources/views/emails/user-welcome.text.twig
@@ -1,7 +1,7 @@
 {% extends "emails/mail.text.twig" %}
 
 {% block message %}
-{{ __('email.user.welcome') }}
+{{ __('email.user.welcome', [username]) }}
 
 {% if not config('signup_requires_arrival') or config('autoarrive') %}
 {{ __('email.user.welcome.can_signup') }}

--- a/src/Events/Listener/Users.php
+++ b/src/Events/Listener/Users.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Events\Listener;
+
+use Engelsystem\Mail\EngelsystemMailer;
+use Engelsystem\Models\User\User;
+use Psr\Log\LoggerInterface;
+
+class Users
+{
+    public function __construct(
+        protected LoggerInterface $log,
+        protected EngelsystemMailer $mailer
+    ) {
+    }
+
+    public function created(User $user): void
+    {
+        $this->mailer->sendViewTranslated(
+            $user,
+            'email.user.welcome.subject',
+            'emails/user-welcome',
+            ['username' => $user->displayName]
+        );
+    }
+}

--- a/src/Events/Listener/Users.php
+++ b/src/Events/Listener/Users.php
@@ -22,7 +22,7 @@ class Users
             $user,
             'email.user.welcome.subject',
             'emails/user-welcome',
-            ['username' => $user->displayName]
+            ['app_name' => config('app_name'), 'username' => $user->displayName]
         );
     }
 }

--- a/src/Factories/User.php
+++ b/src/Factories/User.php
@@ -309,6 +309,8 @@ class User
 
         $this->dbConnection->commit();
 
+        event('user.created', ['user' => $user]);
+
         return $user;
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -101,7 +101,7 @@ function env_secret(string $var, mixed $default = null): string | null
     return env($var, $default);
 }
 
-function event(string|object|null $event = null, array $payload = []): array|EventDispatcher
+function event(string|object|null $event = null, array $payload = []): mixed
 {
     /** @var EventDispatcher $dispatcher */
     $dispatcher = app('events.dispatcher');

--- a/tests/Unit/Events/Listener/UsersTest.php
+++ b/tests/Unit/Events/Listener/UsersTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Events\Listener;
+
+use Engelsystem\Config\Config;
+use Engelsystem\Events\Listener\Users;
+use Engelsystem\Mail\EngelsystemMailer;
+use Engelsystem\Models\User\User;
+use Engelsystem\Test\Unit\HasDatabase;
+use Engelsystem\Test\Unit\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\Test\TestLogger;
+
+class UsersTest extends TestCase
+{
+    use HasDatabase;
+
+    protected TestLogger $log;
+
+    /**
+     * @covers \Engelsystem\Events\Listener\Users::created
+     * @covers \Engelsystem\Events\Listener\Users::__construct
+     */
+    public function testCreated(): void
+    {
+        /** @var EngelsystemMailer|MockObject $mailer */
+        $mailer = $this->createMock(EngelsystemMailer::class);
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $mailer->expects($this->once())
+            ->method('sendViewTranslated')
+            ->willReturnCallback(function (
+                User $recipient,
+                string $subject,
+                string $template,
+                array $data
+            ) use ($user): bool {
+                $this->assertEquals($user->id, $recipient->id);
+                $this->assertEquals('email.user.welcome.subject', $subject);
+                $this->assertEquals('emails/user-welcome', $template);
+                $this->assertArrayHasKey('username', $data);
+                $this->assertEquals($user->displayName, $data['username']);
+                return true;
+            });
+
+        $handler = new Users($this->log, $mailer);
+        $handler->created($user);
+    }
+
+    protected function setUp(): void
+    {
+        $this->log = new TestLogger();
+
+        parent::setUp();
+        $this->initDatabase();
+        $this->app->instance('config', new Config());
+    }
+}

--- a/tests/Unit/Events/Listener/UsersTest.php
+++ b/tests/Unit/Events/Listener/UsersTest.php
@@ -41,6 +41,7 @@ class UsersTest extends TestCase
                 $this->assertEquals($user->id, $recipient->id);
                 $this->assertEquals('email.user.welcome.subject', $subject);
                 $this->assertEquals('emails/user-welcome', $template);
+                $this->assertArrayHasKey('app_name', $data);
                 $this->assertArrayHasKey('username', $data);
                 $this->assertEquals($user->displayName, $data['username']);
                 return true;

--- a/tests/Unit/Factories/UserTest.php
+++ b/tests/Unit/Factories/UserTest.php
@@ -7,6 +7,7 @@ namespace Engelsystem\Test\Unit\Factories;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Engelsystem\Config\Config;
+use Engelsystem\Events\EventDispatcher;
 use Engelsystem\Factories\User;
 use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Http\Exceptions\ValidationException;
@@ -54,6 +55,10 @@ class UserTest extends ServiceProviderTest
         $this->app->instance(ServerRequestInterface::class, new Request());
         $this->app->instance(Authenticator::class, $this->app->make(Authenticator::class));
         $this->app->alias(Authenticator::class, 'authenticator');
+
+        $dispatcher = $this->createMock(EventDispatcher::class);
+        $dispatcher->method('dispatch')->willReturn([]);
+        $this->app->instance('events.dispatcher', $dispatcher);
 
         $this->subject = $this->app->make(User::class);
     }

--- a/tests/Unit/Factories/UserTest.php
+++ b/tests/Unit/Factories/UserTest.php
@@ -57,7 +57,7 @@ class UserTest extends ServiceProviderTest
         $this->app->alias(Authenticator::class, 'authenticator');
 
         $dispatcher = $this->createMock(EventDispatcher::class);
-        $dispatcher->method('dispatch')->willReturn([]);
+        $dispatcher->method('dispatch')->willReturn(null);
         $this->app->instance('events.dispatcher', $dispatcher);
 
         $this->subject = $this->app->make(User::class);


### PR DESCRIPTION
Sends a welcome email to users when they register, confirming their account was created successfully.

Uses the existing email infrastructure and respects the user's email notification preferences.

Fixes #1546