### PR TITLE
Overwrite ExtendsTokenParser

### DIFF
--- a/src/Renderer/ExtendsTokenParser.php
+++ b/src/Renderer/ExtendsTokenParser.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Renderer;
+
+use Illuminate\Support\Str;
+use Twig\Error\SyntaxError;
+use Twig\Loader\FilesystemLoader as FilesystemLoader;
+use Twig\Node\EmptyNode;
+use Twig\Node\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+class ExtendsTokenParser extends AbstractTokenParser
+{
+    public function __construct(protected FilesystemLoader $loader, protected string $basePath)
+    {
+    }
+
+    /**
+     * Allows multi-inheritance by searching for the file to be extended in views and views of all plugins
+     */
+    public function parse(Token $token): Node
+    {
+        $stream = $this->parser->getStream();
+
+        if ($this->parser->peekBlockStack() || !$this->parser->isMainScope()) {
+            throw new SyntaxError(
+                'Cannot use "extend" in a block or macro.',
+                $token->getLine(),
+                $stream->getSourceContext(),
+            );
+        }
+
+        $parent = $this->parser->parseExpression();
+        $templateFile = $stream->getSourceContext()->getPath();
+        $extendsFile = $parent->getAttribute('value');
+
+        $extendsFile = $this->getNextParentFile($templateFile, $extendsFile);
+
+        $parent->setAttribute('value', $extendsFile);
+
+        $this->parser->setParent($parent);
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        return new EmptyNode($token->getLine());
+    }
+
+    public function getTag(): string
+    {
+        return 'extends';
+    }
+
+    protected function getNextParentFile(string $templateFile, string $extendsFile): string
+    {
+        $found = false;
+        foreach ($this->loader->getPaths() as $path) {
+            // Ignore file itself
+            if (Str::startsWith($templateFile, $path . '/')) {
+                $found = true;
+                continue;
+            }
+
+            // Skip all paths "above" the currently extending file
+            if (!$found) {
+                continue;
+            }
+
+            // Use file if it is loadable
+            $parentFilePath = Str::replaceStart($this->basePath . '/', '', $path . '/' . $extendsFile);
+            if ($this->loader->exists($parentFilePath)) {
+                return $parentFilePath;
+            }
+        }
+
+        return $extendsFile;
+    }
+}

--- a/src/Renderer/TwigServiceProvider.php
+++ b/src/Renderer/TwigServiceProvider.php
@@ -24,6 +24,7 @@ use Engelsystem\Renderer\Twig\Extensions\Uuid;
 use Symfony\Component\VarDumper\VarDumper;
 use Twig\Environment as Twig;
 use Twig\Extension\CoreExtension as TwigCore;
+use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface as TwigLoaderInterface;
 use TwigBridge\Extension\Laravel\Model as TwigModel;
 
@@ -79,17 +80,21 @@ class TwigServiceProvider extends ServiceProvider
 
     protected function registerTwigEngine(): void
     {
-        $viewsPath = $this->app->get('path.views');
+        // Paths are added twice to allow "more specific" overwrites with "views/" prefix from plugin templates
+        $viewsPath = [$this->app->get('path.views'), $this->app->get('path.views') . '/..'];
         /** @var EngelsystemConfig $config */
         $config = $this->app->get('config');
 
         $twigLoader = $this->app->make(TwigLoader::class, ['paths' => $viewsPath]);
         $this->app->instance(TwigLoader::class, $twigLoader);
+        $this->app->instance(FilesystemLoader::class, $twigLoader);
         $this->app->instance(TwigLoaderInterface::class, $twigLoader);
         $this->app->instance('twig.loader', $twigLoader);
+        $this->app->tag('twig.loader', ['twig.loader']);
 
         $twigTextLoader = $this->app->make(TwigTextLoader::class, ['paths' => $viewsPath]);
         $this->app->instance('twig.textLoader', $twigTextLoader);
+        $this->app->tag('twig.textLoader', ['twig.loader']);
 
         $cache = $this->app->get('path.cache.views');
         $twigDebug = false;
@@ -129,6 +134,13 @@ class TwigServiceProvider extends ServiceProvider
         // Text is tagged first to catch .text.twig files
         $this->app->tag('renderer.twigTextEngine', ['renderer.engine']);
         $this->app->tag('renderer.twigEngine', ['renderer.engine']);
+
+        // Add token parsers
+        $extendsTokenParser = $this->app->make(
+            ExtendsTokenParser::class,
+            ['basePath' => $this->app->get('path.resources')],
+        );
+        $twig->addTokenParser($extendsTokenParser);
     }
 
     protected function registerTwigExtensions(string $class, string $alias): void

--- a/src/Renderer/TwigServiceProvider.php
+++ b/src/Renderer/TwigServiceProvider.php
@@ -134,11 +134,7 @@ class TwigServiceProvider extends ServiceProvider
     protected function registerTwigExtensions(string $class, string $alias): void
     {
         $alias = 'twig.extension.' . $alias;
-
-        $extension = $this->app->make($class);
-
-        $this->app->instance($class, $extension);
-        $this->app->instance($alias, $extension);
+        $this->app->alias($class, $alias);
 
         $this->app->tag($alias, ['twig.extension']);
     }

--- a/tests/Unit/Renderer/ExtendsTokenParserTest.php
+++ b/tests/Unit/Renderer/ExtendsTokenParserTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit\Renderer;
+
+use Engelsystem\Renderer\ExtendsTokenParser;
+use Engelsystem\Test\Unit\TestCase;
+use Twig\Environment as Twig;
+use Twig\Error\SyntaxError;
+use Twig\Loader\FilesystemLoader;
+use Twig\Loader\LoaderInterface;
+
+class ExtendsTokenParserTest extends TestCase
+{
+    protected ExtendsTokenParser $parser;
+    protected Twig $twig;
+
+    /**
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::__construct
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::getTag
+     */
+    public function testGetTag(): void
+    {
+        $this->assertEquals('extends', $this->parser->getTag());
+    }
+
+    /**
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::parse
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::getNextParentFile
+     */
+    public function testParseNormalExtends(): void
+    {
+        $template = $this->twig->load('extends.twig');
+        $output = $template->render();
+
+        $this->assertStringContainsString('Extended template content - Extends Content', $output);
+    }
+
+    /**
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::parse
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::getNextParentFile
+     */
+    public function testParseWithInheritance(): void
+    {
+        $template = $this->twig->load('inheritance.twig');
+        $output = $template->render();
+
+        $this->assertStringContainsString('Base template content - B Content - A Content', $output);
+    }
+
+    /**
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::parse
+     * @covers \Engelsystem\Renderer\ExtendsTokenParser::getNextParentFile
+     */
+    public function testParseExtendsThrowsError(): void
+    {
+        $this->expectException(SyntaxError::class);
+
+        $this->twig->load('extends-error.twig');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $fsLoader = $this->app->make(FilesystemLoader::class, ['paths' => [
+            __DIR__ . '/Stub/Plugin/A/views',
+            __DIR__ . '/Stub/Plugin/B/views',
+            __DIR__ . '/Stub/views',
+            __DIR__ . '/Stub/views/..',
+        ]]);
+        $this->app->instance(FilesystemLoader::class, $fsLoader);
+        $this->app->instance(LoaderInterface::class, $fsLoader);
+        $this->parser = $this->app->make(ExtendsTokenParser::class, ['basePath' => __DIR__ . '/Stub']);
+
+        $this->twig = $this->app->make(Twig::class);
+        $this->twig->addTokenParser($this->parser);
+    }
+}

--- a/tests/Unit/Renderer/Stub/Plugin/A/views/inheritance.twig
+++ b/tests/Unit/Renderer/Stub/Plugin/A/views/inheritance.twig
@@ -1,0 +1,5 @@
+{% extends 'inheritance.twig' %}
+
+{% block inherit_me -%}
+    {{ parent() }} - A Content
+{%- endblock %}

--- a/tests/Unit/Renderer/Stub/Plugin/B/views/inheritance.twig
+++ b/tests/Unit/Renderer/Stub/Plugin/B/views/inheritance.twig
@@ -1,0 +1,5 @@
+{% extends 'inheritance.twig' %}
+
+{% block inherit_me -%}
+    {{ parent() }} - B Content
+{%- endblock %}

--- a/tests/Unit/Renderer/Stub/views/extended.twig
+++ b/tests/Unit/Renderer/Stub/views/extended.twig
@@ -1,0 +1,3 @@
+{% block inherit_me -%}
+    Extended template content
+{%- endblock %}

--- a/tests/Unit/Renderer/Stub/views/extends-error.twig
+++ b/tests/Unit/Renderer/Stub/views/extends-error.twig
@@ -1,0 +1,3 @@
+{% macro test() %}
+    {% extends 'inheritance.twig' %}
+{% endmacro %}

--- a/tests/Unit/Renderer/Stub/views/extends.twig
+++ b/tests/Unit/Renderer/Stub/views/extends.twig
@@ -1,0 +1,5 @@
+{% extends 'extended.twig' %}
+
+{% block inherit_me -%}
+    {{ parent() }} - Extends Content
+{%- endblock %}

--- a/tests/Unit/Renderer/Stub/views/inheritance.twig
+++ b/tests/Unit/Renderer/Stub/views/inheritance.twig
@@ -1,0 +1,3 @@
+{% block inherit_me -%}
+    Base template content
+{%- endblock %}

--- a/tests/Unit/Renderer/TwigServiceProviderTest.php
+++ b/tests/Unit/Renderer/TwigServiceProviderTest.php
@@ -14,7 +14,6 @@ use Engelsystem\Test\Unit\ServiceProviderTest;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass as Reflection;
 use ReflectionException;
-use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use Twig\Environment as Twig;
 use Twig\Extension\AbstractExtension;
@@ -30,23 +29,14 @@ class TwigServiceProviderTest extends ServiceProviderTest
      */
     public function testRegister(): void
     {
-        $app = $this->getApp(['make', 'instance', 'tag']);
-        $class = $this->createMock(stdClass::class);
+        $app = $this->getApp(['alias', 'tag']);
 
         $className = 'Foo\Bar\Class';
         $classAlias = 'twig.extension.foo';
 
         $app->expects($this->once())
-            ->method('make')
-            ->with('Foo\Bar\Class')
-            ->willReturn($class);
-
-        $app->expects($this->exactly(2))
-            ->method('instance')
-            ->withConsecutive(
-                [$className, $class],
-                [$classAlias, $class]
-            );
+            ->method('alias')
+            ->with($className, $classAlias);
 
         $app->expects($this->once())
             ->method('tag')

--- a/tests/Unit/Renderer/TwigServiceProviderTest.php
+++ b/tests/Unit/Renderer/TwigServiceProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Engelsystem\Test\Unit\Renderer;
 
 use Engelsystem\Config\Config;
+use Engelsystem\Renderer\ExtendsTokenParser;
 use Engelsystem\Renderer\Twig\Extensions\Develop;
 use Engelsystem\Renderer\TwigEngine;
 use Engelsystem\Renderer\TwigLoader;
@@ -19,6 +20,7 @@ use Twig\Environment as Twig;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension as TwigCore;
 use Twig\Extension\ExtensionInterface as ExtensionInterface;
+use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface as TwigLoaderInterface;
 
 class TwigServiceProviderTest extends ServiceProviderTest
@@ -71,21 +73,22 @@ class TwigServiceProviderTest extends ServiceProviderTest
         $devExtension = $this->createMock(Develop::class);
         /** @var VarDumper|MockObject $dumper */
         $dumper = $this->createMock(VarDumper::class);
+        /** @var FilesystemLoader|MockObject $loader1 */
+        $loader1 = $this->createMock(FilesystemLoader::class);
+        $loader2 = (object) [];
 
-        $app = $this->getApp(['get', 'tagged', 'make']);
-
-        $app->expects($this->exactly(3))
-            ->method('get')
-            ->withConsecutive(['twig.environment'], ['twig.textEnvironment'], ['twig.extension.develop'])
-            ->willReturnOnConsecutiveCalls($twig, $textTwig, $devExtension);
-        $app->expects($this->once())
-            ->method('tagged')
-            ->with('twig.extension')
-            ->willReturn([$firsExtension, $secondExtension]);
-        $app->expects($this->once())
-            ->method('make')
-            ->with(VarDumper::class)
-            ->willReturn($dumper);
+        $this->app->instance('twig.environment', $twig);
+        $this->app->instance('twig.textEnvironment', $textTwig);
+        $this->app->instance('twig.extension.develop', $devExtension);
+        $this->app->instance('a', $firsExtension);
+        $this->app->instance('b', $secondExtension);
+        $this->app->tag(['a', 'b'], 'twig.extension');
+        $this->app->instance('no-dir', '/this-dir-should-not-exist');
+        $this->app->instance('other-dir', __DIR__ . '/Stub/');
+        $this->app->singleton(VarDumper::class, fn () => $dumper);
+        $this->app->instance('l1', $loader1);
+        $this->app->instance('l2', $loader2);
+        $this->app->tag(['l1', 'l2'], 'twig.loader');
 
         $twig->expects($this->exactly(2))
             ->method('addExtension')
@@ -99,7 +102,7 @@ class TwigServiceProviderTest extends ServiceProviderTest
             ->method('setDumper')
             ->with($dumper);
 
-        $serviceProvider = new TwigServiceProvider($app);
+        $serviceProvider = new TwigServiceProvider($this->app);
         $serviceProvider->boot();
     }
 
@@ -132,16 +135,18 @@ class TwigServiceProviderTest extends ServiceProviderTest
         $twigText = $this->createMock(Twig::class);
         /** @var TwigEngine|MockObject $twigTextEngine */
         $twigTextEngine = $this->createMock(TwigEngine::class);
+        /** @var ExtendsTokenParser|MockObject $extendsTokenParser */
+        $extendsTokenParser = $this->createMock(ExtendsTokenParser::class);
 
         $app = $this->getApp(['make', 'instance', 'tag', 'get']);
 
         $viewsPath = __DIR__ . '/Stub';
 
-        $app->expects($this->exactly(6))
+        $app->expects($this->exactly(7))
             ->method('make')
             ->withConsecutive(
-                [TwigLoader::class, ['paths' => $viewsPath]],
-                [TwigTextLoader::class, ['paths' => $viewsPath]],
+                [TwigLoader::class, ['paths' => [$viewsPath, $viewsPath . '/..']]],
+                [TwigTextLoader::class, ['paths' => [$viewsPath, $viewsPath . '/..']]],
                 [Twig::class, ['options' => [
                     'cache'            => false,
                     'auto_reload'      => true,
@@ -156,20 +161,23 @@ class TwigServiceProviderTest extends ServiceProviderTest
                     'debug'            => true,
                     'autoescape'       => false,
                 ]]],
-                [TwigEngine::class, ['twig' => $twigText]]
+                [TwigEngine::class, ['twig' => $twigText]],
+                [ExtendsTokenParser::class],
             )->willReturnOnConsecutiveCalls(
                 $twigLoader,
                 $twigTextLoader,
                 $twig,
                 $twigEngine,
                 $twigText,
-                $twigTextEngine
+                $twigTextEngine,
+                $extendsTokenParser,
             );
 
-        $app->expects($this->exactly(9))
+        $app->expects($this->exactly(10))
             ->method('instance')
             ->withConsecutive(
                 [TwigLoader::class, $twigLoader],
+                [FilesystemLoader::class, $twigLoader],
                 [TwigLoaderInterface::class, $twigLoader],
                 ['twig.loader', $twigLoader],
                 ['twig.textLoader', $twigTextLoader],
@@ -180,14 +188,16 @@ class TwigServiceProviderTest extends ServiceProviderTest
                 ['renderer.twigTextEngine', $twigTextEngine],
             );
 
-        $app->expects($this->exactly(3))
+        $app->expects($this->exactly(5))
             ->method('get')
-            ->withConsecutive(['path.views'], ['config'], ['path.cache.views'])
-            ->willReturnOnConsecutiveCalls($viewsPath, $config, 'cache/views');
+            ->withConsecutive(['path.views'], ['path.views'], ['config'], ['path.cache.views'], ['path.resources'])
+            ->willReturnOnConsecutiveCalls($viewsPath, $viewsPath, $config, 'cache/views', '/resources');
 
-        $app->expects($this->exactly(2))
+        $app->expects($this->exactly(4))
             ->method('tag')
             ->withConsecutive(
+                ['twig.loader', ['twig.loader']],
+                ['twig.textLoader', ['twig.loader']],
                 ['renderer.twigTextEngine', ['renderer.engine']], // Text goes first to catch .text.twig files
                 ['renderer.twigEngine', ['renderer.engine']],
             );
@@ -201,6 +211,10 @@ class TwigServiceProviderTest extends ServiceProviderTest
             ->method('getExtension')
             ->with(TwigCore::class)
             ->willReturn($twigCore);
+
+        $twig->expects($this->once())
+            ->method('addTokenParser')
+            ->with($extendsTokenParser);
 
         $twigCore->expects($this->once())
             ->method('setTimezone')


### PR DESCRIPTION
* Twig: Overwrite ExtendsTokenParser to allow for multi-inheritance (multiple "base directories" can have the same files that extend each other)
* Simplify twig loading: Defer extension class creation until usage