### PR TITLE
Shift creation: Fix indentation & disable modus related fields

### DIFF
--- a/includes/pages/admin_shifts.php
+++ b/includes/pages/admin_shifts.php
@@ -594,7 +594,7 @@ function admin_shifts()
                             false,
                             null,
                             null,
-                            '',
+                            'ms-4',
                             [
                                 'radio-name'  => 'mode',
                                 'radio-value' => 'multi',
@@ -615,7 +615,7 @@ function admin_shifts()
                             false,
                             null,
                             null,
-                            '',
+                            'ms-4',
                             [
                                 'radio-name'  => 'mode',
                                 'radio-value' => 'variable',
@@ -624,7 +624,14 @@ function admin_shifts()
                         form_checkbox(
                             'shift_over_midnight',
                             __('Create a shift over midnight.'),
-                            $shift_over_midnight
+                            $shift_over_midnight,
+                            'checked',
+                            null,
+                            'ms-0 mb-3',
+                            [
+                                'radio-name'  => 'mode',
+                                'radio-value' => 'variable',
+                            ],
                         ),
                     ]),
                     div('col-md-6 col-xl-7', [

--- a/includes/sys_form.php
+++ b/includes/sys_form.php
@@ -83,15 +83,28 @@ function form_datetime(string $name, string $label, $value)
  * @param string $html_id
  * @return string
  */
-function form_checkbox($name, $label, $selected, $value = 'checked', $html_id = null)
-{
+function form_checkbox(
+    $name,
+    $label,
+    $selected,
+    $value = 'checked',
+    $html_id = null,
+    $class = '',
+    array $dataAttributes = [],
+) {
     if (is_null($html_id)) {
         $html_id = $name;
     }
 
+    $add = '';
+    foreach ($dataAttributes as $dataType => $dataValue) {
+        $add .= ' data-' . $dataType . '="' . htmlspecialchars($dataValue) . '"';
+    }
+
     return '<div class="form-check">'
-        . '<input class="form-check-input" type="checkbox" id="' . $html_id . '" '
+        . '<input class="form-check-input ' . $class . '" type="checkbox" id="' . $html_id . '" '
         . 'name="' . htmlspecialchars($name) . '" value="' . $value . '" '
+        . $add
         . ($selected ? ' checked="checked"' : '') . ' /><label class="form-check-label" for="' . $html_id . '">'
         . $label
         . '</label></div>';
@@ -288,10 +301,10 @@ function form_element($label, $input, $for = '', $class = '')
     $class = $class ? ' ' . $class : '';
 
     if (empty($label)) {
-        return '<div class="mb-3' . $class . '">' . $input . '</div>';
+        return '<div class="mb-3 ' . $class . '">' . $input . '</div>';
     }
 
-    return '<div class="mb-3' . $class . '">'
+    return '<div class="mb-3 ' . $class . '">'
         . '<label class="form-label" for="' . $for . '">' . $label . '</label>'
         . $input
         . '</div>';


### PR DESCRIPTION
Indent dependent fields (length, hours, over midnight) & disable over midnight checkbox too when shift change time is not selected

Before:
<img width="788" height="314" alt="Screenshot_20260301_003320" src="https://github.com/user-attachments/assets/e2f79c1b-d090-4453-a386-21aa349ea45e" />

After:
<img width="788" height="314" alt="Screenshot_20260301_003224" src="https://github.com/user-attachments/assets/ca37620e-0bf9-4cf3-8e00-ad803f37f12c" />
