### PR TITLE
feat: Compact user shift calender with date lane

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -272,6 +272,10 @@ return [
                     'type' => 'boolean',
                     'default' => true,
                 ],
+                'shift_view.enable_compact_view' => [
+                    'type' => 'boolean',
+                    'default' => false,
+                ],
             ],
         ],
 

--- a/config/app.php
+++ b/config/app.php
@@ -276,6 +276,10 @@ return [
                     'type' => 'boolean',
                     'default' => false,
                 ],
+                'shift_view.enable_date_lane' => [
+                    'type' => 'boolean',
+                    'default' => false,
+                ],
             ],
         ],
 

--- a/includes/sys_template.php
+++ b/includes/sys_template.php
@@ -137,13 +137,13 @@ function icon_bool($boolean)
  * @param string $dom_id
  * @return string
  */
-function div($class, $content = [], $dom_id = '')
+function div($class, $content = [], $dom_id = '', $plainTag = '')
 {
     if (is_array($content)) {
         $content = join("\n", $content);
     }
     $dom_id = $dom_id != '' ? ' id="' . $dom_id . '"' : '';
-    return '<div' . $dom_id . ' class="' . $class . '">' . $content . '</div>';
+    return '<div' . $dom_id . ' class="' . $class . '"' . ($plainTag != '' ? ' ' . $plainTag : '') . '>' . $content . '</div>';
 }
 
 /**

--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -245,10 +245,16 @@ class ShiftCalendarRenderer
             return info(__('No shifts found.'), true);
         }
 
-        return div('shift-calendar table-responsive', [
-                $this->renderTimeLane(),
-                $this->renderShiftLanes(),
-            ]) . $this->renderLegend();
+        $lanes = [];
+
+        if (config('shift_view.enable_date_lane')) {
+            $lanes[] = $this->renderDateLane();
+        }
+
+        $lanes[] = $this->renderTimeLane();
+        $lanes[] = $this->renderShiftLanes();
+
+        return div('shift-calendar table-responsive', $lanes) . $this->renderLegend();
     }
 
     /**
@@ -416,6 +422,54 @@ class ShiftCalendarRenderer
             return $startOfDay <= $thistimeCarbon && $thistimeCarbon < $endOfDay;
         }
         return false;
+    }
+
+    /**
+     * Renders the left date lane
+     *
+     * @return string
+     */
+    private function renderDateLane()
+    {
+        $bg = 'bg-' . theme_type();
+
+        $time_slot = [
+            div('header ' . $bg, []),
+        ];
+
+        $startTime = $this->calendarStart->clone();
+        $endDate = $this->getDateStr($this->calendarEnd);
+
+        $first = true;
+        $current_time = $startTime;
+        do {
+            $day = $this->getDateStr($current_time);
+            list($startOfDay, $endOfDay) = $this->getStartAndEnd($current_time);
+
+            if ($startOfDay != null) {
+                if ($first) {
+                    $startOfDay = $startTime;
+                    $first = false;
+                }
+                $minutesPerRow = ShiftCalendarRenderer::SECONDS_PER_ROW / 60;
+                $num_rows = $startOfDay->floorMinute($minutesPerRow)->diffInSeconds($endOfDay->ceilMinute($minutesPerRow)) / ShiftCalendarRenderer::SECONDS_PER_ROW;
+
+                $time_slot[] = $this->renderDayTick($startOfDay, $num_rows);
+            }
+
+            $current_time->addDay();
+        } while ($day != $endDate);
+
+        return div('lane date', $time_slot);
+    }
+
+    private function renderDayTick($time, $blocks)
+    {
+        $class = 'dow bg-' . theme_type();
+
+        return div($class, [
+            __($time->format('l')) . ', ' . $time->format(__('m-d')),
+        ], '', 'style="height: ' . ($blocks * 30) . 'px"');
     }
 
     /**

--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -2,7 +2,8 @@
 
 namespace Engelsystem;
 
-use Engelsystem\Helpers\Carbon;
+use Carbon\Carbon;
+use DASPRiD\Enum\Exception\IllegalArgumentException;
 use Engelsystem\Models\AngelType;
 use Engelsystem\Models\Shifts\Shift;
 use Engelsystem\Models\Shifts\ShiftEntry;
@@ -34,17 +35,17 @@ class ShiftCalendarRenderer
     /** @var array */
     private $lanes;
 
-    /** @var ShiftsFilter */
-    private $shiftsFilter;
-
-    /** @var int */
-    private $firstBlockStartTime;
-
-    /** @var int */
-    private $lastBlockEndTime;
-
     /** @var int */
     private $blocksPerSlot = null;
+
+    /** @var array */
+    private $startAndEndPerDay;
+
+    /** @var Carbon */
+    private $calendarStart;
+
+    /** @var Carbon */
+    private $calendarEnd;
 
     /**
      * ShiftCalendarRenderer constructor.
@@ -56,10 +57,16 @@ class ShiftCalendarRenderer
      */
     public function __construct($shifts, private $needed_angeltypes, private $shift_entries, ShiftsFilter $shiftsFilter)
     {
-        $this->shiftsFilter = $shiftsFilter;
-        $this->firstBlockStartTime = $this->calcFirstBlockStartTime($shifts);
-        $this->lastBlockEndTime = $this->calcLastBlockEndTime($shifts);
         $this->lanes = $this->assignShiftsToLanes($shifts);
+
+        if (config('shift_view.enable_compact_view')) {
+            $this->startAndEndPerDay = self::collectStartAndEndPerDay($shifts);
+            list($this->calendarStart, $this->calendarEnd) = $this->getCalendarStartAndEnd();
+        } else {
+            $this->startAndEndPerDay = self::mergeTimeSpanIntoList([], $shiftsFilter->getStart(), $shiftsFilter->getEnd());
+            $this->calendarStart     = $shiftsFilter->getStart();
+            $this->calendarEnd       = $shiftsFilter->getEnd();
+        }
     }
 
     /**
@@ -104,19 +111,116 @@ class ShiftCalendarRenderer
     }
 
     /**
-     * @return int
+     * Merges the provides time range [$start, $end] into a list of existing time spans per day.
+     *
+     * @param Carbon[][] $times  List of existing time spans per day
+     * @param Carbon $start      Start datetime of the to-be-added time span
+     * @param Carbon $end        End datetime of the to-be-added time span
+     * @return Carbon[][]        Modified list of time spans per day
      */
-    public function getFirstBlockStartTime()
+    public static function mergeSingleDayTimeSpanIntoList(array $times, Carbon $start, Carbon $end): array
     {
-        return $this->firstBlockStartTime;
+        $dateStr = self::getDateStr($start);
+        if ($start->dayOfMillennium != $end->dayOfMillennium) {
+            throw new IllegalArgumentException('start and end must be on the same day');
+        }
+
+        if (!array_key_exists($dateStr, $times)) {
+            $times[$dateStr] = [$start, $end];
+        } else {
+            $times[$dateStr][0] = min($times[$dateStr][0], $start);
+            $times[$dateStr][1] = max($times[$dateStr][1], $end);
+        }
+
+        return $times;
     }
 
     /**
-     * @return int
+     * Merges the provides time range [$start, $end] into a list of existing time spans per day.
+     * The provided time range may span multiple days.
+     *
+     * @param Carbon[][] $times  List of existing time spans per day
+     * @param Carbon $start      Start datetime of the to-be-added time span
+     * @param Carbon $end        End datetime of the to-be-added time span
+     * @return Carbon[][]        Modified list of time spans per day
      */
-    public function getLastBlockEndTime()
+    public static function mergeTimeSpanIntoList(array $times, Carbon $start, Carbon $end): array
     {
-        return $this->lastBlockEndTime;
+        if ($start->dayOfMillennium != $end->dayOfMillennium) {
+            // Handle the start day: Start at shift start, end at (roughly) midnight
+            $startDayEnd = $start->clone();
+            $startDayEnd->setTime(23, 59);
+
+            $times = self::mergeSingleDayTimeSpanIntoList($times, $start, $startDayEnd);
+
+            // If a time span spans multiple days, include the whole days between the day start and end
+            $daysBetween = $start->daysUntil($end->clone()->setTimeFrom($start));
+            $daysBetween->excludeStartDate(true);
+            $daysBetween->excludeEndDate(true);
+            foreach ($daysBetween as $date) {
+                $dayStart = $date->clone();
+                $dayStart->minuteOfDay(0);
+
+                $dayEnd = $date->clone();
+                $dayEnd->setTime(23, 59);
+
+                $times = self::mergeSingleDayTimeSpanIntoList($times, $dayStart, $dayEnd);
+            }
+
+            // Handle the end day: Start at midnight, end at the shift end
+            $endDayStart = $end->clone();
+            $endDayStart->minuteOfDay(0);
+
+            $times = self::mergeSingleDayTimeSpanIntoList($times, $endDayStart, $end);
+        } else {
+            // The simple case with a shift starting and ending on the same day
+            $times = self::mergeSingleDayTimeSpanIntoList($times, $start, $end);
+        }
+        return $times;
+    }
+
+    /**
+     * @param Shift[] $shifts The shifts to analyse and assign to days
+     * @return array An array of date => [startdatetime; enddatetime]
+     */
+    public static function collectStartAndEndPerDay($shifts): array
+    {
+        $times = [];
+        foreach ($shifts as $shift) {
+            $times = self::mergeTimeSpanIntoList($times, $shift->start, $shift->end);
+        }
+
+        // extend time spans per day by 30 minutes earlier/later, rounded to 15 minute blocks
+        foreach ($times as $interval) {
+            $startMinOfDay = $interval[0]->minuteOfDay;
+            $interval[0]->minuteOfDay(max(0, $startMinOfDay - 30 - (($startMinOfDay - 30) % 15)));
+
+            $endMinOfDay = $interval[1]->minuteOfDay;
+            $interval[1]->minuteOfDay(min(23 * 60 + 59, $endMinOfDay + 30 + (($endMinOfDay + 30) % 15) - 1));
+        }
+
+        return $times;
+    }
+
+
+    private function getStartAndEnd(Carbon $date): array
+    {
+        $dateStr = self::getDateStr($date);
+        return array_key_exists($dateStr, $this->startAndEndPerDay) ? $this->startAndEndPerDay[$dateStr] : [null, null];
+    }
+
+    private function getCalendarStartAndEnd(): array
+    {
+        $startsAndEnds = array_merge(...array_values($this->startAndEndPerDay));
+        return empty($startsAndEnds) ? [null, null] : [min(...$startsAndEnds), max(...$startsAndEnds)];
+    }
+
+    /**
+     * @return string
+     */
+    private static function getDateStr($carbon)
+    {
+        return sprintf('%04d-%02d-%02d', $carbon->year, $carbon->month, $carbon->day);
     }
 
     /**
@@ -174,11 +278,15 @@ class ShiftCalendarRenderer
     {
         $shift_renderer = new ShiftCalendarShiftRenderer();
         $html = '';
-        $rendered_until = $this->getFirstBlockStartTime();
+        $rendered_until = $this->calendarStart->getTimestamp();
+        $previous_tick = 0;
 
         foreach ($lane->getShifts() as $shift) {
             while ($rendered_until + ShiftCalendarRenderer::SECONDS_PER_ROW <= $shift->start->timestamp) {
-                $html .= $this->renderTick($rendered_until);
+                if ($this->shouldRenderTick($rendered_until)) {
+                    $html .= $this->renderTick($rendered_until, $previous_tick);
+                    $previous_tick = $rendered_until;
+                }
                 $rendered_until += ShiftCalendarRenderer::SECONDS_PER_ROW;
             }
 
@@ -219,8 +327,11 @@ class ShiftCalendarRenderer
             $rendered_until += $shift_height * ShiftCalendarRenderer::SECONDS_PER_ROW;
         }
 
-        while ($rendered_until < $this->getLastBlockEndTime()) {
-            $html .= $this->renderTick($rendered_until);
+        while ($rendered_until < $this->calendarEnd->getTimestamp()) {
+            if ($this->shouldRenderTick($rendered_until)) {
+                $html .= $this->renderTick($rendered_until, $previous_tick);
+                $previous_tick = $rendered_until;
+            }
             $rendered_until += ShiftCalendarRenderer::SECONDS_PER_ROW;
         }
 
@@ -239,8 +350,9 @@ class ShiftCalendarRenderer
      * @param boolean $label Should time labels be generated?
      * @return string rendered tick html
      */
-    private function renderTick($time, $label = false)
+    private function renderTick($time, $previousTickTimestamp, $label = false)
     {
+        $previousTickTime = Carbon::createFromTimestamp($previousTickTimestamp, Carbon::now()->timezone);
         $time = Carbon::createFromTimestamp($time, Carbon::now()->timezone);
         $class = $label ? 'tick bg-' . theme_type() : 'tick ';
 
@@ -249,7 +361,7 @@ class ShiftCalendarRenderer
             $class .= ' now';
         }
 
-        if ($time->isStartOfDay()) {
+        if ($time->isStartOfDay() || $time->dayOfYear != $previousTickTime->dayOfYear) {
             if (!$label) {
                 return div($class . ' day');
             }
@@ -281,48 +393,29 @@ class ShiftCalendarRenderer
                 __('log.time'),
             ]),
         ];
+        $previous_tick = 0;
         for ($block = 0; $block < $this->getBlocksPerSlot(); $block++) {
-            $thistime = $this->getFirstBlockStartTime() + ($block * ShiftCalendarRenderer::SECONDS_PER_ROW);
-            $time_slot[] = $this->renderTick($thistime, true);
+            $thistime = $this->calendarStart->getTimestamp() + ($block * ShiftCalendarRenderer::SECONDS_PER_ROW);
+
+            if ($this->shouldRenderTick($thistime)) {
+                $time_slot[] = $this->renderTick($thistime, $previous_tick, true);
+                $previous_tick = $thistime;
+            }
         }
         return div('lane time', $time_slot);
     }
 
-    /**
-     * @param Shift[] $shifts
-     * @return int
-     */
-    private function calcFirstBlockStartTime($shifts)
+    private function shouldRenderTick($thistime): bool
     {
-        $start_time = $this->shiftsFilter->getEndTime();
-        foreach ($shifts as $shift) {
-            if ($shift->start->timestamp < $start_time) {
-                $start_time = $shift->start->timestamp;
-            }
-        }
-        return ShiftCalendarRenderer::SECONDS_PER_ROW * floor(
-            ($start_time - ShiftCalendarRenderer::TIME_MARGIN)
-                / ShiftCalendarRenderer::SECONDS_PER_ROW
-        );
-    }
+        $thistimeCarbon = Carbon::createFromTimestamp($thistime, Carbon::now()->timezone);
+        $dateStr = $this->getDateStr($thistimeCarbon);
 
-    /**
-     * @param Shift[] $shifts
-     * @return int
-     */
-    private function calcLastBlockEndTime($shifts)
-    {
-        $end_time = $this->shiftsFilter->getStartTime();
-        foreach ($shifts as $shift) {
-            if ($shift->end->timestamp > $end_time) {
-                $end_time = $shift->end->timestamp;
-            }
-        }
+        if (array_key_exists($dateStr, $this->startAndEndPerDay)) {
+            list($startOfDay, $endOfDay) = $this->startAndEndPerDay[$dateStr];
 
-        return ShiftCalendarRenderer::SECONDS_PER_ROW * ceil(
-            ($end_time + ShiftCalendarRenderer::TIME_MARGIN)
-                / ShiftCalendarRenderer::SECONDS_PER_ROW
-        );
+            return $startOfDay <= $thistimeCarbon && $thistimeCarbon < $endOfDay;
+        }
+        return false;
     }
 
     /**
@@ -331,7 +424,7 @@ class ShiftCalendarRenderer
     private function calcBlocksPerSlot()
     {
         return (int) ceil(
-            ($this->getLastBlockEndTime() - $this->getFirstBlockStartTime())
+            ($this->calendarEnd->getTimestamp() - $this->calendarStart->getTimestamp())
             / ShiftCalendarRenderer::SECONDS_PER_ROW
         );
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     <source>
         <include>
             <directory>src</directory>
+            <directory>includes</directory>
         </include>
     </source>
 </phpunit>

--- a/resources/assets/themes/base.scss
+++ b/resources/assets/themes/base.scss
@@ -295,6 +295,17 @@ table.table-sticky-header thead {
       padding: 5px 5px 5px 16px;
     }
 
+    .dow {
+      border-top: 2px solid $primary;
+      writing-mode: sideways-lr;
+      text-align: center;
+      font-size: x-large;
+    }
+
+    .dow.today {
+      background: lighten($table-striped-bg, 25%);
+    }
+
     .tick {
       height: 30px;
       border-top: 1px solid darken($table-striped-bg, 2%);
@@ -317,6 +328,17 @@ table.table-sticky-header thead {
     .tick.now {
       border-top: 2px solid $info;
     }
+  }
+
+  .lane.date {
+    position: sticky;
+    left: 0;
+    z-index: $zindex-sticky + 1;
+    border-right: 1px solid $table-border-color;
+    min-width: max-content;
+    width: max-content;
+    flex-grow: 0;
+    flex-shrink: 0;
   }
 
   .lane.time {

--- a/resources/lang/de_DE/additional.po
+++ b/resources/lang/de_DE/additional.po
@@ -469,6 +469,12 @@ msgstr "Beitreten QR Code"
 msgid "config.join_qr_code.info"
 msgstr "Erlaubt das beitreten zu einem Engeltypen mit einem QR Code, benötigt app_key"
 
+msgid "config.shift_view.enable_compact_view"
+msgstr "Kompakter Schichtkalender"
+
+msgid "config.shift_view.enable_compact_view.info"
+msgstr "Versteckt Zeiten im Schichtkalender, zu denen keine Schichten konfiguriert sind."
+
 msgid "config.certificates"
 msgstr "Zertifikate"
 

--- a/resources/lang/de_DE/additional.po
+++ b/resources/lang/de_DE/additional.po
@@ -475,6 +475,12 @@ msgstr "Kompakter Schichtkalender"
 msgid "config.shift_view.enable_compact_view.info"
 msgstr "Versteckt Zeiten im Schichtkalender, zu denen keine Schichten konfiguriert sind."
 
+msgid "config.shift_view.enable_date_lane"
+msgstr "Dedizierte Datumsspalte im Schichtkalender"
+
+msgid "config.shift_view.enable_date_lane.info"
+msgstr "Zeigt zusätzlich Datum und Tag der Woche an."
+
 msgid "config.certificates"
 msgstr "Zertifikate"
 
@@ -776,3 +782,24 @@ msgstr "Plugin erfolgreich aktiviert"
 
 msgid "plugin.disable.success"
 msgstr "Plugin erfolgreich deaktiviert"
+
+msgid "Monday"
+msgstr "Montag"
+
+msgid "Tuesday"
+msgstr "Dienstag"
+
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+msgid "Thursday"
+msgstr "Donnerstag"
+
+msgid "Friday"
+msgstr "Freitag"
+
+msgid "Saturday"
+msgstr "Samstag"
+
+msgid "Sunday"
+msgstr "Sonntag"

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -468,6 +468,12 @@ msgstr "Join QR code"
 msgid "config.join_qr_code.info"
 msgstr "Allow joining an angel type via generated QR code, requires app_key"
 
+msgid "config.shift_view.enable_compact_view"
+msgstr "Compact shift view"
+
+msgid "config.shift_view.enable_compact_view.info"
+msgstr "Limits the shift calendar to times with shifts."
+
 msgid "config.certificates"
 msgstr "Certificates"
 

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -474,6 +474,12 @@ msgstr "Compact shift view"
 msgid "config.shift_view.enable_compact_view.info"
 msgstr "Limits the shift calendar to times with shifts."
 
+msgid "config.shift_view.enable_date_lane"
+msgstr "Dedicated date lane in the shift calendar"
+
+msgid "config.shift_view.enable_date_lane.info"
+msgstr "Shows a date and day of week in an additional lane."
+
 msgid "config.certificates"
 msgstr "Certificates"
 
@@ -879,3 +885,24 @@ msgstr "Plugin enabled successfully"
 
 msgid "plugin.disable.success"
 msgstr "Plugin disabled successfully"
+
+msgid "Monday"
+msgstr "Monday"
+
+msgid "Tuesday"
+msgstr "Tuesday"
+
+msgid "Wednesday"
+msgstr "Wednesday"
+
+msgid "Thursday"
+msgstr "Thursday"
+
+msgid "Friday"
+msgstr "Friday"
+
+msgid "Saturday"
+msgstr "Saturday"
+
+msgid "Sunday"
+msgstr "Sunday"

--- a/tests/Unit/Helpers/ShiftCalendarRendererTest.php
+++ b/tests/Unit/Helpers/ShiftCalendarRendererTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Engelsystem\Test\Unit;
+
+use Carbon\Carbon;
+use Engelsystem\Models\Location;
+use Engelsystem\Models\Shifts\Shift;
+use Engelsystem\Models\Shifts\ShiftType;
+use Engelsystem\ShiftCalendarRenderer;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+#[CoversMethod(ShiftCalendarRenderer::class, 'mergeTimeSpanIntoList')]
+#[CoversMethod(ShiftCalendarRenderer::class, 'collectStartAndEndPerDay')]
+class ShiftCalendarRendererTest extends TestCase
+{
+    public function testMergeTimeSpanIntoListNewDate(): void
+    {
+        $times = [];
+        $start = Carbon::create(2026, 1, 24, 10, 0);
+        $end   = Carbon::create(2026, 1, 24, 12, 0);
+
+        $result = ShiftCalendarRenderer::mergeTimeSpanIntoList($times, $start, $end);
+
+        $this->assertEquals($result, ['2026-01-24' => [$start, $end]]);
+    }
+
+    public function testMergeTimeSpanIntoListExtendEarlier(): void
+    {
+        $existingStart = Carbon::create(2026, 1, 24, 10, 0);
+        $existingEnd   = Carbon::create(2026, 1, 24, 12, 0);
+        $times = ['2026-01-24' => [$existingStart, $existingEnd]];
+
+        $newStart = Carbon::create(2026, 1, 24, 8, 0);
+        $newEnd   = Carbon::create(2026, 1, 24, 11, 0);
+        $result   = ShiftCalendarRenderer::mergeTimeSpanIntoList($times, $newStart, $newEnd);
+
+        $this->assertEquals($result, ['2026-01-24' => [$newStart, $existingEnd]]);
+    }
+
+    public function testMergeTimeSpanIntoListExtendLater(): void
+    {
+        $existingStart = Carbon::create(2026, 1, 24, 10, 0);
+        $existingEnd   = Carbon::create(2026, 1, 24, 12, 0);
+        $times = ['2026-01-24' => [$existingStart, $existingEnd]];
+
+        $newStart = Carbon::create(2026, 1, 24, 11, 0);
+        $newEnd   = Carbon::create(2026, 1, 24, 14, 0);
+        $result   = ShiftCalendarRenderer::mergeTimeSpanIntoList($times, $newStart, $newEnd);
+
+        $this->assertEquals($result, ['2026-01-24' => [$existingStart, $newEnd]]);
+    }
+
+    public function testMergeTimeSpanIntoListWithinExisting(): void
+    {
+        $existingStart = Carbon::create(2026, 1, 24, 10, 0);
+        $existingEnd   = Carbon::create(2026, 1, 24, 14, 0);
+        $times = ['2026-01-24' => [$existingStart, $existingEnd]];
+
+        $newStart = Carbon::create(2026, 1, 24, 11, 0);
+        $newEnd   = Carbon::create(2026, 1, 24, 12, 0);
+        $result   = ShiftCalendarRenderer::mergeTimeSpanIntoList($times, $newStart, $newEnd);
+
+        $this->assertEquals($result, ['2026-01-24' => [$existingStart, $existingEnd]]);
+    }
+
+    private function createShift(Carbon $start, Carbon $end): Shift
+    {
+        return Shift::factory()->create([
+            'location_id' => Location::factory()->create()->id,
+            'shift_type_id' => ShiftType::factory()->create()->id,
+            'start' => $start,
+            'end' => $end,
+        ]);
+    }
+
+    public function testCollectStartAndEndPerDaySimpleShift(): void
+    {
+        $shiftStart = Carbon::create(2026, 1, 24, 10, 0);
+        $shiftEnd   = Carbon::create(2026, 1, 24, 12, 0);
+
+        $result = ShiftCalendarRenderer::collectStartAndEndPerDay([$this->createShift($shiftStart, $shiftEnd)]);
+
+        $this->assertEquals(['2026-01-24' => [
+            Carbon::create(2026, 1, 24, 9, 30), Carbon::create(2026, 1, 24, 12, 29),
+        ]], $result);
+    }
+
+    public function testCollectStartAndEndPerDayMultipleShiftsSameDay(): void
+    {
+        $shift1Start = Carbon::create(2026, 1, 24, 10, 0);
+        $shift1End   = Carbon::create(2026, 1, 24, 12, 0);
+        $shift2Start = Carbon::create(2026, 1, 24, 14, 0);
+        $shift2End   = Carbon::create(2026, 1, 24, 16, 0);
+
+        $shift1 = $this->createShift($shift1Start, $shift1End);
+        $shift2 = $this->createShift($shift2Start, $shift2End);
+
+        $result = ShiftCalendarRenderer::collectStartAndEndPerDay([$shift1, $shift2]);
+
+        $this->assertEquals(['2026-01-24' => [
+                Carbon::create(2026, 1, 24, 9, 30),Carbon::create(2026, 1, 24, 16, 29),
+            ]], $result);
+    }
+
+    public function testCollectStartAndEndPerDayOverMidnight(): void
+    {
+        $start = Carbon::create(2026, 1, 24, 22, 0);
+        $end = Carbon::create(2026, 1, 25, 2, 0);
+
+        $result = ShiftCalendarRenderer::collectStartAndEndPerDay([$this->createShift($start, $end)]);
+
+        // Exactly two entries: start day and end day
+        $this->assertEquals([
+            '2026-01-24' => [Carbon::create(2026, 1, 24, 21, 30), Carbon::create(2026, 1, 24, 23, 59)],
+            '2026-01-25' => [Carbon::create(2026, 1, 25, 0, 0), Carbon::create(2026, 1, 25, 2, 29)],
+        ], $result);
+    }
+
+    public function testCollectStartAndEndPerDayEmptyShifts(): void
+    {
+        $result = ShiftCalendarRenderer::collectStartAndEndPerDay([]);
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    public function testCollectStartAndEndPerDayMultipleDays(): void
+    {
+        $shift1Start = Carbon::create(2026, 1, 24, 10, 0);
+        $shift1End   = Carbon::create(2026, 1, 24, 12, 0);
+        $shift2Start = Carbon::create(2026, 1, 25, 14, 0);
+        $shift2End   = Carbon::create(2026, 1, 25, 16, 0);
+
+        $result = ShiftCalendarRenderer::collectStartAndEndPerDay(
+            [$this->createShift($shift1Start, $shift1End), $this->createShift($shift2Start, $shift2End)]
+        );
+
+        $this->assertEquals([
+            '2026-01-24' => [Carbon::create(2026, 1, 24, 9, 30), Carbon::create(2026, 1, 24, 12, 29)],
+            '2026-01-25' => [Carbon::create(2026, 1, 25, 13, 30), Carbon::create(2026, 1, 25, 16, 29)],
+            ], $result);
+    }
+}


### PR DESCRIPTION
This PR implements a feature that, when enabled, compactifies the shift calendar by removing time frames without shifts at the start and end of each day (i.e., around midnight).

In addition, a second feature enables a dedicated date+dow column.