### PR TITLE
Make shift calendar row granularity configurable

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -327,6 +327,15 @@ return [
                     'type' => 'number',
                     'default' => 2,
                 ],
+                'shift_view_seconds_per_row' => [
+                    'type' => 'number',
+                    'default' => 900,
+                    'step' => 1,
+                    'min' => 1,
+                    'validation' => [
+                        'min:1',
+                    ],
+                ],
             ],
         ],
 

--- a/includes/view/ShiftCalendarRenderer.php
+++ b/includes/view/ShiftCalendarRenderer.php
@@ -11,9 +11,18 @@ use Illuminate\Support\Collection;
 class ShiftCalendarRenderer
 {
     /**
-     * 15m * 60s/m = 900s
+     * Default seconds per row: 15m * 60s/m = 900s
+     * Can be overridden via the 'shift_view_seconds_per_row' config option.
      */
     public const SECONDS_PER_ROW = 900;
+
+    /**
+     * @return int
+     */
+    public static function secondsPerRow(): int
+    {
+        return (int) config('shift_view_seconds_per_row') ?: self::SECONDS_PER_ROW;
+    }
 
     /**
      * Height of a block in pixel.
@@ -177,9 +186,9 @@ class ShiftCalendarRenderer
         $rendered_until = $this->getFirstBlockStartTime();
 
         foreach ($lane->getShifts() as $shift) {
-            while ($rendered_until + ShiftCalendarRenderer::SECONDS_PER_ROW <= $shift->start->timestamp) {
+            while ($rendered_until + self::secondsPerRow() <= $shift->start->timestamp) {
                 $html .= $this->renderTick($rendered_until);
-                $rendered_until += ShiftCalendarRenderer::SECONDS_PER_ROW;
+                $rendered_until += self::secondsPerRow();
             }
 
             $needed_angeltypes = collect($this->needed_angeltypes[$shift->id]);
@@ -216,12 +225,12 @@ class ShiftCalendarRenderer
                 auth()->user()
             );
             $html .= $shift_html;
-            $rendered_until += $shift_height * ShiftCalendarRenderer::SECONDS_PER_ROW;
+            $rendered_until += $shift_height * self::secondsPerRow();
         }
 
         while ($rendered_until < $this->getLastBlockEndTime()) {
             $html .= $this->renderTick($rendered_until);
-            $rendered_until += ShiftCalendarRenderer::SECONDS_PER_ROW;
+            $rendered_until += self::secondsPerRow();
         }
 
         $bg = 'bg-' . theme_type();
@@ -245,7 +254,7 @@ class ShiftCalendarRenderer
         $class = $label ? 'tick bg-' . theme_type() : 'tick ';
 
         $diffNow = $time->diffInMinutes() * 60;
-        if ($diffNow >= 0 && $diffNow < self::SECONDS_PER_ROW) {
+        if ($diffNow >= 0 && $diffNow < self::secondsPerRow()) {
             $class .= ' now';
         }
 
@@ -282,7 +291,7 @@ class ShiftCalendarRenderer
             ]),
         ];
         for ($block = 0; $block < $this->getBlocksPerSlot(); $block++) {
-            $thistime = $this->getFirstBlockStartTime() + ($block * ShiftCalendarRenderer::SECONDS_PER_ROW);
+            $thistime = $this->getFirstBlockStartTime() + ($block * self::secondsPerRow());
             $time_slot[] = $this->renderTick($thistime, true);
         }
         return div('lane time', $time_slot);
@@ -300,9 +309,9 @@ class ShiftCalendarRenderer
                 $start_time = $shift->start->timestamp;
             }
         }
-        return ShiftCalendarRenderer::SECONDS_PER_ROW * floor(
+        return self::secondsPerRow() * floor(
             ($start_time - ShiftCalendarRenderer::TIME_MARGIN)
-                / ShiftCalendarRenderer::SECONDS_PER_ROW
+                / self::secondsPerRow()
         );
     }
 
@@ -319,9 +328,9 @@ class ShiftCalendarRenderer
             }
         }
 
-        return ShiftCalendarRenderer::SECONDS_PER_ROW * ceil(
+        return self::secondsPerRow() * ceil(
             ($end_time + ShiftCalendarRenderer::TIME_MARGIN)
-                / ShiftCalendarRenderer::SECONDS_PER_ROW
+                / self::secondsPerRow()
         );
     }
 
@@ -332,7 +341,7 @@ class ShiftCalendarRenderer
     {
         return (int) ceil(
             ($this->getLastBlockEndTime() - $this->getFirstBlockStartTime())
-            / ShiftCalendarRenderer::SECONDS_PER_ROW
+            / self::secondsPerRow()
         );
     }
 

--- a/includes/view/ShiftCalendarShiftRenderer.php
+++ b/includes/view/ShiftCalendarShiftRenderer.php
@@ -41,7 +41,7 @@ class ShiftCalendarShiftRenderer
 
         $class = $this->classForSignupState($shift_signup_state);
 
-        $blocks = ceil(($shift->end->timestamp - $shift->start->timestamp) / ShiftCalendarRenderer::SECONDS_PER_ROW);
+        $blocks = ceil(($shift->end->timestamp - $shift->start->timestamp) / ShiftCalendarRenderer::secondsPerRow());
         $blocks = max(1, $blocks);
 
         $tags = '';


### PR DESCRIPTION
## Summary
- Revives #949 (closed due to inactivity, no objections raised), rebased onto current `main`
- Adds a `shift_view_seconds_per_row` admin config option (default 900s / 15min) controlling the row height/granularity of the shift calendar, instead of the previously hardcoded `ShiftCalendarRenderer::SECONDS_PER_ROW`
- Adapted to the current admin-config-schema system (`config/app.php`) since the original PR predates that refactor; the constant is kept as the default fallback

## Test plan
- [x] `php -l` on changed files
- [x] Full unit test suite passes (`vendor/bin/phpunit --testsuite Unit`), no regressions
- [x] Manual verification on a running instance (admin sets a custom value and the calendar reflows accordingly)