### PR TITLE
Simplify EventConfig model loading

### DIFF
--- a/src/Config/ConfigServiceProvider.php
+++ b/src/Config/ConfigServiceProvider.php
@@ -23,7 +23,7 @@ class ConfigServiceProvider extends ServiceProvider
 {
     protected array $configFiles = ['app.php', 'config.default.php', 'config.local.php', 'config.php'];
 
-    // Remember to update ConfigServiceProviderTest, config.default.php, and README.md
+    // Remember to update ConfigServiceProviderTest
     protected array $configVarsToPruneNulls = [
         'themes',
         'tshirt_sizes',
@@ -203,6 +203,7 @@ class ConfigServiceProvider extends ServiceProvider
                 $value = match ($options['type'] ?? null) {
                     'datetime-local' => $value && !$value instanceof CarbonCarbon
                         ? Carbon::createFromDatetime((string) $value)
+                            ->setTimezone($config['timezone'] ?? 'UTC')
                         : $value,
                     'date' => $value && !$value instanceof CarbonCarbon
                         ? CarbonDay::createFromDay((string) $value)

--- a/src/Helpers/Carbon.php
+++ b/src/Helpers/Carbon.php
@@ -12,10 +12,13 @@ class Carbon extends \Carbon\Carbon
 
     public const DATETIME_FALLBACK = '!Y-m-d H:i';
 
+    public const DATETIME_DATABASE = '!Y-m-d\\TH:i:s.up';
+
     public const DATETIME_FORMATS = [
         self::DATETIME_LOCAL,
         self::DATETIME_FALLBACK,
         self::DEFAULT_TO_STRING_FORMAT,
+        self::DATETIME_DATABASE,
     ];
 
     /**

--- a/src/Models/EventConfig.php
+++ b/src/Models/EventConfig.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Engelsystem\Models;
 
-use DateTimeInterface;
 use Engelsystem\Helpers\Carbon;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -33,62 +32,13 @@ class EventConfig extends BaseModel
     /** @var array Values that are mass assignable */
     protected $fillable = ['name', 'value']; // phpcs:ignore
 
-    /** @var array<string, string> The configuration values that should be cast to native types */
-    protected array $valueCasts = [
-        'buildup_start' => 'datetime_human',
-        'event_start'   => 'datetime_human',
-        'event_end'     => 'datetime_human',
-        'teardown_end'  => 'datetime_human',
-        'last_metrics'  => 'datetime',
-    ];
-
     /** @var bool It could be interesting to know when a value changed the last time */
     public $timestamps = true; // phpcs:ignore
 
-    /**
-     * Value accessor
-     */
-    public function getValueAttribute(mixed $value): mixed
+    public function casts(): array
     {
-        $value = $value ? $this->fromJson($value) : null;
-
-        /** @see \Illuminate\Database\Eloquent\Concerns\HasAttributes::castAttribute */
-        if (!empty($value)) {
-            return match ($this->getValueCast($this->name)) {
-                'datetime_human' => Carbon::make($value),
-                'datetime'       => Carbon::createFromFormat(DateTimeInterface::ATOM, $value),
-                default          => $value,
-            };
-        }
-
-        return $value;
-    }
-
-    /**
-     * Value mutator
-     */
-    public function setValueAttribute(mixed $value): static
-    {
-        if (!empty($value)) {
-            /** @var Carbon $value */
-            $value = match ($this->getValueCast($this->name)) {
-                'datetime_human' => $value->toDateTimeString('minute'),
-                'datetime'       => $value->format(DateTimeInterface::ATOM),
-                default          => $value,
-            };
-        }
-
-        $value = $this->castAttributeAsJson('value', $value);
-        $this->attributes['value'] = $value;
-
-        return $this;
-    }
-
-    /**
-     * Check if the value has to be cast
-     */
-    protected function getValueCast(string $value): ?string
-    {
-        return $this->valueCasts[$value] ?? null;
+        return [
+            'value' => 'array',
+        ];
     }
 }

--- a/tests/Unit/Config/ConfigServiceProviderTest.php
+++ b/tests/Unit/Config/ConfigServiceProviderTest.php
@@ -115,7 +115,7 @@ class ConfigServiceProviderTest extends TestCase
         $conf = $config->get(null);
 
         $this->assertArrayHasKey('timezone', $conf);
-        $this->assertEquals('Test/Testing', $conf['timezone']);
+        $this->assertEquals('Europe/Berlin', $conf['timezone']);
 
         $timezoneData = $conf['config_options']['system']['config']['timezone']['data'] ?? null;
         $this->assertNotEmpty($timezoneData);
@@ -278,7 +278,10 @@ class ConfigServiceProviderTest extends TestCase
         $this->assertTrue($conf['not_set']);
 
         $this->assertArrayHasKey('date_time', $conf);
-        $this->assertInstanceOf(Carbon::class, $conf['date_time']);
+        /** @var Carbon $dateTime */
+        $dateTime = $conf['date_time'];
+        $this->assertInstanceOf(Carbon::class, $dateTime);
+        $this->assertEquals('Europe/Berlin', $dateTime->getTimezone()->getName());
 
         $this->assertArrayHasKey('date', $conf);
         $this->assertInstanceOf(CarbonDay::class, $conf['date']);

--- a/tests/Unit/Config/Stub/app.php
+++ b/tests/Unit/Config/Stub/app.php
@@ -42,7 +42,7 @@ return [
             'config' => [
                 'timezone' => [
                     'data' => [],
-                    'default' => 'Test/Testing',
+                    'default' => 'Europe/Berlin',
                 ],
                 'theme' => [
                     'data' => [],

--- a/tests/Unit/Controllers/Admin/ConfigControllerTest.php
+++ b/tests/Unit/Controllers/Admin/ConfigControllerTest.php
@@ -525,8 +525,8 @@ class ConfigControllerTest extends ControllerTest
             $config = EventConfig::find($field);
             $this->assertNotEmpty($config);
             $value = $config->value;
-            if ($value instanceof Carbon) {
-                $value = $value->format('Y-m-d\TH:i');
+            if (in_array($field, ['buildup_start', 'event_start', 'event_end', 'teardown_end'])) {
+                $value = Carbon::createFromDatetime($value)->format('Y-m-d\TH:i');
             }
             $this->assertEquals($body[$field], $value);
         }

--- a/tests/Unit/Helpers/CarbonTest.php
+++ b/tests/Unit/Helpers/CarbonTest.php
@@ -15,9 +15,13 @@ class CarbonTest extends TestCase
     {
         $format = '!Y-m-d H:i';
         yield '2022-04-16T10:44' => ['2022-04-16T10:44', Carbon::createFromFormat($format, '2022-04-16 10:44')];
-        yield '2022-04-16 10:44' => ['2022-04-16T10:44', Carbon::createFromFormat($format, '2022-04-16 10:44')];
+        yield '2022-04-16 10:44' => ['2022-04-16 10:44', Carbon::createFromFormat($format, '2022-04-16 10:44')];
         yield '2020-12-24T13:37' => ['2020-12-24T13:37', Carbon::createFromFormat($format, '2020-12-24 13:37')];
-        yield '2020-12-24 13:37' => ['2020-12-24T13:37', Carbon::createFromFormat($format, '2020-12-24 13:37')];
+        yield '2020-12-24 13:37' => ['2020-12-24 13:37', Carbon::createFromFormat($format, '2020-12-24 13:37')];
+        yield '2020-12-25T09:34:49.987654Z (Database Zulu time)' => [
+            '2020-12-25T09:34:49.987654Z',
+            Carbon::createFromFormat($format . ':s', '2020-12-25 09:34:49'),
+        ];
     }
 
     public function invalidDates(): Traversable


### PR DESCRIPTION
* Removes Date & DateTime casting from EventConfig model
* Uses the models own array data type to be serialized as json
* Fix Carbon tests :upside_down_face: 