### PR TITLE
Show number of member per angeltype on AngelType overview

### DIFF
--- a/includes/controller/angeltypes_controller.php
+++ b/includes/controller/angeltypes_controller.php
@@ -348,9 +348,13 @@ function angeltypes_list_controller()
         $angeltype->actions = table_buttons($actions);
     }
 
+    /** @var UserAngelType $user_angeltype */
+    $user_angeltype = UserAngelType::whereUserId($user->id)->where('angel_type_id', $angeltype->id)->first();
+    $isSupporter = !is_null($user_angeltype) && $user_angeltype->supporter;
+
     return [
         angeltypes_title(),
-        AngelTypes_list_view($angeltypes, auth()->can('admin_angel_types')),
+        AngelTypes_list_view($angeltypes, auth()->can('admin_angel_types'), auth()->can('admin_user_angeltypes') || $isSupporter),
     ];
 }
 
@@ -384,16 +388,27 @@ function AngelType_validate_name($name, AngelType $angeltype)
  */
 function AngelTypes_with_user($userId): Collection
 {
+    $countsQuery = UserAngelType::query()
+        ->select('angel_type_id')
+        ->selectRaw('COUNT(*) AS member_count')
+        ->selectRaw('SUM(CASE WHEN confirm_user_id IS NULL THEN 1 ELSE 0 END) AS pending_count')
+        ->groupBy('angel_type_id');
+
     return AngelType::query()
         ->select([
             'angel_types.*',
             'user_angel_type.id AS user_angel_type_id',
             'user_angel_type.confirm_user_id',
             'user_angel_type.supporter',
+            'counts.member_count',
+            'counts.pending_count',
         ])
+        ->selectRaw('COALESCE(counts.member_count, 0) - (CASE WHEN angel_types.restricted THEN COALESCE(counts.pending_count, 0) ELSE 0 END) AS member_count')
+        ->selectRaw('CASE WHEN angel_types.restricted THEN COALESCE(counts.pending_count, 0) ELSE 0 END AS pending_count')
         ->leftJoin('user_angel_type', function (JoinClause $join) use ($userId) {
             $join->on('angel_types.id', 'user_angel_type.angel_type_id');
             $join->where('user_angel_type.user_id', $userId);
         })
+        ->leftJoinSub($countsQuery, 'counts', 'angel_types.id', 'counts.angel_type_id')
         ->get();
 }

--- a/includes/view/AngelTypes_view.php
+++ b/includes/view/AngelTypes_view.php
@@ -786,7 +786,7 @@ function AngelTypes_render_contact_info(AngelType $angeltype)
  * @param bool $admin_angeltypes
  * @return string
  */
-function AngelTypes_list_view($angeltypes, bool $admin_angeltypes)
+function AngelTypes_list_view($angeltypes, bool $admin_angeltypes, bool $admin_user_angeltypes)
 {
     $add = button(
         url('/angeltypes', ['action' => 'edit']),
@@ -795,6 +795,19 @@ function AngelTypes_list_view($angeltypes, bool $admin_angeltypes)
         '',
         __('general.add')
     );
+
+    $tableColumns = [
+                'name' => __('general.name'),
+                'member_count' => icon('people-fill') . ' ' . __('Members'),
+    ] +
+    ($admin_user_angeltypes ? ['pending_count' => icon('hourglass-split') . ' ' . __('Unconfirmed')] : [])
+     + [
+                'is_restricted' => icon('mortarboard-fill') . __('angeltypes.restricted'),
+                'shift_self_signup_allowed' => icon('pencil-square') . __('shift.self_signup.allowed'),
+                'membership' => __('Membership'),
+                'actions' => '',
+            ];
+
     return page_with_title(
         angeltypes_title() . ' ' . ($admin_angeltypes ? $add : ''),
         [
@@ -802,13 +815,7 @@ function AngelTypes_list_view($angeltypes, bool $admin_angeltypes)
             buttons([
                 button(url('/angeltypes/about'), __('angeltypes.about')),
             ]),
-            table([
-                'name' => __('general.name'),
-                'is_restricted' => icon('mortarboard-fill') . __('angeltypes.restricted'),
-                'shift_self_signup_allowed' => icon('pencil-square') . __('shift.self_signup.allowed'),
-                'membership' => __('Membership'),
-                'actions' => '',
-            ], $angeltypes),
+            table($tableColumns, $angeltypes),
         ],
         true,
     );


### PR DESCRIPTION
This PR includes two new columns in the Angel types overview: The number of already confirmed angels in each type and (depending on the users permissions) the number of unconfirmed angels.