### PR TITLE
feat: allow angel types to permit shift signup before arrival

### DIFF
--- a/db/migrations/2026_01_14_000000_add_signup_before_arrival_to_angel_types.php
+++ b/db/migrations/2026_01_14_000000_add_signup_before_arrival_to_angel_types.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Migrations;
+
+use Engelsystem\Database\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddSignupBeforeArrivalToAngelTypes extends Migration
+{
+    /**
+     * Run the migration
+     */
+    public function up(): void
+    {
+        $this->schema->table('angel_types', function (Blueprint $table): void {
+            $table->boolean('shift_signup_before_arrival')->default(false)->after('restricted');
+        });
+    }
+
+    /**
+     * Reverse the migration
+     */
+    public function down(): void
+    {
+        $this->schema->table('angel_types', function (Blueprint $table): void {
+            $table->dropColumn('shift_signup_before_arrival');
+        });
+    }
+}

--- a/includes/controller/angeltypes_controller.php
+++ b/includes/controller/angeltypes_controller.php
@@ -117,6 +117,7 @@ function angeltype_edit_controller()
             }
 
             $angeltype->restricted = $request->has('restricted');
+            $angeltype->shift_signup_before_arrival = $request->has('shift_signup_before_arrival');
             $angeltype->shift_self_signup = $request->has('shift_self_signup');
             $angeltype->show_on_dashboard = $request->has('show_on_dashboard');
             $angeltype->hide_register = $request->has('hide_register');

--- a/includes/controller/angeltypes_controller.php
+++ b/includes/controller/angeltypes_controller.php
@@ -117,7 +117,9 @@ function angeltype_edit_controller()
             }
 
             $angeltype->restricted = $request->has('restricted');
-            $angeltype->shift_signup_before_arrival = $request->has('shift_signup_before_arrival');
+            if (config('signup_requires_arrival')) {
+                $angeltype->shift_signup_before_arrival = $request->has('shift_signup_before_arrival');
+            }
             $angeltype->shift_self_signup = $request->has('shift_self_signup');
             $angeltype->show_on_dashboard = $request->has('show_on_dashboard');
             $angeltype->hide_register = $request->has('hide_register');

--- a/includes/model/NeededAngelTypes_model.php
+++ b/includes/model/NeededAngelTypes_model.php
@@ -22,7 +22,8 @@ function NeededAngelTypes_by_shift($shift)
             `needed_angel_types`.*,
             `angel_types`.`name`,
             `angel_types`.`restricted`,
-            `angel_types`.`shift_self_signup`
+            `angel_types`.`shift_self_signup`,
+            `angel_types`.`shift_signup_before_arrival`
         FROM `needed_angel_types`
         JOIN `angel_types` ON `angel_types`.`id` = `needed_angel_types`.`angel_type_id`
         WHERE `needed_angel_types`.`shift_id` = ?
@@ -39,7 +40,8 @@ function NeededAngelTypes_by_shift($shift)
             `needed_angel_types`.*,
             `angel_types`.`name`,
             `angel_types`.`restricted`,
-            `angel_types`.`shift_self_signup`
+            `angel_types`.`shift_self_signup`,
+            `angel_types`.`shift_signup_before_arrival`
         FROM `needed_angel_types`
         JOIN `angel_types` ON `angel_types`.`id` = `needed_angel_types`.`angel_type_id`
         WHERE `needed_angel_types`.`shift_type_id` = ?
@@ -54,7 +56,8 @@ function NeededAngelTypes_by_shift($shift)
             `needed_angel_types`.*,
             `angel_types`.`name`,
             `angel_types`.`restricted`,
-            `angel_types`.`shift_self_signup`
+            `angel_types`.`shift_self_signup`,
+            `angel_types`.`shift_signup_before_arrival`
         FROM `needed_angel_types`
         JOIN `angel_types` ON `angel_types`.`id` = `needed_angel_types`.`angel_type_id`
         WHERE `needed_angel_types`.`location_id` = ?

--- a/includes/model/Shifts_model.php
+++ b/includes/model/Shifts_model.php
@@ -554,7 +554,7 @@ function Shift_signup_allowed_angel(
         return new ShiftSignupState(ShiftSignupStatus::NOT_YET, $free_entries);
     }
 
-    if (config('signup_requires_arrival') && !$user->state->arrived) {
+    if (config('signup_requires_arrival') && !$user->state->arrived && !$angeltype->shift_signup_before_arrival) {
         return new ShiftSignupState(ShiftSignupStatus::NOT_ARRIVED, $free_entries);
     }
 

--- a/includes/model/Shifts_model.php
+++ b/includes/model/Shifts_model.php
@@ -223,7 +223,8 @@ function NeededAngeltypes_by_ShiftsFilter(ShiftsFilter $shiftsFilter)
             `angel_types`.`id`,
             `angel_types`.`name`,
             `angel_types`.`restricted`,
-            `angel_types`.`shift_self_signup`
+            `angel_types`.`shift_self_signup`,
+            `angel_types`.`shift_signup_before_arrival`
         FROM `shifts`
         JOIN `needed_angel_types` ON `needed_angel_types`.`shift_id`=`shifts`.`id`
         JOIN `angel_types` ON `angel_types`.`id`= `needed_angel_types`.`angel_type_id`
@@ -241,7 +242,8 @@ function NeededAngeltypes_by_ShiftsFilter(ShiftsFilter $shiftsFilter)
             `angel_types`.`id`,
             `angel_types`.`name`,
             `angel_types`.`restricted`,
-            `angel_types`.`shift_self_signup`
+            `angel_types`.`shift_self_signup`,
+            `angel_types`.`shift_signup_before_arrival`
         FROM `shifts`
         JOIN `needed_angel_types` ON `needed_angel_types`.`shift_type_id`=`shifts`.`shift_type_id`
         JOIN `angel_types` ON `angel_types`.`id`= `needed_angel_types`.`angel_type_id`
@@ -261,7 +263,8 @@ function NeededAngeltypes_by_ShiftsFilter(ShiftsFilter $shiftsFilter)
             `angel_types`.`id`,
             `angel_types`.`name`,
             `angel_types`.`restricted`,
-            `angel_types`.`shift_self_signup`
+            `angel_types`.`shift_self_signup`,
+            `angel_types`.`shift_signup_before_arrival`
         FROM `shifts`
         JOIN `needed_angel_types` ON `needed_angel_types`.`location_id`=`shifts`.`location_id`
         JOIN `angel_types` ON `angel_types`.`id`= `needed_angel_types`.`angel_type_id`
@@ -301,7 +304,8 @@ function NeededAngeltype_by_Shift_and_Angeltype(Shift $shift, AngelType $angelty
                 `angel_types`.`id`,
                 `angel_types`.`name`,
                 `angel_types`.`restricted`,
-                `angel_types`.`shift_self_signup`
+                `angel_types`.`shift_self_signup`,
+                `angel_types`.`shift_signup_before_arrival`
             FROM `shifts`
             JOIN `needed_angel_types` ON `needed_angel_types`.`shift_id`=`shifts`.`id`
             JOIN `angel_types` ON `angel_types`.`id`= `needed_angel_types`.`angel_type_id`
@@ -319,7 +323,8 @@ function NeededAngeltype_by_Shift_and_Angeltype(Shift $shift, AngelType $angelty
                 `angel_types`.`id`,
                 `angel_types`.`name`,
                 `angel_types`.`restricted`,
-                `angel_types`.`shift_self_signup`
+                `angel_types`.`shift_self_signup`,
+                `angel_types`.`shift_signup_before_arrival`
             FROM `shifts`
             JOIN `needed_angel_types` ON `needed_angel_types`.`shift_type_id`=`shifts`.`shift_type_id`
             JOIN `angel_types` ON `angel_types`.`id`= `needed_angel_types`.`angel_type_id`
@@ -339,7 +344,8 @@ function NeededAngeltype_by_Shift_and_Angeltype(Shift $shift, AngelType $angelty
                 `angel_types`.`id`,
                 `angel_types`.`name`,
                 `angel_types`.`restricted`,
-                `angel_types`.`shift_self_signup`
+                `angel_types`.`shift_self_signup`,
+                `angel_types`.`shift_signup_before_arrival`
             FROM `shifts`
             JOIN `needed_angel_types` ON `needed_angel_types`.`location_id`=`shifts`.`location_id`
             JOIN `angel_types` ON `angel_types`.`id`= `needed_angel_types`.`angel_type_id`

--- a/includes/view/AngelTypes_view.php
+++ b/includes/view/AngelTypes_view.php
@@ -160,6 +160,18 @@ function AngelType_edit_view(AngelType $angeltype, bool $supporter_mode)
                                 $angeltype->restricted
                             ),
                         $supporter_mode
+                            ? form_info(
+                                __('angeltypes.shift_signup_before_arrival'),
+                                $angeltype->shift_signup_before_arrival ? __('Yes') : __('No')
+                            )
+                            : form_checkbox(
+                                'shift_signup_before_arrival',
+                                __('angeltypes.shift_signup_before_arrival') .
+                                ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
+                                __('angeltypes.shift_signup_before_arrival.info') . '"></span>',
+                                $angeltype->shift_signup_before_arrival
+                            ),
+                        $supporter_mode
                             ? form_info(__('shift.self_signup'), $angeltype->shift_self_signup ? __('Yes') : __('No'))
                             : form_checkbox(
                                 'shift_self_signup',

--- a/includes/view/AngelTypes_view.php
+++ b/includes/view/AngelTypes_view.php
@@ -159,18 +159,20 @@ function AngelType_edit_view(AngelType $angeltype, bool $supporter_mode)
                                 __('angeltypes.restricted.info') . '"></span>',
                                 $angeltype->restricted
                             ),
-                        $supporter_mode
-                            ? form_info(
-                                __('angeltypes.shift_signup_before_arrival'),
-                                $angeltype->shift_signup_before_arrival ? __('Yes') : __('No')
-                            )
-                            : form_checkbox(
-                                'shift_signup_before_arrival',
-                                __('angeltypes.shift_signup_before_arrival') .
-                                ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
-                                __('angeltypes.shift_signup_before_arrival.info') . '"></span>',
-                                $angeltype->shift_signup_before_arrival
-                            ),
+                        config('signup_requires_arrival')
+                            ? ($supporter_mode
+                                ? form_info(
+                                    __('angeltypes.shift_signup_before_arrival'),
+                                    $angeltype->shift_signup_before_arrival ? __('Yes') : __('No')
+                                )
+                                : form_checkbox(
+                                    'shift_signup_before_arrival',
+                                    __('angeltypes.shift_signup_before_arrival') .
+                                    ' <span class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" title="' .
+                                    __('angeltypes.shift_signup_before_arrival.info') . '"></span>',
+                                    $angeltype->shift_signup_before_arrival
+                                ))
+                            : '',
                         $supporter_mode
                             ? form_info(__('shift.self_signup'), $angeltype->shift_self_signup ? __('Yes') : __('No'))
                             : form_checkbox(

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1927,6 +1927,12 @@ msgid "angeltypes.restricted.hint"
 msgstr "Dieser Engeltyp benötigt eine Einweisung bei einem Einführungstreffen. "
 "Weitere Informationen findest du möglicherweise in der Beschreibung."
 
+msgid "angeltypes.shift_signup_before_arrival"
+msgstr "Schichteintragung vor Ankunft erlauben"
+
+msgid "angeltypes.shift_signup_before_arrival.info"
+msgstr "Erlaubt Benutzern, sich für Schichten dieses Engeltyps einzutragen, bevor sie als angekommen markiert sind."
+
 msgid "angeltypes.can-change-later"
 msgstr "Du kannst Deine Auswahl später in den Einstellungen ändern."
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -772,6 +772,12 @@ msgid "angeltypes.restricted.hint"
 msgstr "This angel type requires attendance at an introduction meeting. "
 "You might find additional information in the description."
 
+msgid "angeltypes.shift_signup_before_arrival"
+msgstr "Allow shift signup before arrival"
+
+msgid "angeltypes.shift_signup_before_arrival.info"
+msgstr "Allow users to sign up for shifts of this angel type before being marked as arrived."
+
 msgid "angeltypes.can-change-later"
 msgstr "You can change your selection later in the settings."
 

--- a/src/Models/AngelType.php
+++ b/src/Models/AngelType.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  * @property string                            $contact_dect
  * @property string                            $contact_email
  * @property boolean                           $restricted # If users need an introduction
+ * @property boolean                           $shift_signup_before_arrival # If users can sign up before arrival
  * @property boolean                           $requires_driver_license # If users must have a driver license
  * @property boolean                           $requires_ifsg_certificate # If users must have a ifsg certificate
  * @property boolean                           $shift_self_signup # Users can sign up for shifts
@@ -57,8 +58,9 @@ class AngelType extends BaseModel
         'contact_name'              => '',
         'contact_dect'              => '',
         'contact_email'             => '',
-        'restricted'                => true,
-        'requires_driver_license'   => false,
+        'restricted'                   => true,
+        'shift_signup_before_arrival'  => false,
+        'requires_driver_license'      => false,
         'requires_ifsg_certificate' => false,
         'shift_self_signup'         => true,
         'show_on_dashboard'         => true,
@@ -80,6 +82,7 @@ class AngelType extends BaseModel
         'contact_email',
 
         'restricted',
+        'shift_signup_before_arrival',
         'requires_driver_license',
         'requires_ifsg_certificate',
         'shift_self_signup',
@@ -90,8 +93,9 @@ class AngelType extends BaseModel
 
     /** @var array<string, string> */
     protected $casts = [ // phpcs:ignore
-        'restricted'                => 'boolean',
-        'requires_driver_license'   => 'boolean',
+        'restricted'                   => 'boolean',
+        'shift_signup_before_arrival'  => 'boolean',
+        'requires_driver_license'      => 'boolean',
         'requires_ifsg_certificate' => 'boolean',
         'shift_self_signup'         => 'boolean',
         'show_on_dashboard'         => 'boolean',


### PR DESCRIPTION
Adds a per-angel-type setting `signup_allowed_before_arrival` that overrides the global `signup_requires_arrival` config. When enabled on an angel type, users can sign up for shifts of that type even before being marked as arrived.

This is useful for teams that want to let trusted members commit to shifts before the event starts, while keeping the arrival requirement in place for other angel types.

Fixes #579