### PR TITLE
feat(profile): add shift filter by state

### DIFF
--- a/includes/controller/users_controller.php
+++ b/includes/controller/users_controller.php
@@ -159,6 +159,11 @@ function user_controller()
         }
     }
 
+    $shift_filter = $request->input('shift_filter', '');
+    if (!in_array($shift_filter, ['upcoming', 'running', 'completed'])) {
+        $shift_filter = '';
+    }
+
     $shifts = Shifts_by_user($user_source->id, true);
     foreach ($shifts as $shift) {
         // TODO: Move queries to model
@@ -232,6 +237,7 @@ function user_controller()
                 || $is_ifsg_supporter
                 || auth()->can('user.drive.edit')
                 || $is_drive_supporter,
+            $shift_filter,
         ),
     ];
 }

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -496,16 +496,32 @@ function User_view_myshifts(
         foreach ($myshifts_table as $i => &$shift) {
             $before = $myshifts_table[$i - 1] ?? null;
             $after = $myshifts_table[$i + 1] ?? null;
+            $now = Carbon::now();
+
+            // Determine shift state for filtering
+            $stateClass = '';
+            if (isset($shift['start']) && isset($shift['end'])) {
+                if ($now < $shift['start']) {
+                    $stateClass = 'shift-state-upcoming';
+                } elseif ($now > $shift['end']) {
+                    $stateClass = 'shift-state-completed';
+                } else {
+                    $stateClass = 'shift-state-running';
+                }
+            }
+
             if ($shift['freeloaded']) {
-                $shift['row-class'] = 'border border-danger border-2';
-            } elseif (Carbon::now() > $shift['start'] && Carbon::now() < $shift['end']) {
-                $shift['row-class'] = 'border border-info border-2';
-            } elseif ($after && Carbon::now() > $shift['end'] && Carbon::now() < $after['start']) {
-                $shift['row-class'] = 'border-bottom border-info';
-            } elseif (!$before && Carbon::now() < $shift['start']) {
-                $shift['row-class'] = 'border-top-info';
-            } elseif (!$after && Carbon::now() > $shift['end']) {
-                $shift['row-class'] = 'border-bottom border-info';
+                $shift['row-class'] = 'border border-danger border-2 ' . $stateClass;
+            } elseif ($now > $shift['start'] && $now < $shift['end']) {
+                $shift['row-class'] = 'border border-info border-2 ' . $stateClass;
+            } elseif ($after && $now > $shift['end'] && $now < $after['start']) {
+                $shift['row-class'] = 'border-bottom border-info ' . $stateClass;
+            } elseif (!$before && $now < $shift['start']) {
+                $shift['row-class'] = 'border-top-info ' . $stateClass;
+            } elseif (!$after && $now > $shift['end']) {
+                $shift['row-class'] = 'border-bottom border-info ' . $stateClass;
+            } else {
+                $shift['row-class'] = $stateClass;
             }
         }
         if ($show_sum) {
@@ -664,7 +680,17 @@ function User_view(
             $admin_user_worklog_privilege,
         );
         if (count($my_shifts) > 0) {
-            $myshifts_table = div('', table([
+            $shift_filter_buttons = '<div class="btn-group mb-2" role="group" aria-label="' . __('profile.shifts.filter') . '">'
+                . '<button type="button" class="btn btn-outline-primary btn-sm active" data-filter="all">'
+                . __('general.all') . '</button>'
+                . '<button type="button" class="btn btn-outline-success btn-sm" data-filter="upcoming">'
+                . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</button>'
+                . '<button type="button" class="btn btn-outline-info btn-sm" data-filter="running">'
+                . icon('play-circle') . ' ' . __('profile.shifts.running') . '</button>'
+                . '<button type="button" class="btn btn-outline-secondary btn-sm" data-filter="completed">'
+                . icon('calendar-check') . ' ' . __('profile.shifts.completed') . '</button>'
+                . '</div>';
+            $shifts_table_html = table([
                 'date' => __('Day & Time'),
                 'duration' => __('Duration'),
                 'hints' => '',
@@ -672,7 +698,8 @@ function User_view(
                 'shift_info' => __('Name & Workmates'),
                 'comment' => __('worklog.description'),
                 'actions' => __('general.actions'),
-            ], $my_shifts));
+            ], $my_shifts);
+            $myshifts_table = div('', $shift_filter_buttons . '<div id="shifts-table-container">' . $shifts_table_html . '</div>');
         } elseif ($user_source->state->force_active && config('enable_force_active')) {
             $myshifts_table = success(
                 ($its_me ? __('You have done enough.') : (__('%s has done enough.', [$user_source->name]))),

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -716,7 +716,7 @@ function User_view(
                 . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</a>'
                 . '<a href="' . $filter_url_running . '" class="btn btn-outline-info btn-sm' . ($shift_filter === 'running' ? ' active' : '') . '" data-filter="running">'
                 . icon('play-circle') . ' ' . __('profile.shifts.running') . '</a>'
-                . '<a href="' . $filter_url_completed . '" class="btn btn-outline-secondary btn-sm' . ($shift_filter === 'completed' ? ' active' : '') . '" data-filter="completed">'
+                . '<a href="' . $filter_url_completed . '" class="btn btn-outline-dark btn-sm' . ($shift_filter === 'completed' ? ' active' : '') . '" data-filter="completed">'
                 . icon('calendar-check') . ' ' . __('profile.shifts.completed') . '</a>'
                 . '</div>';
             $shifts_table_html = table([

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -682,7 +682,7 @@ function User_view(
         if (count($my_shifts) > 0) {
             $shift_filter_buttons = '<div class="btn-group mb-2" role="group" aria-label="' . __('profile.shifts.filter') . '">'
                 . '<button type="button" class="btn btn-outline-primary btn-sm active" data-filter="all">'
-                . __('general.all') . '</button>'
+                . __('form.all') . '</button>'
                 . '<button type="button" class="btn btn-outline-success btn-sm" data-filter="upcoming">'
                 . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</button>'
                 . '<button type="button" class="btn btn-outline-info btn-sm" data-filter="running">'

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -522,22 +522,20 @@ function User_view_myshifts(
             $before = $myshifts_table[$i - 1] ?? null;
             $after = $myshifts_table[$i + 1] ?? null;
 
-            // Use stored shift_state for CSS class (for JS progressive enhancement)
-            $stateClass = isset($shift['shift_state']) ? 'shift-state-' . $shift['shift_state'] : '';
-
+            $shift['row-class'] = '';
             if ($shift['freeloaded']) {
-                $shift['row-class'] = 'border border-danger border-2 ' . $stateClass;
+                $shift['row-class'] = 'border border-danger border-2';
             } elseif ($shift['shift_state'] === 'running') {
-                $shift['row-class'] = 'border border-info border-2 ' . $stateClass;
+                $shift['row-class'] = 'border border-info border-2';
             } elseif ($after && $shift['shift_state'] === 'completed' && ($after['shift_state'] ?? '') === 'upcoming') {
-                $shift['row-class'] = 'border-bottom border-info ' . $stateClass;
+                $shift['row-class'] = 'border-bottom border-info';
             } elseif (!$before && $shift['shift_state'] === 'upcoming') {
-                $shift['row-class'] = 'border-top-info ' . $stateClass;
+                $shift['row-class'] = 'border-top-info';
             } elseif (!$after && $shift['shift_state'] === 'completed') {
-                $shift['row-class'] = 'border-bottom border-info ' . $stateClass;
-            } else {
-                $shift['row-class'] = $stateClass;
+                $shift['row-class'] = 'border-bottom border-info';
             }
+            // Use stored shift_state for CSS class (for JS progressive enhancement)
+            $shift['row-class'] .= $shift['shift_state'] ? ' shift-state-' . $shift['shift_state'] : '';
         }
         if ($show_sum) {
             $myshifts_table[] = [
@@ -709,32 +707,28 @@ function User_view(
         $filter_url_completed = url('/users', array_merge($filter_base_params, ['shift_filter' => 'completed']));
 
         $shift_filter_buttons = '<div class="btn-group mb-2" role="group" aria-label="' . __('profile.shifts.filter') . '" id="shift-filter-buttons">'
-            . '<a href="' . $filter_url_all . '" class="btn btn-outline-primary btn-sm' . ($shift_filter === '' ? ' active' : '') . '" data-filter="all">'
-            . __('form.all') . '</a>'
-            . '<a href="' . $filter_url_upcoming . '" class="btn btn-outline-success btn-sm' . ($shift_filter === 'upcoming' ? ' active' : '') . '" data-filter="upcoming">'
-            . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</a>'
-            . '<a href="' . $filter_url_running . '" class="btn btn-outline-info btn-sm' . ($shift_filter === 'running' ? ' active' : '') . '" data-filter="running">'
-            . icon('play-circle') . ' ' . __('profile.shifts.running') . '</a>'
-            . '<a href="' . $filter_url_completed . '" class="btn btn-outline-' . (theme_type() == 'dark' ? 'light' : 'dark') . ' btn-sm' . ($shift_filter === 'completed' ? ' active' : '') . '" data-filter="completed">'
-            . icon('calendar-check') . ' ' . __('profile.shifts.completed') . '</a>'
+            . button($filter_url_all, __('form.all'), 'btn-outline-primary btn-sm' . (!$shift_filter ? ' active' : ''), '', '', false, ['filter' => 'all'])
+            . button($filter_url_upcoming, icon('calendar-plus') . ' ' . __('profile.shifts.upcoming'), 'btn-outline-success btn-sm' . ($shift_filter === 'upcoming' ? ' active' : ''), '', '', false, ['filter' => 'upcoming'])
+            . button($filter_url_running, icon('play-circle') . ' ' . __('profile.shifts.running'), 'btn-outline-info btn-sm' . ($shift_filter === 'running' ? ' active' : ''), '', '', false, ['filter' => 'running'])
+            . button($filter_url_completed, icon('calendar-check') . ' ' . __('profile.shifts.completed'), 'btn-outline-' . (theme_type() == 'dark' ? 'light' : 'dark') . ' btn-sm' . ($shift_filter === 'completed' ? ' active' : ''), '', '', false, ['filter' => 'completed'])
             . '</div>';
-        $shifts_table_html = table([
-            'date' => __('Day & Time'),
-            'duration' => __('Duration'),
-            'hints' => '',
-            'location' => __('Location'),
-            'shift_info' => __('Name & Workmates'),
-            'comment' => __('worklog.description'),
-            'actions' => __('general.actions'),
-        ], $my_shifts);
         if (count($my_shifts) > 0) {
-            $myshifts_table =  $shift_filter_buttons . '<div id="shifts-table-container">' . $shifts_table_html . '</div>';
+            $shifts_table_html = table([
+                'date' => __('Day & Time'),
+                'duration' => __('Duration'),
+                'hints' => '',
+                'location' => __('Location'),
+                'shift_info' => __('Name & Workmates'),
+                'comment' => __('worklog.description'),
+                'actions' => __('general.actions'),
+            ], $my_shifts);
+            $myshifts_table = $shift_filter_buttons . '<div id="shifts-table-container">' . $shifts_table_html . '</div>';
         } elseif ($user_source->state->force_active && config('enable_force_active')) {
-            $myshifts_table = success(
+            $myshifts_table = ($its_me ? $shift_filter_buttons : '') . success(
                 ($its_me ? __('You have done enough.') : (__('%s has done enough.', [$user_source->name]))),
                 true
             );
-        } elseif (str::contains(request()->getRequestUri(), 'shift_filter')) {
+        } elseif ($shift_filter) {
             $myshifts_table = $shift_filter_buttons;
         }
     }
@@ -874,7 +868,6 @@ function User_view(
                 $admin_user_privilege ? User_oauth_render($user_source) : '',
             ]),
             ($its_me || $admin_user_privilege) ? '<h2>' . $my_shifts_title . '</h2>' : '',
-
             $myshifts_table,
             ($its_me && $nightShiftsConfig['enabled'] && $goodie_enabled) ? info(
                 icon('moon-stars')

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -697,43 +697,45 @@ function User_view(
             $admin_user_worklog_privilege,
             $shift_filter,
         );
+        // Build filter URLs, preserving user_id if viewing another user
+        $filter_base_params = ['action' => 'view'];
+        if (!$its_me) {
+            $filter_base_params['user_id'] = $user_source->id;
+        }
+
+        $filter_url_all = url('/users', $filter_base_params);
+        $filter_url_upcoming = url('/users', array_merge($filter_base_params, ['shift_filter' => 'upcoming']));
+        $filter_url_running = url('/users', array_merge($filter_base_params, ['shift_filter' => 'running']));
+        $filter_url_completed = url('/users', array_merge($filter_base_params, ['shift_filter' => 'completed']));
+
+        $shift_filter_buttons = '<div class="btn-group mb-2" role="group" aria-label="' . __('profile.shifts.filter') . '" id="shift-filter-buttons">'
+            . '<a href="' . $filter_url_all . '" class="btn btn-outline-primary btn-sm' . ($shift_filter === '' ? ' active' : '') . '" data-filter="all">'
+            . __('form.all') . '</a>'
+            . '<a href="' . $filter_url_upcoming . '" class="btn btn-outline-success btn-sm' . ($shift_filter === 'upcoming' ? ' active' : '') . '" data-filter="upcoming">'
+            . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</a>'
+            . '<a href="' . $filter_url_running . '" class="btn btn-outline-info btn-sm' . ($shift_filter === 'running' ? ' active' : '') . '" data-filter="running">'
+            . icon('play-circle') . ' ' . __('profile.shifts.running') . '</a>'
+            . '<a href="' . $filter_url_completed . '" class="btn btn-outline-' . (theme_type() == 'dark' ? 'light' : 'dark') . ' btn-sm' . ($shift_filter === 'completed' ? ' active' : '') . '" data-filter="completed">'
+            . icon('calendar-check') . ' ' . __('profile.shifts.completed') . '</a>'
+            . '</div>';
+        $shifts_table_html = table([
+            'date' => __('Day & Time'),
+            'duration' => __('Duration'),
+            'hints' => '',
+            'location' => __('Location'),
+            'shift_info' => __('Name & Workmates'),
+            'comment' => __('worklog.description'),
+            'actions' => __('general.actions'),
+        ], $my_shifts);
         if (count($my_shifts) > 0) {
-            // Build filter URLs, preserving user_id if viewing another user
-            $filter_base_params = ['action' => 'view'];
-            if (!$its_me) {
-                $filter_base_params['user_id'] = $user_source->id;
-            }
-
-            $filter_url_all = url('/users', $filter_base_params);
-            $filter_url_upcoming = url('/users', array_merge($filter_base_params, ['shift_filter' => 'upcoming']));
-            $filter_url_running = url('/users', array_merge($filter_base_params, ['shift_filter' => 'running']));
-            $filter_url_completed = url('/users', array_merge($filter_base_params, ['shift_filter' => 'completed']));
-
-            $shift_filter_buttons = '<div class="btn-group mb-2" role="group" aria-label="' . __('profile.shifts.filter') . '" id="shift-filter-buttons">'
-                . '<a href="' . $filter_url_all . '" class="btn btn-outline-primary btn-sm' . ($shift_filter === '' ? ' active' : '') . '" data-filter="all">'
-                . __('form.all') . '</a>'
-                . '<a href="' . $filter_url_upcoming . '" class="btn btn-outline-success btn-sm' . ($shift_filter === 'upcoming' ? ' active' : '') . '" data-filter="upcoming">'
-                . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</a>'
-                . '<a href="' . $filter_url_running . '" class="btn btn-outline-info btn-sm' . ($shift_filter === 'running' ? ' active' : '') . '" data-filter="running">'
-                . icon('play-circle') . ' ' . __('profile.shifts.running') . '</a>'
-                . '<a href="' . $filter_url_completed . '" class="btn btn-outline-dark btn-sm' . ($shift_filter === 'completed' ? ' active' : '') . '" data-filter="completed">'
-                . icon('calendar-check') . ' ' . __('profile.shifts.completed') . '</a>'
-                . '</div>';
-            $shifts_table_html = table([
-                'date' => __('Day & Time'),
-                'duration' => __('Duration'),
-                'hints' => '',
-                'location' => __('Location'),
-                'shift_info' => __('Name & Workmates'),
-                'comment' => __('worklog.description'),
-                'actions' => __('general.actions'),
-            ], $my_shifts);
-            $myshifts_table = div('', $shift_filter_buttons . '<div id="shifts-table-container">' . $shifts_table_html . '</div>');
+            $myshifts_table =  $shift_filter_buttons . '<div id="shifts-table-container">' . $shifts_table_html . '</div>';
         } elseif ($user_source->state->force_active && config('enable_force_active')) {
             $myshifts_table = success(
                 ($its_me ? __('You have done enough.') : (__('%s has done enough.', [$user_source->name]))),
                 true
             );
+        } elseif (str::contains(request()->getRequestUri(), 'shift_filter')) {
+            $myshifts_table = $shift_filter_buttons;
         }
     }
 
@@ -872,6 +874,7 @@ function User_view(
                 $admin_user_privilege ? User_oauth_render($user_source) : '',
             ]),
             ($its_me || $admin_user_privilege) ? '<h2>' . $my_shifts_title . '</h2>' : '',
+
             $myshifts_table,
             ($its_me && $nightShiftsConfig['enabled'] && $goodie_enabled) ? info(
                 icon('moon-stars')

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -448,7 +448,7 @@ function User_view_myshift(Shift $shift, $user_source, $its_me, $supporter)
  * @param bool $goodie_admin
  * @param Worklog[]|Collection $user_worklogs
  * @param bool $admin_user_worklog_privilege
- * @param Collection|int[] $supported_angeltypes
+ * @param string $shift_filter Filter: '', 'upcoming', 'running', 'completed'
  *
  * @return array
  */
@@ -460,6 +460,7 @@ function User_view_myshifts(
     $goodie_admin,
     $user_worklogs,
     $admin_user_worklog_privilege,
+    $shift_filter = '',
 ) {
     $goodie = GoodieType::from(config('goodie_type'));
     $goodie_enabled = $goodie !== GoodieType::None;
@@ -471,6 +472,7 @@ function User_view_myshifts(
 
     $myshifts_table = [];
     $timeSum = 0;
+    $now = Carbon::now();
     foreach ($shifts as $shift) {
         $key = $shift->start->timestamp . '-shift-' . $shift->shift_entry_id . $shift->id;
         $supporter = $supported_angeltypes->contains($shift->angel_type_id);
@@ -478,15 +480,38 @@ function User_view_myshifts(
             $show_sum = false;
             continue;
         }
+
+        // Determine shift state for server-side filtering
+        $shift_state = '';
+        if ($now < $shift->start) {
+            $shift_state = 'upcoming';
+        } elseif ($now > $shift->end) {
+            $shift_state = 'completed';
+        } else {
+            $shift_state = 'running';
+        }
+
+        // Apply server-side filter if set
+        if ($shift_filter !== '' && $shift_state !== $shift_filter) {
+            continue;
+        }
+
         $myshifts_table[$key] = User_view_myshift($shift, $user_source, $its_me, $supporter);
+        $myshifts_table[$key]['shift_state'] = $shift_state;
         if (!$shift->freeloaded_by) {
             $timeSum += ($shift->end->timestamp - $shift->start->timestamp);
         }
     }
 
     foreach ($user_worklogs as $worklog) {
+        // Worklogs are always in the past, so they're always "completed"
+        if ($shift_filter !== '' && $shift_filter !== 'completed') {
+            continue;
+        }
+
         $key = $worklog->worked_at->timestamp . '-worklog-' . $worklog->id;
         $myshifts_table[$key] = User_view_worklog($worklog, $admin_user_worklog_privilege, $its_me);
+        $myshifts_table[$key]['shift_state'] = 'completed';
         $timeSum += $worklog->hours * 3600;
     }
 
@@ -496,29 +521,19 @@ function User_view_myshifts(
         foreach ($myshifts_table as $i => &$shift) {
             $before = $myshifts_table[$i - 1] ?? null;
             $after = $myshifts_table[$i + 1] ?? null;
-            $now = Carbon::now();
 
-            // Determine shift state for filtering
-            $stateClass = '';
-            if (isset($shift['start']) && isset($shift['end'])) {
-                if ($now < $shift['start']) {
-                    $stateClass = 'shift-state-upcoming';
-                } elseif ($now > $shift['end']) {
-                    $stateClass = 'shift-state-completed';
-                } else {
-                    $stateClass = 'shift-state-running';
-                }
-            }
+            // Use stored shift_state for CSS class (for JS progressive enhancement)
+            $stateClass = isset($shift['shift_state']) ? 'shift-state-' . $shift['shift_state'] : '';
 
             if ($shift['freeloaded']) {
                 $shift['row-class'] = 'border border-danger border-2 ' . $stateClass;
-            } elseif ($now > $shift['start'] && $now < $shift['end']) {
+            } elseif ($shift['shift_state'] === 'running') {
                 $shift['row-class'] = 'border border-info border-2 ' . $stateClass;
-            } elseif ($after && $now > $shift['end'] && $now < $after['start']) {
+            } elseif ($after && $shift['shift_state'] === 'completed' && ($after['shift_state'] ?? '') === 'upcoming') {
                 $shift['row-class'] = 'border-bottom border-info ' . $stateClass;
-            } elseif (!$before && $now < $shift['start']) {
+            } elseif (!$before && $shift['shift_state'] === 'upcoming') {
                 $shift['row-class'] = 'border-top-info ' . $stateClass;
-            } elseif (!$after && $now > $shift['end']) {
+            } elseif (!$after && $shift['shift_state'] === 'completed') {
                 $shift['row-class'] = 'border-bottom border-info ' . $stateClass;
             } else {
                 $shift['row-class'] = $stateClass;
@@ -633,6 +648,7 @@ function User_view_worklog(Worklog $worklog, $admin_user_worklog_privilege, $its
  * @param bool $admin_user_worklog_privilege
  * @param Worklog[]|Collection $user_worklogs
  * @param bool $admin_certificates
+ * @param string $shift_filter Filter: '', 'upcoming', 'running', 'completed'
  *
  * @return string
  */
@@ -648,7 +664,8 @@ function User_view(
     $goodie_admin,
     $admin_user_worklog_privilege,
     $user_worklogs,
-    $admin_certificates
+    $admin_certificates,
+    $shift_filter = ''
 ) {
     $goodie = GoodieType::from(config('goodie_type'));
     $goodie_enabled = $goodie !== GoodieType::None;
@@ -678,17 +695,29 @@ function User_view(
             $goodie_admin,
             $user_worklogs,
             $admin_user_worklog_privilege,
+            $shift_filter,
         );
         if (count($my_shifts) > 0) {
-            $shift_filter_buttons = '<div class="btn-group mb-2" role="group" aria-label="' . __('profile.shifts.filter') . '">'
-                . '<button type="button" class="btn btn-outline-primary btn-sm active" data-filter="all">'
-                . __('form.all') . '</button>'
-                . '<button type="button" class="btn btn-outline-success btn-sm" data-filter="upcoming">'
-                . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</button>'
-                . '<button type="button" class="btn btn-outline-info btn-sm" data-filter="running">'
-                . icon('play-circle') . ' ' . __('profile.shifts.running') . '</button>'
-                . '<button type="button" class="btn btn-outline-secondary btn-sm" data-filter="completed">'
-                . icon('calendar-check') . ' ' . __('profile.shifts.completed') . '</button>'
+            // Build filter URLs, preserving user_id if viewing another user
+            $filter_base_params = ['action' => 'view'];
+            if (!$its_me) {
+                $filter_base_params['user_id'] = $user_source->id;
+            }
+
+            $filter_url_all = url('/users', $filter_base_params);
+            $filter_url_upcoming = url('/users', array_merge($filter_base_params, ['shift_filter' => 'upcoming']));
+            $filter_url_running = url('/users', array_merge($filter_base_params, ['shift_filter' => 'running']));
+            $filter_url_completed = url('/users', array_merge($filter_base_params, ['shift_filter' => 'completed']));
+
+            $shift_filter_buttons = '<div class="btn-group mb-2" role="group" aria-label="' . __('profile.shifts.filter') . '" id="shift-filter-buttons">'
+                . '<a href="' . $filter_url_all . '" class="btn btn-outline-primary btn-sm' . ($shift_filter === '' ? ' active' : '') . '" data-filter="all">'
+                . __('form.all') . '</a>'
+                . '<a href="' . $filter_url_upcoming . '" class="btn btn-outline-success btn-sm' . ($shift_filter === 'upcoming' ? ' active' : '') . '" data-filter="upcoming">'
+                . icon('calendar-plus') . ' ' . __('profile.shifts.upcoming') . '</a>'
+                . '<a href="' . $filter_url_running . '" class="btn btn-outline-info btn-sm' . ($shift_filter === 'running' ? ' active' : '') . '" data-filter="running">'
+                . icon('play-circle') . ' ' . __('profile.shifts.running') . '</a>'
+                . '<a href="' . $filter_url_completed . '" class="btn btn-outline-secondary btn-sm' . ($shift_filter === 'completed' ? ' active' : '') . '" data-filter="completed">'
+                . icon('calendar-check') . ' ' . __('profile.shifts.completed') . '</a>'
                 . '</div>';
             $shifts_table_html = table([
                 'date' => __('Day & Time'),

--- a/resources/assets/js/shift-filter.js
+++ b/resources/assets/js/shift-filter.js
@@ -3,7 +3,7 @@ import { ready } from './ready';
 /**
  * Progressive enhancement for shift filtering on user profile.
  * Server-side filtering works via links; this JS enhances by filtering client-side
- * without a page reload.
+ * without a page reload - but only when all data is present in the DOM.
  */
 ready(() => {
   const filterButtonsContainer = document.getElementById('shift-filter-buttons');
@@ -20,8 +20,19 @@ ready(() => {
     return;
   }
 
+  // Check if page was loaded with server-side filtering already applied.
+  // If so, not all rows are in the DOM, so we can't filter client-side.
+  const currentUrl = new URL(window.location.href);
+  const serverFiltered = currentUrl.searchParams.has('shift_filter');
+
   filterLinks.forEach((link) => {
     link.addEventListener('click', (e) => {
+      // If server already filtered the data, we need a full page load to get all rows.
+      // Only enhance to client-side filtering when viewing unfiltered (all) data.
+      if (serverFiltered) {
+        return; // Let the link navigate normally
+      }
+
       e.preventDefault();
 
       const filter = link.dataset.filter;

--- a/resources/assets/js/shift-filter.js
+++ b/resources/assets/js/shift-filter.js
@@ -1,27 +1,40 @@
 import { ready } from './ready';
 
+/**
+ * Progressive enhancement for shift filtering on user profile.
+ * Server-side filtering works via links; this JS enhances by filtering client-side
+ * without a page reload.
+ */
 ready(() => {
-  const filterButtons = document.querySelectorAll('[data-filter]');
+  const filterButtonsContainer = document.getElementById('shift-filter-buttons');
   const shiftsContainer = document.getElementById('shifts-table-container');
 
-  if (!filterButtons.length || !shiftsContainer) {
+  if (!filterButtonsContainer || !shiftsContainer) {
     return;
   }
 
+  const filterLinks = filterButtonsContainer.querySelectorAll('a[data-filter]');
   const table = shiftsContainer.querySelector('table');
-  if (!table) {
+
+  if (!filterLinks.length || !table) {
     return;
   }
 
-  filterButtons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const filter = button.dataset.filter;
+  filterLinks.forEach((link) => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+
+      const filter = link.dataset.filter;
+      const newUrl = link.href;
+
+      // Update URL without page reload
+      history.replaceState(null, '', newUrl);
 
       // Update active button state
-      filterButtons.forEach((btn) => btn.classList.remove('active'));
-      button.classList.add('active');
+      filterLinks.forEach((l) => l.classList.remove('active'));
+      link.classList.add('active');
 
-      // Filter rows
+      // Filter rows client-side
       const rows = table.querySelectorAll('tbody tr');
       rows.forEach((row) => {
         if (filter === 'all') {

--- a/resources/assets/js/shift-filter.js
+++ b/resources/assets/js/shift-filter.js
@@ -1,0 +1,40 @@
+import { ready } from './ready';
+
+ready(() => {
+  const filterButtons = document.querySelectorAll('[data-filter]');
+  const shiftsContainer = document.getElementById('shifts-table-container');
+
+  if (!filterButtons.length || !shiftsContainer) {
+    return;
+  }
+
+  const table = shiftsContainer.querySelector('table');
+  if (!table) {
+    return;
+  }
+
+  filterButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const filter = button.dataset.filter;
+
+      // Update active button state
+      filterButtons.forEach((btn) => btn.classList.remove('active'));
+      button.classList.add('active');
+
+      // Filter rows
+      const rows = table.querySelectorAll('tbody tr');
+      rows.forEach((row) => {
+        if (filter === 'all') {
+          row.style.display = '';
+        } else {
+          const stateClass = `shift-state-${filter}`;
+          if (row.classList.contains(stateClass)) {
+            row.style.display = '';
+          } else {
+            row.style.display = 'none';
+          }
+        }
+      });
+    });
+  });
+});

--- a/resources/assets/js/shift-filter.js
+++ b/resources/assets/js/shift-filter.js
@@ -16,7 +16,7 @@ ready(() => {
   const filterLinks = filterButtonsContainer.querySelectorAll('a[data-filter]');
   const table = shiftsContainer.querySelector('table');
 
-  if (filterLinks.length <= 0|| !table) {
+  if (filterLinks.length <= 0 || !table) {
     return;
   }
 

--- a/resources/assets/js/shift-filter.js
+++ b/resources/assets/js/shift-filter.js
@@ -16,7 +16,7 @@ ready(() => {
   const filterLinks = filterButtonsContainer.querySelectorAll('a[data-filter]');
   const table = shiftsContainer.querySelector('table');
 
-  if (!filterLinks.length || !table) {
+  if (filterLinks.length <= 0|| !table) {
     return;
   }
 
@@ -42,6 +42,7 @@ ready(() => {
       history.replaceState(null, '', newUrl);
 
       // Update active button state
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: ...
       filterLinks.forEach((l) => l.classList.remove('active'));
       link.classList.add('active');
 

--- a/resources/assets/js/vendor.js
+++ b/resources/assets/js/vendor.js
@@ -6,3 +6,4 @@ import './dashboard';
 import './design';
 import './voucher';
 import './table-responsive-sticky-header';
+import './shift-filter';

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1596,6 +1596,18 @@ msgstr "Du kannst deine Engeltypen <a href=\"%s\">auf der Engeltypen-Seite</a> v
 msgid "profile.my_shifts"
 msgstr "Meine Schichten"
 
+msgid "profile.shifts.filter"
+msgstr "Schichten filtern"
+
+msgid "profile.shifts.upcoming"
+msgstr "Kommende"
+
+msgid "profile.shifts.running"
+msgstr "Laufend"
+
+msgid "profile.shifts.completed"
+msgstr "Abgeschlossen"
+
 msgid "settings.profile"
 msgstr "Profil"
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -408,6 +408,18 @@ msgstr "You can manage your angel types <a href=\"%s\">here</a>."
 msgid "profile.my_shifts"
 msgstr "My shifts"
 
+msgid "profile.shifts.filter"
+msgstr "Filter shifts"
+
+msgid "profile.shifts.upcoming"
+msgstr "Upcoming"
+
+msgid "profile.shifts.running"
+msgstr "Running"
+
+msgid "profile.shifts.completed"
+msgstr "Completed"
+
 msgid "settings.profile"
 msgstr "Profile"
 


### PR DESCRIPTION
Users can now filter their shifts by state (upcoming, running, completed) on the profile page. Filter buttons are displayed above the shifts table.

Closes #399