### PR TITLE
Smaller refactorings & updates in preparation for plugins

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 120
 
-[{.babelrc,package.json}]
+[{.babelrc,package.json,composer.json}]
 indent_size = 2
 
 [docker/**.conf]

--- a/bin/config2docs
+++ b/bin/config2docs
@@ -4,10 +4,8 @@
 declare(strict_types=1);
 
 use Engelsystem\Application;
-use Engelsystem\Config\Config;
-use Engelsystem\Controllers\Admin\ConfigController;
+use Engelsystem\Controllers\Admin\BaseConfigController;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 require_once __DIR__ . '/../includes/application.php';
 
@@ -31,9 +29,19 @@ if (in_array('help', $argv) || in_array('--help', $argv) || in_array('-h', $argv
     exit;
 }
 
-/** @var ConfigController $configController */
-$configController = $app->make(ConfigController::class, ['withAll' => true]);
-$options = $configController->getOptions();
+$configExtractor = new class extends BaseConfigController {
+    public function __construct()
+    {
+        parent::__construct();
+        $this->parseOptions(true, true);
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+};
+$options = $configExtractor->getOptions();
 
 function toTypeValue($value): string
 {

--- a/composer.json
+++ b/composer.json
@@ -1,91 +1,91 @@
 {
-    "name": "engelsystem/engelsystem",
-    "description": "Shift planning system for chaos events",
-    "type": "project",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "msquare",
-            "email": "msquare@notrademark.de"
-        },
-        {
-            "name": "MyIgel",
-            "email": "igor.scheller@igorshp.de"
-        }
-    ],
-    "scripts": {
-        "phpcs": ["phpcs -p --cache"],
-        "phpcbf": ["phpcbf -p"],
-        "phpstan": "phpstan",
-        "phpunit": "php -d memory_limit=-1 vendor/bin/phpunit",
-        "phpunit:coverage": "php -d memory_limit=-1 vendor/bin/phpunit --coverage-text --coverage-html ./public/coverage/"
+  "name": "engelsystem/engelsystem",
+  "description": "Shift planning system for chaos events",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "msquare",
+      "email": "msquare@notrademark.de"
     },
-    "require": {
-        "php": ">=8.2.0",
-        "ext-intl": "*",
-        "ext-json": "*",
-        "ext-libxml": "*",
-        "ext-mbstring": "*",
-        "ext-pdo": "*",
-        "ext-simplexml": "*",
-        "ext-xml": "*",
-        "bacon/bacon-qr-code": "^3.0",
-        "firebase/php-jwt": "^7.0",
-        "gettext/gettext": "^5.7",
-        "gettext/translator": "^1.2",
-        "guzzlehttp/guzzle": "^7.10",
-        "illuminate/container": "^12.50",
-        "illuminate/database": "^12.50",
-        "illuminate/pagination": "^12.50",
-        "illuminate/support": "^12.50",
-        "laravel/serializable-closure": "^2.0",
-        "league/commonmark": "^2.7",
-        "league/oauth2-client": "^2.7",
-        "league/openapi-psr7-validator": "^0.22.0",
-        "nikic/fast-route": "^1.3",
-        "nyholm/psr7": "^1.8",
-        "psr/container": "^2.0",
-        "psr/http-message": "^1.1",
-        "psr/http-server-middleware": "^1.0",
-        "psr/log": "^3.0",
-        "rcrowe/twigbridge": "^0.14",
-        "respect/validation": "^2.4",
-        "symfony/http-foundation": "^7.3",
-        "symfony/mailer": "^7.3",
-        "symfony/psr-http-message-bridge": "^7.3",
-        "twig/twig": "^3.23",
-        "vlucas/phpdotenv": "^5.6"
-    },
-    "require-dev": {
-        "dms/phpunit-arraysubset-asserts": "^0.5.0",
-        "fakerphp/faker": "^1.24",
-        "fig/log-test": "^1.2",
-        "filp/whoops": "^2.18",
-        "phpcompatibility/php-compatibility": "^10.0.0-alpha2",
-        "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^9.6",
-        "slevomat/coding-standard": "^8.25",
-        "squizlabs/php_codesniffer": "^4.0",
-        "symfony/var-dumper": "^7.3"
-    },
-    "autoload": {
-        "psr-4": {
-            "Engelsystem\\": "src/"
-        },
-        "classmap": ["db/migrations"],
-        "files": ["src/helpers.php"]
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Database\\Factories\\Engelsystem\\Models\\": "db/factories/",
-            "Engelsystem\\Test\\": "tests/"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        },
-        "sort-packages": true
+    {
+      "name": "MyIgel",
+      "email": "igor.scheller@igorshp.de"
     }
+  ],
+  "scripts": {
+    "phpcs": ["phpcs -p --cache"],
+    "phpcbf": ["phpcbf -p"],
+    "phpstan": "phpstan",
+    "phpunit": "php -d memory_limit=-1 vendor/bin/phpunit",
+    "phpunit:coverage": "php -d memory_limit=-1 vendor/bin/phpunit --coverage-text --coverage-html ./public/coverage/"
+  },
+  "require": {
+    "php": ">=8.2.0",
+    "ext-intl": "*",
+    "ext-json": "*",
+    "ext-libxml": "*",
+    "ext-mbstring": "*",
+    "ext-pdo": "*",
+    "ext-simplexml": "*",
+    "ext-xml": "*",
+    "bacon/bacon-qr-code": "^3.0",
+    "firebase/php-jwt": "^7.0",
+    "gettext/gettext": "^5.7",
+    "gettext/translator": "^1.2",
+    "guzzlehttp/guzzle": "^7.10",
+    "illuminate/container": "^12.50",
+    "illuminate/database": "^12.50",
+    "illuminate/pagination": "^12.50",
+    "illuminate/support": "^12.50",
+    "laravel/serializable-closure": "^2.0",
+    "league/commonmark": "^2.7",
+    "league/oauth2-client": "^2.7",
+    "league/openapi-psr7-validator": "^0.22.0",
+    "nikic/fast-route": "^1.3",
+    "nyholm/psr7": "^1.8",
+    "psr/container": "^2.0",
+    "psr/http-message": "^1.1",
+    "psr/http-server-middleware": "^1.0",
+    "psr/log": "^3.0",
+    "rcrowe/twigbridge": "^0.14",
+    "respect/validation": "^2.4",
+    "symfony/http-foundation": "^7.3",
+    "symfony/mailer": "^7.3",
+    "symfony/psr-http-message-bridge": "^7.3",
+    "twig/twig": "^3.23",
+    "vlucas/phpdotenv": "^5.6"
+  },
+  "require-dev": {
+    "dms/phpunit-arraysubset-asserts": "^0.5.0",
+    "fakerphp/faker": "^1.24",
+    "fig/log-test": "^1.2",
+    "filp/whoops": "^2.18",
+    "phpcompatibility/php-compatibility": "^10.0.0-alpha2",
+    "phpstan/phpstan": "^2.1",
+    "phpunit/phpunit": "^9.6",
+    "slevomat/coding-standard": "^8.25",
+    "squizlabs/php_codesniffer": "^4.0",
+    "symfony/var-dumper": "^7.3"
+  },
+  "autoload": {
+    "psr-4": {
+      "Engelsystem\\": "src/"
+    },
+    "classmap": ["db/migrations"],
+    "files": ["src/helpers.php"]
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Database\\Factories\\Engelsystem\\Models\\": "db/factories/",
+      "Engelsystem\\Test\\": "tests/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    },
+    "sort-packages": true
+  }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -97,40 +97,38 @@ return [
          * Structure of a config page:
          * '[slug]' => [
          *   'title' => '[title]', # Optional page title, default to config.[key]
+         *   'icon' => '[icon]', # Optional, default gear-fill
+         *   'order' => 42, # Optional, menu position
+         *   'url' => '[path]', # Optional, path to config page
+         *   'permission' => '[permission]' # Optional, string or array
          *   'validation' => callable, # Optional, callable($request, $rules) to validate the page request
-         *    'config' => [...], # A list of "config options" / config fields, see below
+         *   'config' => [...], # A list of "config options" / config fields, see below
          * ]
          *
          * Structure of a config option:
-         * '[name]' => [ # Config name
-         *     'title' => '[title], # Optional, default config.[name]
-         *     'permission' => '[permission]' # Optional, string or array
-         *     'icon' => '[icon]', # Optional, default gear-fill
-         *     'config' => [
-         *         '[name]' => [ # Name must be globally unique
-         *             'name' => 'some.value', # Optional, default: config.[name]
-         *             'info' => 'some.info', # Optional, default: config.[name].info if available
-         *             'type' => 'string', # Possible types:
-         *                  string, text, datetime-local, date, boolean, number, url, select, select_multi
-         *             'default' => '[value]', # Optional
-         *             'data' => ['[value]', '[key]' => '[value]'], # Optional, select data
-         *             'required' => true, # Optional, default false
-         *             'env' => '[name]', # Optional, env var to load, default name in upper case
-         *             'hidden' => false, # Optional, default false, hides the config from frontend
-         *             'permission' => '[permission]' # Optional, string or array
-         *             'validation' => ['[validation]'] # Optional, array of validation options
-         *             'write_back' => false, # Optional, writes the config to config.local.php
-         *                                                Only effective for single-server-installations
-         *             'preserve_key' => false, # Optional, preserves key in selects, disables auto translation
-         *             # Optional translation: config.[name].info for information messages
-         *             # Optionally other options used by the correlating field template
-         *         ],
-         *     ],
+         * '[name]' => [ # Config name, must be globally unique
+         *   'name' => 'some.value', # Optional, default: config.[name]
+         *   'info' => 'some.info', # Optional, default: config.[name].info if available
+         *   'type' => 'string', # Possible types:
+         *        string, text, datetime-local, date, boolean, number, url, select, select_multi
+         *   'default' => '[value]', # Optional
+         *   'data' => ['[value]', '[key]' => '[value]'], # Optional, select data
+         *   'required' => true, # Optional, default false
+         *   'env' => '[name]', # Optional, env var to load, default name in upper case
+         *   'hidden' => false, # Optional, default false, hides the config from frontend
+         *   'permission' => '[permission]' # Optional, string or array
+         *   'validation' => ['[validation]'] # Optional, array of validation options
+         *   'write_back' => false, # Optional, writes the config to config.local.php
+         *                                      Only effective for single-server-installations
+         *   'preserve_key' => false, # Optional, preserves key in selects, disables auto translation
+         *   # Optional translation: config.[name].info for information messages
+         *   # Optionally other options used by the correlating field template
          * ],
          */
 
         'event' => [
             'icon' => 'calendar-heart',
+            'order' => 10,
             'config' => [
                 'name' => [
                     'type' => 'string',
@@ -174,6 +172,7 @@ return [
 
         'features' => [
             'icon' => 'ui-checks',
+            'order' => 20,
             'config' => [
                 'enable_dect' => [
                     'name' => 'general.dect',
@@ -270,6 +269,7 @@ return [
 
         'certificates' => [
             'icon' => 'card-checklist',
+            'order' => 30,
             'config' => [
                 'driving_license_enabled' => [
                     'name' => 'settings.certificates.driving_license',
@@ -291,6 +291,7 @@ return [
 
         'shifts' => [
             'icon' => 'calendar-week',
+            'order' => 50,
             'config' => [
                 'signup_advance_hours' => [
                     'type' => 'number',
@@ -329,6 +330,7 @@ return [
 
         'goodie' => [
             'icon' => 'gift',
+            'order' => 60,
             'config' => [
                 'goodie_type' => [
                     'type' => 'select',
@@ -370,6 +372,7 @@ return [
         ],
 
         'system' => [
+            'order' => 90,
             'config' => [
                 'app_name' => [
                     'type' => 'string',

--- a/resources/views/admin/config/index.twig
+++ b/resources/views/admin/config/index.twig
@@ -1,7 +1,7 @@
 {% extends 'layouts/app.twig' %}
 {% import 'macros/base.twig' as m %}
 
-{% block title %}{{ __(title|default(__('config.config'))) }} {{ __('config.config') }}{% endblock %}
+{% block title %}{{ __(title|default('')) }} {{ __('config.config') }}{% endblock %}
 
 {% block content %}
     <div class="container user-settings">
@@ -9,7 +9,7 @@
             <h1>
                 {{ __('config.config') }}
                 <small class="text-muted">
-                    {{ __(title|default(__('config.config'))) }}
+                    {{ __(title|default('')) }}
                 </small>
             </h1>
         {% endblock %}
@@ -21,8 +21,8 @@
                         {% if not option.permission|default(false) or can(option.permission) %}
                             <li class="nav-item">
                                 <a
-                                    class="nav-link {% if option.url == request.url() %}active{% endif %}"
-                                    href="{{ option.url }}"
+                                    class="nav-link {% if url(option.url) == request.url() %}active{% endif %}"
+                                    href="{{ url(option.url) }}"
                                 >
                                     {{ m.icon(option.icon ?? 'gear-fill') }}
                                     {{ __(option.title) }}

--- a/src/Controllers/Admin/BaseConfigController.php
+++ b/src/Controllers/Admin/BaseConfigController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Controllers\Admin;
+
+use Engelsystem\Controllers\BaseController;
+use Engelsystem\Controllers\HasUserNotifications;
+use Illuminate\Support\Str;
+
+abstract class BaseConfigController extends BaseController
+{
+    use HasUserNotifications;
+
+    protected array $options = [];
+
+    protected array $permissions = [
+        'config.edit',
+    ];
+
+    public function __construct()
+    {
+        $this->options = config('config_options', []);
+        // Sort by order ascending, ignore missing
+        uasort(
+            $this->options,
+            fn($a, $b) => ($a['order'] ?? $b['order'] ?? 0) <=> ($b['order'] ?? $a['order'] ?? 0)
+        );
+    }
+
+    protected function getPageData(string $page): array
+    {
+        return [
+            'page' => $page,
+            'title' => $this->options[$page]['title'],
+            'config' => $this->options[$page]['config'],
+            'options' => $this->options,
+        ];
+    }
+
+    protected function parseOptions(bool $localConfigWritable = false, bool $withAll = false): void
+    {
+        $fromEnv = array_filter(config('env_config', []), fn($a) => !is_null($a));
+
+        foreach ($this->options as $key => $value) {
+            // Add page URL
+            if (empty($this->options[$key]['url'])) {
+                $this->options[$key]['url'] = url('/admin/config/' . $key);
+                $this->options[$key]['url_added'] = true;
+            }
+
+            // Configure page translation names
+            if (empty($this->options[$key]['title'])) {
+                $this->options[$key]['title'] = 'config.' . $key;
+            }
+
+            // Define internal validation action
+            $internalValidation = 'validate' . Str::ucfirst($key);
+            if (method_exists($this, $internalValidation)) {
+                // Used until proper dynamic config loading is implemented
+                $this->options[$key]['validation'] = [$this, $internalValidation];
+            }
+
+            // Iterate over settings
+            foreach ($this->options[$key]['config'] as $name => $config) {
+                // Ignore hidden options
+                if (!empty($config['hidden']) && !$withAll) {
+                    unset($this->options[$key]['config'][$name]);
+                    continue;
+                }
+
+                // Set name for translation
+                if (empty($this->options[$key]['config'][$name]['name'])) {
+                    $this->options[$key]['config'][$name]['name'] = 'config.' . $name;
+                }
+
+                // Configure required icon
+                if (!empty($this->options[$key]['config'][$name]['required'])) {
+                    $this->options[$key]['config'][$name]['required_icon'] = true;
+                }
+
+                // Set ENV name
+                if (empty($config['env'])) {
+                    $config['env'] = Str::upper($name);
+                    $this->options[$key]['config'][$name]['env'] = $config['env'];
+                }
+
+                // Configure select values
+                if ($config['type'] == 'select' || $config['type'] == 'select_multi') {
+                    $data = [];
+                    foreach ($config['data'] ?? [] as $dataKey => $dataValue) {
+                        if (is_int($dataKey) && !($config['preserve_key'] ?? false)) {
+                            $dataKey = $dataValue;
+                            $dataValue = 'config.' . $name . '.select.' . $dataKey;
+                        }
+                        $data[$dataKey] = $dataValue;
+                    }
+                    $this->options[$key]['config'][$name]['data'] = $data;
+                }
+
+                // Set if set from ENV
+                if (isset($fromEnv[$config['env']])) {
+                    $this->options[$key]['config'][$name]['in_env'] = true;
+                }
+
+                // Set if local config can be written to
+                if (!$localConfigWritable && ($config['write_back'] ?? false)) {
+                    $this->options[$key]['config'][$name]['writable'] = false;
+                }
+            }
+        }
+    }
+}

--- a/src/Controllers/Admin/ConfigController.php
+++ b/src/Controllers/Admin/ConfigController.php
@@ -48,6 +48,11 @@ class ConfigController extends BaseController
     ) {
         $this->localConfig = $app->get('path.config') . '/config.local.php';
         $this->options = $this->config->get('config_options', []);
+        // Sort by order ascending, ignore missing
+        uasort(
+            $this->options,
+            fn($a, $b) => ($a['order'] ?? $b['order'] ?? 0) <=> ($b['order'] ?? $a['order'] ?? 0)
+        );
         $this->parseOptions($withAll);
     }
 

--- a/src/Controllers/Admin/ConfigController.php
+++ b/src/Controllers/Admin/ConfigController.php
@@ -6,8 +6,6 @@ namespace Engelsystem\Controllers\Admin;
 
 use Engelsystem\Application;
 use Engelsystem\Config\Config;
-use Engelsystem\Controllers\BaseController;
-use Engelsystem\Controllers\HasUserNotifications;
 use Engelsystem\Helpers\Authenticator;
 use Engelsystem\Helpers\Carbon;
 use Engelsystem\Helpers\CarbonDay;
@@ -16,44 +14,29 @@ use Engelsystem\Http\Exceptions\HttpNotFound;
 use Engelsystem\Http\Redirector;
 use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
-use Engelsystem\Http\UrlGeneratorInterface;
 use Engelsystem\Models\EventConfig;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 
-class ConfigController extends BaseController
+class ConfigController extends BaseConfigController
 {
-    use HasUserNotifications;
-
     protected string $localConfig;
 
     protected string $passwordPlaceholder = '**********';
 
-    protected array $permissions = [
-        'config.edit',
-    ];
-
-    protected array $options = [];
-
     public function __construct(
-        protected Response $response,
-        protected Config $config,
-        protected Redirector $redirect,
-        protected UrlGeneratorInterface $url,
-        protected LoggerInterface $log,
-        protected Authenticator $auth,
         Application $app,
-        bool $withAll = false, # Used to get all config options, for example for docs
+        protected Config $config,
+        protected Authenticator $auth,
+        protected Redirector $redirect,
+        protected Response $response,
+        protected LoggerInterface $log,
     ) {
+        parent::__construct();
         $this->localConfig = $app->get('path.config') . '/config.local.php';
-        $this->options = $this->config->get('config_options', []);
-        // Sort by order ascending, ignore missing
-        uasort(
-            $this->options,
-            fn($a, $b) => ($a['order'] ?? $b['order'] ?? 0) <=> ($b['order'] ?? $a['order'] ?? 0)
-        );
-        $this->parseOptions($withAll);
+        $localConfigWriteable = $this->isFileWritable($this->localConfig);
+        $this->parseOptions($localConfigWriteable);
     }
 
     public function index(): Response
@@ -65,13 +48,14 @@ class ConfigController extends BaseController
     {
         $page = $this->activePage($request);
 
+        if (empty($this->options[$page]['url_added'])) {
+            return $this->redirect->to($this->options[$page]['url']);
+        }
+
         return $this->response->withView(
             'admin/config/index',
             [
-                'page' => $page,
-                'title' => $this->options[$page]['title'],
-                'config' => $this->options[$page]['config'],
-                'options' => $this->options,
+                ...$this->getPageData($page),
             ]
         );
     }
@@ -161,11 +145,6 @@ class ConfigController extends BaseController
         return $this->redirect->back();
     }
 
-    public function getOptions(): array
-    {
-        return $this->options;
-    }
-
     protected function isFileWritable(string $file): bool
     {
         return
@@ -205,8 +184,8 @@ class ConfigController extends BaseController
                 'select' => $validation[] = 'in:' . implode(',', array_keys($setting['data'])),
                 'select_multi' => $validation[] = 'array_val|in_many:' . implode(',', array_keys($setting['data'])),
                 'password' =>
-                    $request->postData($key) !== $this->passwordPlaceholder
-                    && (!empty($setting['required']) || $request->postData($key))
+                $request->postData($key) !== $this->passwordPlaceholder
+                && (!empty($setting['required']) || $request->postData($key))
                     ? $validation[] = 'length:' . $this->config->get('password_min_length')
                     : null,
                 default => throw new InvalidArgumentException(
@@ -224,77 +203,6 @@ class ConfigController extends BaseController
         return $this->validate($request, $rules);
     }
 
-    protected function parseOptions(bool $withAll = true): void
-    {
-        $fromEnv = array_filter($this->config->get('env_config'), fn($a) => !is_null($a));
-        $localConfigWritable = $this->isFileWritable($this->localConfig);
-
-        foreach ($this->options as $key => $value) {
-            // Add page URLs
-            $this->options[$key]['url'] = $this->url->to('/admin/config/' . $key);
-
-            // Configure page translation names
-            if (empty($this->options[$key]['title'])) {
-                $this->options[$key]['title'] = 'config.' . $key;
-            }
-
-            // Define internal validation action
-            $internalValidation = 'validate' . Str::ucfirst($key);
-            if (method_exists($this, $internalValidation)) {
-                // Used until proper dynamic config loading is implemented
-                $this->options[$key]['validation'] = [$this, $internalValidation];
-            }
-
-            // Iterate over settings
-            foreach ($this->options[$key]['config'] as $name => $config) {
-                // Ignore hidden options
-                if (!empty($config['hidden']) && !$withAll) {
-                    unset($this->options[$key]['config'][$name]);
-                    continue;
-                }
-
-                // Set name for translation
-                if (empty($this->options[$key]['config'][$name]['name'])) {
-                    $this->options[$key]['config'][$name]['name'] = 'config.' . $name;
-                }
-
-                // Configure required icon
-                if (!empty($this->options[$key]['config'][$name]['required'])) {
-                    $this->options[$key]['config'][$name]['required_icon'] = true;
-                }
-
-                // Set ENV name
-                if (empty($config['env'])) {
-                    $config['env'] = Str::upper($name);
-                    $this->options[$key]['config'][$name]['env'] = $config['env'];
-                }
-
-                // Configure select values
-                if ($config['type'] == 'select' || $config['type'] == 'select_multi') {
-                    $data = [];
-                    foreach ($config['data'] ?? [] as $dataKey => $dataValue) {
-                        if (is_int($dataKey) && !($config['preserve_key'] ?? false)) {
-                            $dataKey = $dataValue;
-                            $dataValue = 'config.' . $name . '.select.' . $dataKey;
-                        }
-                        $data[$dataKey] = $dataValue;
-                    }
-                    $this->options[$key]['config'][$name]['data'] = $data;
-                }
-
-                // Set if set from ENV
-                if (isset($fromEnv[$config['env']])) {
-                    $this->options[$key]['config'][$name]['in_env'] = true;
-                }
-
-                // Set if local config can be written to
-                if (!$localConfigWritable && ($config['write_back'] ?? false)) {
-                    $this->options[$key]['config'][$name]['writable'] = false;
-                }
-            }
-        }
-    }
-
     protected function filterShownSettings(array $settings): array
     {
         // Ignore values from env
@@ -307,7 +215,7 @@ class ConfigController extends BaseController
     {
         $page = $request->getAttribute('page');
 
-        if (empty($this->options[$page])) {
+        if (!$page || empty($this->options[$page])) {
             throw new HttpNotFound();
         }
 

--- a/tests/Unit/Controllers/Admin/BaseConfigControllerTest.php
+++ b/tests/Unit/Controllers/Admin/BaseConfigControllerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Controllers\Admin;
+
+use Engelsystem\Http\UrlGeneratorInterface;
+use Engelsystem\Test\Unit\Controllers\Admin\Stub\BaseConfigControllerImplementation;
+use Engelsystem\Test\Unit\Controllers\ControllerTest;
+
+class BaseConfigControllerTest extends ControllerTest
+{
+    protected array $options = [
+        'test' => [
+            'config' => [
+                'something' => [
+                    'type' => 'text',
+                ],
+                'some_config_from_env' => [
+                    'type' => 'text',
+                    'required' => true,
+                    'write_back' => true,
+                ],
+                'hidden_stuff' => [
+                    'type' => 'text',
+                    'hidden' => true,
+                ],
+                'drops' => [
+                    'type' => 'select',
+                    'data' => [
+                        'first',
+                        'second',
+                    ],
+                ],
+            ],
+        ],
+        'foo' => [
+            'order' => 20,
+            'config' => [],
+        ],
+        'bar' => [
+            'order' => 10,
+            'config' => [],
+        ],
+        'lorem' => [
+            'config' => [],
+            'title' => 'some.title',
+            'url' => '/test',
+        ],
+    ];
+
+    /**
+     * @covers \Engelsystem\Controllers\Admin\BaseConfigController::__construct
+     */
+    public function testConstruct(): void
+    {
+        $controller = new BaseConfigControllerImplementation();
+        // Ensure order
+        $this->assertEquals(['test', 'bar', 'foo', 'lorem'], array_keys($controller->getOptions()));
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Admin\BaseConfigController::__construct
+     */
+    public function testDefaultPermissions(): void
+    {
+        $controller = new BaseConfigControllerImplementation();
+        $this->assertEquals(['config.edit'], $controller->getPermissions());
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Admin\BaseConfigController::getPageData
+     */
+    public function testGetPageData(): void
+    {
+        $controller = new BaseConfigControllerImplementation();
+        $controller->callParseOptions();
+
+        $pageData = $controller->callGetPageData('test');
+        $this->assertArrayHasKey('page', $pageData);
+        $this->assertEquals('test', $pageData['page']);
+
+        $this->assertArrayHasKey('title', $pageData);
+        $this->assertEquals('config.test', $pageData['title']);
+
+        $this->assertArrayHasKey('config', $pageData);
+        $this->assertArrayHasKey('something', $pageData['config']);
+
+        $this->assertArrayHasKey('options', $pageData);
+        $this->assertArrayHasKey('test', $pageData['options']);
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Admin\BaseConfigController::parseOptions
+     */
+    public function testParseOptions(): void
+    {
+        $controller = new BaseConfigControllerImplementation();
+        $controller->callParseOptions();
+
+        $pageData = $controller->callGetPageData('test');
+        $options = $pageData['options'];
+        $this->assertArrayHasKey('test', $options);
+        $this->assertArrayHasKey('bar', $options);
+        $this->assertArrayHasKey('foo', $options);
+        $this->assertArrayHasKey('lorem', $options);
+
+        $value = $options['test'];
+        $this->assertEquals('/admin/config/test', $value['url']);
+        $this->assertTrue($value['url_added']);
+        $this->assertEquals('config.test', $value['title']);
+
+        $this->assertIsCallable($options['foo']['validation']);
+
+        $config = $value['config'];
+        $this->assertArrayHasKey('something', $config);
+        $this->assertArrayHasKey('some_config_from_env', $config);
+        $this->assertArrayHasKey('drops', $config);
+        $this->assertArrayNotHasKey('hidden_stuff', $config);
+
+        $this->assertEquals('config.something', $config['something']['name']);
+        $this->assertTrue($config['some_config_from_env']['required_icon']);
+
+        $this->assertEquals(
+            ['first' => 'config.drops.select.first', 'second' => 'config.drops.select.second'],
+            $config['drops']['data']
+        );
+
+        $this->assertTrue($config['some_config_from_env']['in_env']);
+        $this->assertFalse($config['some_config_from_env']['writable']);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config->set('config_options', $this->options);
+        $this->config->set('env_config', ['SOME_CONFIG_FROM_ENV' => 'I am the env!']);
+
+        $url = $this->getMockForAbstractClass(UrlGeneratorInterface::class);
+        $url->expects($this->any())
+            ->method('to')
+            ->willReturnCallback(function (string $path, array $parameters = []) {
+                return $path . ($parameters ? '?' . http_build_query($parameters) : '');
+            });
+        $this->app->instance('http.urlGenerator', $url);
+    }
+}

--- a/tests/Unit/Controllers/Admin/ConfigControllerTest.php
+++ b/tests/Unit/Controllers/Admin/ConfigControllerTest.php
@@ -88,6 +88,14 @@ class ConfigControllerTest extends ControllerTest
             ],
             'permission' => 'some_test_permission',
         ],
+        'foo' => [
+            'order' => 20,
+            'config' => [],
+        ],
+        'bar' => [
+            'order' => 10,
+            'config' => [],
+        ],
         'invalid' => [
             'config' => [
                 'broken' => [
@@ -151,6 +159,17 @@ class ConfigControllerTest extends ControllerTest
         'url' => 'https://example.com/test',
         'to_be_written_to_file' => '1',
     ];
+
+    /**
+     * @covers \Engelsystem\Controllers\Admin\ConfigController::__construct
+     */
+    public function testConstruct(): void
+    {
+        /** @var ConfigController $controller */
+        $controller = $this->app->make(ConfigController::class);
+        // Ensure order
+        $this->assertEquals(['test', 'bar', 'foo', 'invalid', 'event'], array_keys($controller->getOptions()));
+    }
 
     /**
      * @covers \Engelsystem\Controllers\Admin\ConfigController::index

--- a/tests/Unit/Controllers/Admin/ConfigControllerTest.php
+++ b/tests/Unit/Controllers/Admin/ConfigControllerTest.php
@@ -11,6 +11,7 @@ use Engelsystem\Http\Exceptions\HttpForbidden;
 use Engelsystem\Http\Exceptions\HttpNotFound;
 use Engelsystem\Http\Exceptions\ValidationException;
 use Engelsystem\Http\Request;
+use Engelsystem\Http\UrlGeneratorInterface;
 use Engelsystem\Http\Validation\Validator;
 use Engelsystem\Models\EventConfig;
 use Engelsystem\Test\Unit\Controllers\ControllerTest;
@@ -88,14 +89,6 @@ class ConfigControllerTest extends ControllerTest
             ],
             'permission' => 'some_test_permission',
         ],
-        'foo' => [
-            'order' => 20,
-            'config' => [],
-        ],
-        'bar' => [
-            'order' => 10,
-            'config' => [],
-        ],
         'invalid' => [
             'config' => [
                 'broken' => [
@@ -134,6 +127,14 @@ class ConfigControllerTest extends ControllerTest
                 ],
             ],
         ],
+        'some-plugin' => [
+            'url' => '/config/plugin',
+            'config' => [
+                'test' => [
+                    'type' => 'text',
+                ],
+            ],
+        ],
     ];
 
     protected array $validEventBody = [
@@ -161,17 +162,6 @@ class ConfigControllerTest extends ControllerTest
     ];
 
     /**
-     * @covers \Engelsystem\Controllers\Admin\ConfigController::__construct
-     */
-    public function testConstruct(): void
-    {
-        /** @var ConfigController $controller */
-        $controller = $this->app->make(ConfigController::class);
-        // Ensure order
-        $this->assertEquals(['test', 'bar', 'foo', 'invalid', 'event'], array_keys($controller->getOptions()));
-    }
-
-    /**
      * @covers \Engelsystem\Controllers\Admin\ConfigController::index
      */
     public function testIndex(): void
@@ -189,7 +179,6 @@ class ConfigControllerTest extends ControllerTest
      * @covers \Engelsystem\Controllers\Admin\ConfigController::__construct
      * @covers \Engelsystem\Controllers\Admin\ConfigController::edit
      * @covers \Engelsystem\Controllers\Admin\ConfigController::activePage
-     * @covers \Engelsystem\Controllers\Admin\ConfigController::parseOptions
      */
     public function testEdit(): void
     {
@@ -242,7 +231,7 @@ class ConfigControllerTest extends ControllerTest
                 $this->assertArrayHasKey('url', $data['options']['test']);
                 $this->assertArrayHasKey('title', $data['options']['test']);
                 $this->assertEquals('config.test', $data['options']['test']['title']);
-                $this->assertEquals('http://localhost/admin/config/test', $data['options']['test']['url']);
+                $this->assertEquals('/admin/config/test', $data['options']['test']['url']);
 
                 $this->assertArrayNotHasKey('something_to_hide', $data['config']);
 
@@ -258,7 +247,6 @@ class ConfigControllerTest extends ControllerTest
 
     /**
      * @covers \Engelsystem\Controllers\Admin\ConfigController::isFileWritable
-     * @covers \Engelsystem\Controllers\Admin\ConfigController::parseOptions
      */
     public function testEditNotWritable(): void
     {
@@ -274,6 +262,22 @@ class ConfigControllerTest extends ControllerTest
                 $this->assertFalse($data['config']['to_be_written_to_file']['writable']);
                 return $this->response;
             });
+
+        /** @var ConfigController $controller */
+        $controller = $this->app->make(ConfigController::class);
+
+        $response = $controller->edit($this->request);
+        $this->assertEquals($this->response, $response);
+    }
+
+    /**
+     * @covers \Engelsystem\Controllers\Admin\ConfigController::edit
+     */
+    public function testEditOverwrittenUrl(): void
+    {
+        $this->request->attributes->set('page', 'some-plugin');
+
+        $this->setExpects($this->response, 'redirectTo', ['http://localhost/config/plugin'], $this->response);
 
         /** @var ConfigController $controller */
         $controller = $this->app->make(ConfigController::class);
@@ -331,7 +335,6 @@ class ConfigControllerTest extends ControllerTest
      * @covers \Engelsystem\Controllers\Admin\ConfigController::save
      * @covers \Engelsystem\Controllers\Admin\ConfigController::validation
      * @covers \Engelsystem\Controllers\Admin\ConfigController::filterShownSettings
-     * @covers \Engelsystem\Controllers\Admin\ConfigController::parseOptions
      */
     public function testSaveTestValidateSuccessful(): void
     {
@@ -379,7 +382,7 @@ class ConfigControllerTest extends ControllerTest
     }
 
     /**
-     * @covers \Engelsystem\Controllers\Admin\ConfigController::validation
+     * @covers       \Engelsystem\Controllers\Admin\ConfigController::validation
      * @dataProvider validationErrorsProvider
      */
     public function testSaveValidationError(array $errorData): void
@@ -636,20 +639,6 @@ class ConfigControllerTest extends ControllerTest
         $this->assertStringNotContainsString('default value', $content);
     }
 
-    /**
-     * @covers \Engelsystem\Controllers\Admin\ConfigController::getOptions
-     */
-    public function testGetOptions(): void
-    {
-        /** @var ConfigController $controller */
-        $controller = $this->app->make(ConfigController::class);
-        $data = $controller->getOptions();
-
-        $this->assertArrayHasKey('test', $data);
-        $this->assertArrayHasKey('invalid', $data);
-        $this->assertArrayHasKey('event', $data);
-    }
-
     public function setUp(): void
     {
         parent::setUp();
@@ -663,6 +652,14 @@ class ConfigControllerTest extends ControllerTest
         $this->app->instance(Authenticator::class, $this->auth);
         $this->auth->setPermissions(['some_test_permission']);
         $this->app->instance('path.config', __DIR__ . '/Stub');
+
+        $url = $this->getMockForAbstractClass(UrlGeneratorInterface::class);
+        $url->expects($this->any())
+            ->method('to')
+            ->willReturnCallback(function (string $path, array $parameters = []) {
+                return $path . ($parameters ? '?' . http_build_query($parameters) : '');
+            });
+        $this->app->instance('http.urlGenerator', $url);
     }
 
     public function tearDown(): void

--- a/tests/Unit/Controllers/Admin/Stub/BaseConfigControllerImplementation.php
+++ b/tests/Unit/Controllers/Admin/Stub/BaseConfigControllerImplementation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Controllers\Admin\Stub;
+
+use Engelsystem\Controllers\Admin\BaseConfigController;
+use Engelsystem\Http\Request;
+
+class BaseConfigControllerImplementation extends BaseConfigController
+{
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function callGetPageData(string $page): array
+    {
+        return $this->getPageData($page);
+    }
+
+    public function callParseOptions(): void
+    {
+        $this->parseOptions();
+    }
+
+    public function validateFoo(Request $request, array $rules): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Database/Migration/MigrateTest.php
+++ b/tests/Unit/Database/Migration/MigrateTest.php
@@ -24,6 +24,7 @@ class MigrateTest extends TestCase
      * @covers \Engelsystem\Database\Migration\Migrate::run
      * @covers \Engelsystem\Database\Migration\Migrate::setOutput
      * @covers \Engelsystem\Database\Migration\Migrate::mergeMigrations
+     * @covers \Engelsystem\Database\Migration\Migrate::setNamespace
      */
     public function testRun(): void
     {
@@ -85,6 +86,7 @@ class MigrateTest extends TestCase
         $this->setExpects($migration, 'lockTable', null, null, $this->atLeastOnce());
         $this->setExpects($migration, 'unlockTable', null, null, $this->atLeastOnce());
 
+        $migration->setNamespace('Engelsystem\\Test\\Unit\\Database\\Migration\\Stub\\');
         $migration->run('foo', Direction::UP);
 
         $messages = [];
@@ -190,6 +192,7 @@ class MigrateTest extends TestCase
         $app->bind(SchemaBuilder::class, 'schema');
 
         $migration = new Migrate($schema, $app);
+        $migration->setNamespace('Engelsystem\\Test\\Unit\\Database\\Migration\\Stub\\');
 
         $migration->run(__DIR__ . '/Stub', Direction::UP);
 
@@ -239,6 +242,7 @@ class MigrateTest extends TestCase
         $this->app->bind(SchemaBuilder::class, 'schema');
 
         $migration = new Migrate($schema, $this->app);
+        $migration->setNamespace('Engelsystem\\Test\\Unit\\Database\\Migration\\Stub\\');
 
         $messages = [];
         $migration->setOutput(function ($msg) use (&$messages): void {

--- a/tests/Unit/Database/Migration/MigrationTest.php
+++ b/tests/Unit/Database/Migration/MigrationTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Engelsystem\Test\Unit\Database\Migration;
 
-use Engelsystem\Migrations\AnotherStuff;
+use Engelsystem\Test\Unit\Database\Migration\Stub\AnotherStuff;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Database/Migration/Stub/2001_04_11_123456_create_lorem_ipsum_table.php
+++ b/tests/Unit/Database/Migration/Stub/2001_04_11_123456_create_lorem_ipsum_table.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Engelsystem\Migrations;
+namespace Engelsystem\Test\Unit\Database\Migration\Stub;
 
 use Engelsystem\Database\Migration\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/tests/Unit/Database/Migration/Stub/2017_12_24_053300_another_stuff.php
+++ b/tests/Unit/Database/Migration/Stub/2017_12_24_053300_another_stuff.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Engelsystem\Migrations;
+namespace Engelsystem\Test\Unit\Database\Migration\Stub;
 
 use Engelsystem\Database\Migration\Migration;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;

--- a/tests/Unit/Database/Migration/Stub/2022_12_22_221222_add_some_feature.php
+++ b/tests/Unit/Database/Migration/Stub/2022_12_22_221222_add_some_feature.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Engelsystem\Migrations;
+namespace Engelsystem\Test\Unit\Database\Migration\Stub;
 
 use Engelsystem\Database\Migration\Migration;
 

--- a/tests/Unit/Database/Migration/Stub/2025_01_06_112911_oauth2_server_tables.php
+++ b/tests/Unit/Database/Migration/Stub/2025_01_06_112911_oauth2_server_tables.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Engelsystem\Migrations;
+namespace Engelsystem\Test\Unit\Database\Migration\Stub;
 
 use Engelsystem\Database\Migration\Migration;
 


### PR DESCRIPTION
* Format composer.json using editorconfig (only 2 spaces for consistency)
* Added option to sort config menu points / adding entries in between
* Migrations: Set namespace explicitly, skip unknown migrations instead of discarding them
* ConfigController: Split config parsing part as BaseConfigController to make reusing easier (for example in config2docs)