### PR TITLE
fix(test): avoid serializing Faker Generator in unique cache

### DIFF
--- a/db/factories/User/ContactFactory.php
+++ b/db/factories/User/ContactFactory.php
@@ -18,7 +18,7 @@ class ContactFactory extends Factory
         return [
             'user_id' => User::factory(),
             'dect'   => $this->faker->optional()->numberBetween(1000, 9999),
-            'email'  => $this->faker->unique()->optional()->safeEmail(),
+            'email'  => $this->faker->optional() ? $this->faker->unique()->safeEmail() : null,
             'mobile' => $this->faker->optional(.2)->phoneNumber(),
         ];
     }


### PR DESCRIPTION
Fixes a memory leak in the test suite caused by chaining `unique()->optional()` in ContactFactory. This pattern causes Faker's UniqueGenerator to serialize the entire Generator object for each unique value, which blows up memory usage.

Splitting into separate calls (`$faker->optional() ? $faker->unique()->safeEmail() : null`) means only the resulting string gets serialized.

Before: ShiftsControllerTest used 2.4GB and took 12-14s, full suite crashed at 1G limit.
After: ShiftsControllerTest uses 44MB and takes 2.4s, full suite runs fine with 244MB peak.

This is arguably a bug in Faker itself - will check if it's been addressed upstream.