### PR TITLE
Implement optional user-data sync from OAuth

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -639,6 +639,16 @@ return [
                     'hidden' => true,
                     'default' => false,
                 ],
+                'username_sync_pattern' => [
+                    'type' => 'string',
+                    'hidden' => true,
+                    'default' => '/[^\p{L}\p{N}_.-]/ui',
+                ],
+                'username_sync_replace' => [
+                    'type' => 'string',
+                    'hidden' => true,
+                    'default' => '-',
+                ],
                 'environment' => [
                     'type' => 'select',
                     'hidden' => true,
@@ -779,6 +789,8 @@ return [
                             'first_name' => 'first-name',
                             // Info last name field (optional)
                             'last_name' => 'last-name',
+                            // User-data fields to be updated from OAuth provider on each login (optional)
+                            'sso_fields_to_sync' => ['username', 'email', 'first_name', 'last_name'],
                             // User URL to provider, linked on provider settings page (optional)
                             'url' => '[provider page]',
                             // Whether info attributes are nested arrays (optional)

--- a/resources/lang/de_DE/default.po
+++ b/resources/lang/de_DE/default.po
@@ -1558,6 +1558,9 @@ msgstr "Das %s darf mir E-Mails senden "
 msgid "registration.email_system.info"
 msgstr "Genauere Einstellungen sind in deinem Profil möglich."
 
+msgid "registration.fromsso"
+msgstr "Dieser Wert kommt aus dem SSO und kann nicht geändert werden!"
+
 msgid "settings.profile.email_news"
 msgstr "Benachrichtige mich bei neuen News."
 

--- a/resources/lang/en_US/default.po
+++ b/resources/lang/en_US/default.po
@@ -371,6 +371,9 @@ msgstr "The %s may send me e-mails "
 msgid "registration.email_system.info"
 msgstr "Detailed preferences can be set in your profile."
 
+msgid "registration.fromsso"
+msgstr "This value is kept in sync with SSO and cannot be changed."
+
 msgid "settings.profile.email_news"
 msgstr "Notify me of new news."
 

--- a/resources/views/macros/form.twig
+++ b/resources/views/macros/form.twig
@@ -62,7 +62,7 @@ Renders an input field wrapped in a DIV with mb-3.
                 {% if opt.required_icon|default(false) %}
                     {{ _self.entry_required() }}
                 {% endif %}
-                {% if opt.info is defined %}
+                {% if opt.info is defined and opt.info != null %}
                     {{ _self.info(opt.info) }}
                 {% endif %}
                 {% if opt.warning is defined %}

--- a/resources/views/pages/registration.twig
+++ b/resources/views/pages/registration.twig
@@ -4,6 +4,11 @@
 
 {% block title %}{{ __('registration.title') }}{% endblock %}
 
+{% set ssoSyncUserName  = f.formData('sso-sync-username', false) %}
+{% set ssoSyncEMail     = f.formData('sso-sync-email', false) %}
+{% set ssoSyncFirstName = f.formData('sso-sync-first_name', false) %}
+{% set ssoSyncLastName  = f.formData('sso-sync-last_name', false) %}
+
 {% block content %}
 <div class="container">
     <div class="mb-5">
@@ -37,7 +42,8 @@
                 {% endif %}
 
                 <div class="col-md-6">
-                    {{ f.input(
+                    {{
+                        f.input(
                         'username',
                         __('general.nick'),
                         {
@@ -45,7 +51,9 @@
                             'max_length': 24,
                             'required': true,
                             'required_icon': true,
-                            'value': f.formData('username', ''),
+                            'disabled': ssoSyncUserName,
+                            'info': ssoSyncUserName ? __('registration.fromsso') : null,
+                            'value': f.formData('username', '')
                         }
                     ) }}
                 </div>
@@ -86,6 +94,7 @@
                 {% endif %}
 
                 <div class="col-md-6">
+                    
                     {{ f.input(
                         'email',
                         __('general.email'),
@@ -94,7 +103,9 @@
                             'max_length': 254,
                             'required': true,
                             'required_icon': true,
-                            'value': f.formData('email', ''),
+                            'disabled': ssoSyncEMail,
+                            'info': ssoSyncEMail ? __('registration.fromsso') : null,
+                            'value': f.formData('email', '')
                         }
                     ) }}
                 </div>
@@ -167,6 +178,8 @@
                                 'max_length': 64,
                                 'required': isFirstnameRequired,
                                 'required_icon': isFirstnameRequired,
+                                'disabled': ssoSyncFirstName,
+                                'info': ssoSyncFirstName ? __('registration.fromsso') : null,
                                 'value': f.formData('firstname', ''),
                             }
                         ) }}
@@ -180,6 +193,8 @@
                                 'max_length': 64,
                                 'required': isLastnameRequired,
                                 'required_icon': isLastnameRequired,
+                                'disabled': ssoSyncLastName,
+                                'info': ssoSyncLastName ? __('registration.fromsso') : null,
                                 'value': f.formData('lastname', ''),
                             }
                         ) }}

--- a/resources/views/pages/settings/profile.twig
+++ b/resources/views/pages/settings/profile.twig
@@ -21,6 +21,7 @@
                 {{ f.input('nick', __('general.nick'), {
                     'value': userdata.name,
                     'disabled': true,
+                    'info': ssoSyncUserName ? __('registration.fromsso') : null,
                 }) }}
             </div>
             {% if config('enable_pronoun') %}
@@ -44,6 +45,8 @@
                         'max_length': 64,
                         'required': isFirstnameRequired,
                         'required_icon': isFirstnameRequired,
+                        'disabled': ssoSyncFirstName,
+                        'info': ssoSyncFirstName ? __('registration.fromsso') : null,
                     }) }}
                 </div>
                 <div class="col-sm-6">
@@ -52,6 +55,8 @@
                         'max_length': 64,
                         'required': isLastnameRequired,
                         'required_icon': isLastnameRequired,
+                        'disabled': ssoSyncLastName,
+                        'info': ssoSyncLastName ? __('registration.fromsso') : null,
                     }) }}
                 </div>
             </div>
@@ -116,6 +121,8 @@
                     'max_length': 254,
                     'required': true,
                     'required_icon': true,
+                    'disabled': ssoSyncEMail,
+                    'info': ssoSyncEMail ? __('registration.fromsso') : null,
                 }) }}
             </div>
 

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -13,6 +13,7 @@ use Engelsystem\Http\Request;
 use Engelsystem\Http\Response;
 use Engelsystem\Http\UrlGenerator;
 use Engelsystem\Models\OAuth;
+use Engelsystem\Models\User\User;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -38,6 +39,93 @@ class OAuthController extends BaseController
         protected Session $session,
         protected UrlGenerator $url
     ) {
+    }
+
+    /**
+     * Apply optional username transformation to make usernames from OAuth provider
+     * compatible with username requirements.
+     *
+     * @param string $username The original (non-transformed) OAuth username
+     * @return string The length-capped and transformed username
+     */
+    private function transformUserName(string $username): string
+    {
+        $pattern = $this->config->get('username_sync_pattern', null);
+        $replace = $this->config->get('username_sync_replace', null);
+
+        if ($pattern !== null && $replace !== null) {
+            $username = preg_replace($pattern, $replace, $username);
+        } elseif ($pattern !== null || $replace !== null) {
+            $this->log->error(
+                'username_sync_pattern or replace is set, but not both. Ignoring transformation.',
+                ['username' => $username, 'pattern' => $pattern, 'replace' => $replace]
+            );
+        }
+
+        return substr($username, 0, 24);
+    }
+
+    private function checkForUpdate(
+        User $user,
+        array $config,
+        string $key,
+        string|null $currentValue,
+        Collection $userdata,
+        mixed $transformer = null
+    ): mixed {
+        if (in_array($key, $config['sso_fields_to_sync'] ?? [])) {
+            if (!$userdata->has($config[$key])) {
+                $this->log->error(
+                    'Cannot update {key} for user ID {id}: SSO field missing - fix your SSO config!',
+                    [
+                        'key' => $key,
+                        'id' => $user->id,
+                    ]
+                );
+
+                return [$currentValue, false];
+            }
+
+            $rawNewValue = $userdata[$config[$key]];
+            $newValue = $transformer ? $transformer($rawNewValue) : $rawNewValue;
+
+            if ($currentValue != $newValue) {
+                $this->log->info(
+                    'Updating {key} for user ID {id} from {old} to {new} via SSO sync',
+                    [
+                        'key' => $key,
+                        'id' => $user->id,
+                        'old' => $currentValue,
+                        'new' => $newValue,
+                    ]
+                );
+
+                return [$newValue, true];
+            }
+        }
+        return [$currentValue, false];
+    }
+
+    private function updateUserDataFromSSO(User $user, array $config, Collection $userdata): void
+    {
+        [$user->name, $nameUpdated] =
+            $this->checkForUpdate($user, $config, 'username', $user->name, $userdata, [$this, 'transformUserName']);
+
+        [$user->email, $emailUpdated] = $this->checkForUpdate($user, $config, 'email', $user->email, $userdata);
+
+        [$user->personalData->first_name, $firstNameUpdated] =
+            $this->checkForUpdate($user, $config, 'first_name', $user->personalData->first_name, $userdata);
+
+        [$user->personalData->last_name, $lastNameUpdated] =
+            $this->checkForUpdate($user, $config, 'last_name', $user->personalData->last_name, $userdata);
+
+        if ($nameUpdated || $emailUpdated) {
+            $user->save();
+        }
+
+        if ($firstNameUpdated || $lastNameUpdated) {
+            $user->personalData->save();
+        }
     }
 
     public function index(Request $request): Response
@@ -185,6 +273,7 @@ class OAuthController extends BaseController
             $this->handleArrive($providerName, $oauth, $resourceOwner);
         }
 
+        $this->updateUserDataFromSSO($oauth->user, $config, $userdata);
         $response = $this->authController->loginUser($oauth->user);
         event('oauth2.login', ['provider' => $providerName, 'data' => $userdata]);
 
@@ -321,13 +410,14 @@ class OAuthController extends BaseController
     ): Response {
         $config = array_merge(
             [
-                'username'           => null,
-                'email'              => null,
-                'first_name'         => null,
-                'last_name'          => null,
-                'enable_password'    => false,
-                'allow_registration' => null,
-                'groups'             => null,
+                'username'             => null,
+                'email'                => null,
+                'first_name'           => null,
+                'last_name'            => null,
+                'enable_password'      => false,
+                'allow_registration'   => null,
+                'groups'               => null,
+                'sso_fields_to_sync'   => [],
             ],
             $config
         );
@@ -337,10 +427,31 @@ class OAuthController extends BaseController
         }
 
         // Set registration form field data
-        $this->session->set('form-data-username', $userdata->get($config['username']));
+        $username = $this->transformUserName($userdata->get($config['username']));
+        $this->session->set('form-data-username', $username);
+
         $this->session->set('form-data-email', $userdata->get($config['email']));
         $this->session->set('form-data-firstname', $userdata->get($config['first_name']));
         $this->session->set('form-data-lastname', $userdata->get($config['last_name']));
+
+        // Additionally keep user information from SSO in session
+        $fieldsToSync = $config['sso_fields_to_sync'] ?? [];
+        foreach (['username', 'email', 'first_name', 'last_name'] as $field) {
+            $this->session->set('form-data-sso-sync-' . $field, in_array($field, $fieldsToSync));
+        }
+
+        if (in_array('username', $fieldsToSync)) {
+            $this->session->set('oauth2_data_username', $username);
+        }
+        if (in_array('email', $fieldsToSync)) {
+            $this->session->set('oauth2_data_email', $userdata->get($config['email']));
+        }
+        if (in_array('first_name', $fieldsToSync)) {
+            $this->session->set('oauth2_data_firstname', $userdata->get($config['first_name']));
+        }
+        if (in_array('last_name', $fieldsToSync)) {
+            $this->session->set('oauth2_data_lastname', $userdata->get($config['last_name']));
+        }
 
         // Define OAuth state
         $this->session->set('oauth2_groups', $userdata->get($config['groups'], []));

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -56,6 +56,10 @@ class SettingsController extends BaseController
                 'isTShirtSizeRequired' => in_array('tshirt_size', $requiredFields),
                 'isMobileRequired' => in_array('mobile', $requiredFields),
                 'isDectRequired' => in_array('dect', $requiredFields),
+                'ssoSyncUserName' => $this->isFromSso('username'),
+                'ssoSyncEMail' => $this->isFromSso('email'),
+                'ssoSyncFirstName' => $this->isFromSso('first_name'),
+                'ssoSyncLastName' => $this->isFromSso('last_name'),
             ]
         );
     }
@@ -73,8 +77,12 @@ class SettingsController extends BaseController
         }
 
         if (config('enable_full_name')) {
-            $user->personalData->first_name = $data['first_name'];
-            $user->personalData->last_name = $data['last_name'];
+            if (!$this->isFromSso('first_name')) {
+                $user->personalData->first_name = $data['first_name'];
+            }
+            if (!$this->isFromSso('last_name')) {
+                $user->personalData->last_name = $data['last_name'];
+            }
         }
 
         if (config('enable_planned_arrival')) {
@@ -100,7 +108,10 @@ class SettingsController extends BaseController
             $user->settings->mobile_show = $data['mobile_show'] ?: false;
         }
 
-        $user->email = $data['email'];
+        if (!$this->isFromSso('email')) {
+            $user->email = $data['email'];
+        }
+
         $user->settings->email_shiftinfo = $data['email_shiftinfo'] ?: false;
         $user->settings->email_news = $data['email_news'] ?: false;
         $user->settings->email_human = $data['email_human'] ?: false;
@@ -442,10 +453,27 @@ class SettingsController extends BaseController
         })->isNotEmpty();
     }
 
-    private function isRequired(string $key): string
+    private function isRequired(string $key): bool
     {
         $requiredFields = $this->config->get('required_user_fields');
-        return in_array($key, $requiredFields) ? 'required' : 'optional';
+        return in_array($key, $requiredFields);
+    }
+
+    private function isFromSso(string $key): bool
+    {
+        $fromSso = false;
+
+        foreach ($this->auth->user()->oauth as $oauth) {
+            $config = config('oauth')[$oauth->provider] ?? [];
+            $fromSso = $fromSso || in_array($key, $config['sso_fields_to_sync'] ?? []);
+        }
+
+        return $fromSso;
+    }
+
+    private function reqStr(bool $isRequired): string
+    {
+        return $isRequired ? 'required' : 'optional';
     }
 
     /**
@@ -454,27 +482,30 @@ class SettingsController extends BaseController
     private function getSaveProfileRules(User $user): array
     {
         $goodie_tshirt = $this->config->get('goodie_type') === GoodieType::Tshirt->value;
+        $firstNameReqStr = $this->reqStr(!$this->isFromSso('first_name') && $this->isRequired('firstname'));
+        $lastNameReqStr = $this->reqStr(!$this->isFromSso('last_name') && $this->isRequired('lastname'));
         $rules = [
-            'pronoun' => $this->isRequired('pronoun') . '|max:15',
-            'first_name' => $this->isRequired('firstname') . '|max:64',
-            'last_name' => $this->isRequired('lastname') . '|max:64',
-            'dect' => $this->isRequired('dect') . '|length:0:40',
+            'pronoun' => $this->reqStr($this->isRequired('pronoun')) . '|max:15',
+            'first_name' => $firstNameReqStr . '|max:64',
+            'last_name' => $lastNameReqStr . '|max:64',
+            'dect' => $this->reqStr($this->isRequired('dect')) . '|length:0:40',
             // dect/mobile can be purely numbers. "max" would have checked their values, not their character length.
-            'mobile' => $this->isRequired('mobile') . '|length:0:40',
+            'mobile' => $this->reqStr($this->isRequired('mobile')) . '|length:0:40',
             'mobile_show' => 'optional|checked',
-            'email' => 'required|email|max:254',
+            'email' => $this->reqStr(!$this->isFromSso('email')) . '|email|max:254',
             'email_shiftinfo' => 'optional|checked',
             'email_news' => 'optional|checked',
             'email_human' => 'optional|checked',
             'email_messages' => 'optional|checked',
             'email_goodie' => 'optional|checked',
         ];
+
         if (config('enable_planned_arrival')) {
             $rules['planned_arrival_date'] = 'required|date:Y-m-d';
             $rules['planned_departure_date'] = 'optional|date:Y-m-d';
         }
         if ($goodie_tshirt && !$user->state->got_goodie) {
-            $rules['shirt_size'] = $this->isRequired('tshirt_size') . '|shirt_size';
+            $rules['shirt_size'] = $this->reqStr($this->isRequired('tshirt_size')) . '|shirt_size';
         }
         return $rules;
     }

--- a/tests/Unit/Controllers/OAuthControllerTest.php
+++ b/tests/Unit/Controllers/OAuthControllerTest.php
@@ -18,6 +18,7 @@ use Engelsystem\Models\OAuth;
 use Engelsystem\Models\User\User;
 use Engelsystem\Test\Unit\HasDatabase;
 use Engelsystem\Test\Unit\TestCase;
+use Illuminate\Support\Collection;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
@@ -27,6 +28,7 @@ use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\Test\TestLogger;
+use ReflectionClass;
 use Symfony\Component\HttpFoundation\Session\Session as Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
@@ -41,6 +43,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 #[CoversMethod(OAuthController::class, 'requireProvider')]
 #[CoversMethod(OAuthController::class, 'isValidProvider')]
 #[CoversMethod(OAuthController::class, 'disconnect')]
+#[CoversMethod(OAuthController::class, 'transformUserName')]
+#[CoversMethod(OAuthController::class, 'updateUserDataFromSSO')]
 #[AllowMockObjectsWithoutExpectations]
 class OAuthControllerTest extends TestCase
 {
@@ -181,6 +185,290 @@ class OAuthControllerTest extends TestCase
         $controller->index($request);
         $this->assertTrue((bool) User::find(1)->state->arrived);
         $this->assertFalse($this->log->hasInfoThatContains('as arrived'));
+    }
+
+    /**
+     * Helper method to invoke private methods using reflection
+     */
+    private function invokePrivateMethod(object $object, string $methodName, array $args = []): mixed
+    {
+        $reflection = new ReflectionClass($object);
+        $method = $reflection->getMethod($methodName);
+        return $method->invokeArgs($object, $args);
+    }
+
+    /**
+     * Helper method to create OAuthController with custom config
+     */
+    private function createControllerWithConfig(array $config): OAuthController
+    {
+        $fullConfig = array_merge(['oauth' => $this->oauthConfig], $config);
+        return new OAuthController(
+            $this->auth,
+            $this->authController,
+            new Config($fullConfig),
+            $this->log,
+            $this->oauth,
+            $this->redirect,
+            $this->session,
+            $this->url,
+        );
+    }
+
+    /**
+     * Helper method to create a user with personal data for SSO tests
+     */
+    private function createUserWithPersonalData(): User
+    {
+        $userData = $this->getInitialUserData();
+
+        $user = User::factory()->create([
+            'name' => $userData['username'],
+            'email' => $userData['email'],
+        ]);
+
+        $user->personalData()->create([
+            'first_name' => $userData['first_name'],
+            'last_name' => $userData['last_name'],
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * @return array Of test user data - names reflect the internal naming.
+     */
+    private function getInitialUserData(): array
+    {
+        return [
+            'username' => 'testuser',
+            'email' => 'test@example.com',
+            'first_name' => 'Test',
+            'last_name' => 'User',
+        ];
+    }
+
+    /**
+     * @return array Of "new" user data as OAuth would - names reflect the SSO naming scheme.
+     */
+    private function getUpdatedSsoUserData(array $missingFields): array
+    {
+        $data = [
+            'name' => 'updateduser',
+            'mail' => 'updated@example.com',
+            'given_name' => 'UpdatedFirst',
+            'family_name' => 'UpdatedLast',
+        ];
+        return array_diff_key($data, array_flip($missingFields));
+    }
+
+    private function getOAuthConfig(array $customConfig = []): array
+    {
+        return array_merge([
+            'username' => 'name',
+            'email' => 'mail',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'sso_fields_to_sync' => [],
+        ], $customConfig);
+    }
+
+    /**
+     * Helper method to test transformUserName with given parameters
+     */
+    private function assertTransformUserName(OAuthController $controller, string $input, string $expected): void
+    {
+        $result = $this->invokePrivateMethod($controller, 'transformUserName', [$input]);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testTransformUserNameWithoutPattern(): void
+    {
+        $controller = $this->getMock();
+
+        // Test without pattern/replace config
+        $this->assertTransformUserName($controller, 'john.doe@example.com', 'john.doe@example.com');
+
+        // Test with long username (should truncate to 24 chars)
+        $longUsername = 'this_is_a_very_long_username_that_exceeds_24_characters';
+        $result = $this->invokePrivateMethod($controller, 'transformUserName', [$longUsername]);
+        $this->assertEquals('this_is_a_very_long_user', $result);
+        $this->assertEquals(24, strlen($result));
+    }
+
+    public function testTransformUserNameWithPattern(): void
+    {
+        $controller = $this->createControllerWithConfig([
+            'username_sync_pattern' => '/@.*$/',
+            'username_sync_replace' => '',
+        ]);
+
+        // Test email transformation (remove domain)
+        $this->assertTransformUserName($controller, 'john.doe@example.com', 'john.doe');
+
+        // Test username without @ symbol
+        $this->assertTransformUserName($controller, 'johndoe', 'johndoe');
+    }
+
+    public function testTransformUserNameWithComplexPattern(): void
+    {
+        $controller = $this->createControllerWithConfig([
+            'username_sync_pattern' => '/[^a-zA-Z0-9._-]/',
+            'username_sync_replace' => '_',
+        ]);
+
+        // Test special character replacement
+        $this->assertTransformUserName($controller, 'john doe@#%', 'john_doe___');
+
+        // Test already valid username
+        $this->assertTransformUserName($controller, 'john.doe-123', 'john.doe-123');
+    }
+
+
+    private function testUpdateUserDataFromSSO(array $fields, array $missingSsoFields = []): void
+    {
+        $user = $this->createUserWithPersonalData();
+        $config = $this->getOAuthConfig(['sso_fields_to_sync' => $fields]);
+
+        $oldUserData = $this->getInitialUserData();
+        $ssoData = $this->getUpdatedSsoUserData($missingSsoFields);
+
+        $expectedUserData = $oldUserData;
+        foreach ($fields as $field) {
+            if (!in_array($config[$field], $missingSsoFields)) {
+                $expectedUserData[$field] = $ssoData[$config[$field]];
+            }
+        }
+
+
+        $controller = $this->getMock();
+
+        // Reset log to have clean state for this test
+        $this->log->reset();
+
+        $this->invokePrivateMethod($controller, 'updateUserDataFromSSO', [$user, $config, new Collection($ssoData)]);
+
+        $user->refresh();
+        $user->personalData->refresh();
+
+        foreach ($expectedUserData as $field => $expectedValue) {
+            if (in_array($field, ['first_name', 'last_name'])) {
+                $this->assertEquals(
+                    $expectedValue,
+                    $user->personalData->$field,
+                    'Personal data field ' . $field . " should be '" . $expectedValue . "'"
+                );
+            } else {
+                // The config 'username' field is mapped to User's 'name'
+                if (in_array($field, ['username'])) {
+                    $field = 'name';
+                }
+
+                $this->assertEquals(
+                    $expectedValue,
+                    $user->$field,
+                    "User's " . $field . " should be '" . $expectedValue . "'"
+                );
+            }
+        }
+
+        foreach (array_diff_key($this->getOAuthConfig(), ['sso_fields_to_sync' => []]) as $configKey => $ssoKey) {
+            // Check if there was an error log entry in case the SSO field is missing,
+            // and verify there is no log entry otherwise
+            $logHasMissingFieldError = $this->log->hasError([
+                'message' => 'Cannot update {key} for user ID {id}: SSO field missing - fix your SSO config!',
+                'context' => [
+                    'key' => $configKey,
+                    'id' => $user->id,
+                ],
+            ]);
+
+            $expectMissingFieldError = in_array($configKey, $config['sso_fields_to_sync'] ?? [])
+                && in_array($ssoKey, $missingSsoFields);
+
+            if ($expectMissingFieldError) {
+                $this->assertTrue(
+                    $logHasMissingFieldError,
+                    'Should have an error message for missing SSO field ' . $ssoKey
+                );
+            } else {
+                $this->assertFalse(
+                    $logHasMissingFieldError,
+                    'Should not have an error message for non-missing SSO field ' . $ssoKey
+                );
+            }
+
+            // Check if there was an info log entry in case the user data was updated,
+            // and verify there is no log entry otherwise
+            $logHasUpdateInfo = $this->log->hasInfo([
+                'message' => 'Updating {key} for user ID {id} from {old} to {new} via SSO sync',
+                'context' => [
+                    'key' => $configKey,
+                    'id' => $user->id,
+                    'old' => $oldUserData[$configKey],
+                    'new' => $expectedUserData[$configKey] ?? null,
+                ],
+            ]);
+
+            $expectUpdateInfo = in_array($configKey, $config['sso_fields_to_sync'] ?? [])
+                && !in_array($ssoKey, $missingSsoFields)
+                && $oldUserData[$configKey] != $ssoData[$ssoKey];
+
+            if ($expectUpdateInfo) {
+                $this->assertTrue(
+                    $logHasUpdateInfo,
+                    'Should have an info message for updated SSO field ' . $ssoKey
+                );
+            } else {
+                $this->assertFalse(
+                    $logHasUpdateInfo,
+                    'Should not have an info message for non-updated SSO field ' . $ssoKey
+                );
+            }
+        }
+    }
+
+    public function testUpdateUserDataFromSSOWithEmailSync(): void
+    {
+        $this->testUpdateUserDataFromSSO(['email']);
+    }
+
+    public function testUpdateUserDataFromSSOWithUserNameSync(): void
+    {
+        $this->testUpdateUserDataFromSSO(['username']);
+    }
+
+    public function testUpdateUserDataFromSSOWithFirstNameSync(): void
+    {
+        $this->testUpdateUserDataFromSSO(['first_name']);
+    }
+
+    public function testUpdateUserDataFromSSOWithLastNameSync(): void
+    {
+        $this->testUpdateUserDataFromSSO(['last_name']);
+    }
+
+    public function testUpdateUserDataFromSSOForAllFields(): void
+    {
+        $this->testUpdateUserDataFromSSO(['first_name', 'last_name', 'email', 'username']);
+    }
+
+    public function testUpdateUserDataFromSSOForNoFields(): void
+    {
+        $this->testUpdateUserDataFromSSO([]);
+    }
+
+    public function testUpdateUserDataFromSSOForAllFieldsMissingLastName(): void
+    {
+        $this->testUpdateUserDataFromSSO(['first_name', 'last_name', 'email', 'username'], ['family_name']);
+    }
+
+    public function testUpdateUserDataFromSSOForAllFieldsMissingAllFields(): void
+    {
+        $this->testUpdateUserDataFromSSO(
+            ['first_name', 'last_name', 'email', 'username'],
+            ['given_name', 'family_name', 'mail', 'name']
+        );
     }
 
     public function testIndexRedirectToProvider(): void


### PR DESCRIPTION
This PR enables syncing several user-data fields (nickname, mail, first name, last name) with values from an OAuth-providers on each login.

Enabling this feature for a field prevents the user from modifying the field "by hand".