### PR TITLE
Hide build warnings to be fixed by Bootstrap 6

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,12 +96,24 @@ module.exports = {
               sourceMap: true,
               sassOptions: {
                 quietDeps: true,
+                // See https://sass-lang.com/d/[deprecation]
+                silenceDeprecations: [
+                  'import',
+                  'global-builtin',
+                  'legacy-js-api',
+                  'color-functions',
+                  'if-function',
+                  'duplicate-var-flags',
+                ],
               },
             },
           },
         ],
       },
     ],
+  },
+  performance: {
+    hints: false,
   },
   plugins,
   devtool,


### PR DESCRIPTION
* import warnings can only be usably fixed by bootstrap 6 as far as i understand
* the others are annoying and could be fixed before but might need some effort