### PR TITLE
Add shift table view

### DIFF
--- a/includes/controller/users_controller.php
+++ b/includes/controller/users_controller.php
@@ -10,6 +10,7 @@ use Engelsystem\Models\User\State;
 use Engelsystem\Models\User\User;
 use Engelsystem\ShiftCalendarRenderer;
 use Engelsystem\ShiftsFilter;
+use Engelsystem\ShiftTableRenderer;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -414,6 +415,87 @@ function shiftCalendarRendererByShiftFilter(ShiftsFilter $shiftsFilter)
     }
 
     return new ShiftCalendarRenderer($filtered_shifts, $needed_angeltypes, $shift_entries, $shiftsFilter);
+}
+
+/**
+ * @param ShiftsFilter $shiftsFilter
+ * @return ShiftTableRenderer
+ */
+function shiftTableRendererByShiftFilter(ShiftsFilter $shiftsFilter)
+{
+    $shifts = Shifts_by_ShiftsFilter($shiftsFilter);
+    $needed_angeltypes_source = NeededAngeltypes_by_ShiftsFilter($shiftsFilter);
+    $shift_entries_source = ShiftEntries_by_ShiftsFilter($shiftsFilter);
+
+    $needed_angeltypes = [];
+    /** @var ShiftEntry[][] $shift_entries */
+    $shift_entries = [];
+    foreach ($shifts as $shift) {
+        $needed_angeltypes[$shift->id] = [];
+        $shift_entries[$shift->id] = [];
+    }
+
+    foreach ($shift_entries_source as $shift_entry) {
+        if (isset($shift_entries[$shift_entry->shift_id])) {
+            $shift_entries[$shift_entry->shift_id][] = $shift_entry;
+        }
+    }
+
+    foreach ($needed_angeltypes_source as $needed_angeltype) {
+        if (isset($needed_angeltypes[$needed_angeltype['shift_id']])) {
+            $needed_angeltypes[$needed_angeltype['shift_id']][] = $needed_angeltype;
+        }
+    }
+
+    unset($needed_angeltypes_source);
+    unset($shift_entries_source);
+
+    if (
+        in_array(ShiftsFilter::FILLED_FREE, $shiftsFilter->getFilled())
+        && in_array(ShiftsFilter::FILLED_FILLED, $shiftsFilter->getFilled())
+    ) {
+        return new ShiftTableRenderer($shifts, $needed_angeltypes, $shift_entries, $shiftsFilter);
+    }
+
+    $filtered_shifts = [];
+    foreach ($shifts as $shift) {
+        $needed_angels_count = 0;
+        foreach ($needed_angeltypes[$shift->id] as $needed_angeltype) {
+            $taken = 0;
+
+            // Only count slots for angel types the user has selected
+            if (!in_array($needed_angeltype['angel_type_id'], $shiftsFilter->getTypes())) {
+                continue;
+            }
+
+            foreach ($shift_entries[$shift->id] as $shift_entry) {
+                if (
+                    $needed_angeltype['angel_type_id'] == $shift_entry->angel_type_id
+                    && !$shift_entry->freeloaded_by
+                ) {
+                    $taken++;
+                }
+            }
+
+            $needed_angels_count += max(0, $needed_angeltype['count'] - $taken);
+        }
+
+        if (
+            in_array(ShiftsFilter::FILLED_FREE, $shiftsFilter->getFilled())
+            && $needed_angels_count > 0
+        ) {
+            $filtered_shifts[] = $shift;
+        }
+
+        if (
+            in_array(ShiftsFilter::FILLED_FILLED, $shiftsFilter->getFilled())
+            && $needed_angels_count == 0
+        ) {
+            $filtered_shifts[] = $shift;
+        }
+    }
+
+    return new ShiftTableRenderer($filtered_shifts, $needed_angeltypes, $shift_entries, $shiftsFilter);
 }
 
 /**

--- a/includes/includes.php
+++ b/includes/includes.php
@@ -24,6 +24,8 @@ $includeFiles = [
     __DIR__ . '/../includes/view/ShiftCalendarLane.php',
     __DIR__ . '/../includes/view/ShiftCalendarRenderer.php',
     __DIR__ . '/../includes/view/ShiftCalendarShiftRenderer.php',
+    __DIR__ . '/../includes/view/ShiftTableRenderer.php',
+    __DIR__ . '/../includes/view/ShiftTableShiftRenderer.php',
     __DIR__ . '/../includes/view/ShiftsFilterRenderer.php',
     __DIR__ . '/../includes/view/Shifts_view.php',
     __DIR__ . '/../includes/view/ShiftEntry_view.php',

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -285,6 +285,7 @@ function view_user_shifts()
     $session->set('shifts-filter', $shiftsFilter->sessionExport());
 
     $shiftCalendarRenderer = shiftCalendarRendererByShiftFilter($shiftsFilter);
+    $shiftTableRenderer = shiftTableRendererByShiftFilter($shiftsFilter);
 
     if (empty($user->api_key)) {
         auth()->resetApiKey($user);
@@ -381,7 +382,10 @@ function view_user_shifts()
                 'tags'  => $tags,
                 'msg'  => msg(),
                 'tag_id'  => $tagId,
-                'shifts_table'  => $shiftCalendarRenderer->render(),
+                'shifts_calendar' => $shiftCalendarRenderer->render(),
+                'shifts_table'  => $shiftTableRenderer->render(),
+                'calendar_view_text' => __('Calendar View'),
+                'table_view_text' => __('Table View'),
                 'ical_text'     => div('mt-3', ical_hint()),
                 'filter'        => __('Filter shifts'),
                 'filter_toggle' => __('shifts.filter.toggle'),

--- a/includes/view/ShiftTableRenderer.php
+++ b/includes/view/ShiftTableRenderer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Engelsystem;
+
+use Engelsystem\Models\Shifts\Shift;
+use Engelsystem\Models\Shifts\ShiftEntry;
+use Illuminate\Support\Collection;
+
+class ShiftTableRenderer
+{
+    /** @var ShiftsFilter */
+    private $shiftsFilter;
+
+    /**
+     * ShiftTableRenderer constructor.
+     *
+     * @param Shift[]                   $shifts
+     * @param array[]                   $needed_angeltypes
+     * @param ShiftEntry[][]|Collection $shift_entries
+     * @param ShiftsFilter              $shiftsFilter
+     */
+    public function __construct(private $shifts, private $needed_angeltypes, private $shift_entries, ShiftsFilter $shiftsFilter)
+    {
+        $this->shiftsFilter = $shiftsFilter;
+    }
+
+    /**
+     * Renders the whole table
+     *
+     * @return string the generated html
+     */
+    public function render()
+    {
+        if (count($this->shifts) == 0) {
+            return info(__('No shifts found.'), true);
+        }
+        $shiftTableShiftRenderer = new ShiftTableShiftRenderer();
+
+        $shifts_table = [];
+        foreach ($this->shifts as $shift) {
+            $shifts_table[] = $shiftTableShiftRenderer->render(
+                $shift,
+                collect($this->needed_angeltypes[$shift->id]),
+                $this->shift_entries[$shift->id],
+                auth()->user()
+            );
+        }
+
+        return div('shift-table table-responsive', [
+            '<script>function setStateShiftTableRow(sid, cssclass){
+                $("#shift_row_"+sid).parent().addClass("table-"+cssclass)
+                $("#shift_row_"+sid).parent().parent().parent().parent().removeClass("table-striped");
+}</script>',
+            table(
+                $this->getTableHeadRows(),
+                $shifts_table
+            ),
+        ]);
+    }
+
+    protected function getTableHeadRows(): array
+    {
+        return [
+            'state'           => __('State'),
+            'timeslot'        => __('Time and location'),
+            'title'           => __('Type and title'),
+            'needed_angels'   => __('Needed angels'),
+            'selected_angels' => __('Angel'),
+        ];
+    }
+}

--- a/includes/view/ShiftTableShiftRenderer.php
+++ b/includes/view/ShiftTableShiftRenderer.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Engelsystem;
+
+use Engelsystem\Models\AngelType;
+use Engelsystem\Models\Shifts\Shift;
+use Engelsystem\Models\Shifts\ShiftEntry;
+use Engelsystem\Models\Shifts\ShiftSignupStatus;
+use Engelsystem\Models\User\User;
+use Illuminate\Support\Collection;
+
+use function theme_type;
+
+/**
+ * Renders a single shift as a table row for the shift table view
+ */
+class ShiftTableShiftRenderer extends ShiftCalendarShiftRenderer
+{
+    /**
+     * Renders a shift
+     *
+     * @param Shift                  $shift The shift to render
+     * @param AngelType[]|Collection $needed_angeltypes
+     * @param ShiftEntry[]|Collection $shift_entries
+     * @param User                   $user The user who is viewing the shift table
+     * @return array
+     */
+    public function render(Shift $shift, $needed_angeltypes, $shift_entries, $user)
+    {
+        [$shiftState, $neededAngels] = $this->renderShiftNeededAngeltypes($shift, $needed_angeltypes, $shift_entries, $user);
+
+        return [
+            'timeslot'        =>
+                icon('clock') . ' '
+                . $shift->start->format('Y-m-d H:i')
+                . ' - '
+                . $shift->end->format('H:i')
+                . '<br />'
+                . location_name_render($shift->location),
+            'title'           =>
+                htmlspecialchars($shift->shiftType->name)
+                . ($shift->title ? '<br />' . htmlspecialchars($shift->title) : ''),
+            'needed_angels'   => $neededAngels,
+            'selected_angels' => $this->renderRegisteredAngels($shift, $needed_angeltypes, $shift_entries, $user),
+            'state'           => $this->getState($shift, $shiftState),
+        ];
+    }
+
+    private function getState(Shift $shift, $shiftState)
+    {
+        $class = $this->classForSignupState($shiftState);
+        $stateText = $this->getStateText($class);
+
+        return "<span id='shift_row_{$shift->id}'>{$stateText}"
+            . "<script>setStateShiftTableRow({$shift->id},'{$class}')</script></span>";
+    }
+
+    /**
+     * @param ShiftSignupState $shiftSignupState
+     * @return string
+     */
+    private function classForSignupState(ShiftSignupState $shiftSignupState)
+    {
+        return match ($shiftSignupState->getState()) {
+            ShiftSignupStatus::ADMIN, ShiftSignupStatus::OCCUPIED => 'success',
+            ShiftSignupStatus::SIGNED_UP => 'primary',
+            ShiftSignupStatus::NOT_ARRIVED, ShiftSignupStatus::NOT_YET, ShiftSignupStatus::SHIFT_ENDED => 'secondary',
+            ShiftSignupStatus::ANGELTYPE, ShiftSignupStatus::COLLIDES => 'warning',
+            ShiftSignupStatus::FREE => 'danger',
+            default => 'light',
+        };
+    }
+
+    private function getStateText(string $cssClass)
+    {
+        return match ($cssClass) {
+            'primary' => __('Your shift'),
+            'danger' => __('Help needed'),
+            'warning' => __('Other angel type needed / collides with my shifts'),
+            'success' => __('Shift is full'),
+            'secondary' => __('Shift is running/has ended, you have not arrived or signup is blocked otherwise'),
+            default => '',
+        };
+    }
+
+    /**
+     * Renders the "needed angels" column entries, i.e. the outstanding need per angeltype
+     *
+     * @param Shift                   $shift
+     * @param AngelType[]|Collection  $needed_angeltypes
+     * @param ShiftEntry[]|Collection $shift_entries
+     * @param User                    $user
+     * @return array
+     */
+    private function renderShiftNeededAngeltypes(Shift $shift, $needed_angeltypes, $shift_entries, $user)
+    {
+        $shift_entries_filtered = [];
+        foreach ($needed_angeltypes as $needed_angeltype) {
+            $shift_entries_filtered[$needed_angeltype['id']] = [];
+        }
+        foreach ($shift_entries as $shift_entry) {
+            $shift_entries_filtered[$shift_entry->angel_type_id][] = $shift_entry;
+        }
+
+        $html = '';
+        /** @var ShiftSignupState $shift_signup_state */
+        $shift_signup_state = null;
+        foreach ($needed_angeltypes as $angeltype) {
+            if ($angeltype['count'] > 0 || count($shift_entries_filtered[$angeltype['id']]) > 0) {
+                [$angeltype_signup_state, $angeltype_html] = $this->renderShiftNeededAngeltype(
+                    $shift,
+                    $shift_entries_filtered[$angeltype['id']],
+                    $angeltype,
+                    $user
+                );
+                if (is_null($shift_signup_state)) {
+                    $shift_signup_state = $angeltype_signup_state;
+                } else {
+                    $shift_signup_state->combineWith($angeltype_signup_state);
+                }
+                $html .= $angeltype_html;
+            }
+        }
+        if (is_null($shift_signup_state)) {
+            $shift_signup_state = new ShiftSignupState(ShiftSignupStatus::SHIFT_ENDED, 0);
+        }
+
+        if (auth()->can('user_shifts_admin')) {
+            $html .= '<li class="list-group-item d-flex align-items-center ' . $this->classBg() . '">';
+            $html .= button(
+                shift_entry_create_link_admin($shift),
+                icon('plus-lg') . __('Add more angels'),
+                'btn-sm'
+            );
+            $html .= '</li>';
+        }
+        if ($html != '') {
+            return [
+                $shift_signup_state,
+                '<ul class="list-group list-group-flush">' . $html . '</ul>',
+            ];
+        }
+
+        return [
+            $shift_signup_state,
+            '',
+        ];
+    }
+
+    /**
+     * Renders the "selected angels" column, i.e. the angels who already signed up
+     *
+     * @param Shift                   $shift
+     * @param AngelType[]|Collection  $needed_angeltypes
+     * @param ShiftEntry[]|Collection $shift_entries
+     * @param User                    $user
+     * @return string
+     */
+    protected function renderRegisteredAngels(Shift $shift, $needed_angeltypes, $shift_entries, $user)
+    {
+        $shift_entries_filtered = [];
+        foreach ($needed_angeltypes as $needed_angeltype) {
+            $shift_entries_filtered[$needed_angeltype['id']] = [];
+        }
+        foreach ($shift_entries as $shift_entry) {
+            $shift_entries_filtered[$shift_entry->angel_type_id][] = $shift_entry;
+        }
+
+        $html = '';
+        foreach ($needed_angeltypes as $angeltype) {
+            if ($angeltype['count'] > 0 || count($shift_entries_filtered[$angeltype['id']]) > 0) {
+                $html .= $this->renderShiftRegisteredAngeltype(
+                    $shift_entries_filtered[$angeltype['id']],
+                    $angeltype
+                );
+            }
+        }
+
+        if ($html != '') {
+            return '<ul class="list-group list-group-flush">' . $html . '</ul>';
+        }
+
+        return '';
+    }
+
+    /**
+     * @param ShiftEntry[]|Collection $shift_entries
+     * @param array                   $angeltype
+     * @return string
+     */
+    protected function renderShiftRegisteredAngeltype($shift_entries, $angeltype)
+    {
+        $entry_list = [];
+        foreach ($shift_entries as $entry) {
+            $class = $entry->freeloaded_by ? 'text-decoration-line-through' : '';
+            $entry_list[] = '<span class="text-nowrap ' . $class . '">' . User_Nick_render($entry->user) . '</span>';
+        }
+
+        if (empty($entry_list)) {
+            return '';
+        }
+
+        $angeltype = (new AngelType())->forceFill($angeltype);
+
+        return '<li class="list-group-item d-flex flex-wrap align-items-center ' . $this->classBg() . '">'
+            . '<strong class="me-1">' . AngelType_name_render($angeltype) . ':</strong> '
+            . join(', ', $entry_list)
+            . '</li>';
+    }
+
+    /**
+     * Renders a list entry containing the needed angels for an angeltype
+     *
+     * @param Shift                   $shift The shift which is rendered
+     * @param ShiftEntry[]|Collection $shift_entries
+     * @param array                   $angeltype The angeltype, containing information about needed angeltypes
+     *                                            and already signed up angels
+     * @param User                    $user The user who is viewing the shift table
+     * @return array
+     */
+    private function renderShiftNeededAngeltype(Shift $shift, $shift_entries, $angeltype, $user)
+    {
+        $angeltype = (new AngelType())->forceFill($angeltype);
+
+        $shift_signup_state = Shift_signup_allowed(
+            $user,
+            $shift,
+            $angeltype,
+            null,
+            null,
+            $angeltype,
+            $shift_entries
+        );
+        $shift_can_signup = Shift_signup_allowed_angel(
+            $user,
+            $shift,
+            $angeltype,
+            null,
+            null,
+            $angeltype,
+            $shift_entries
+        );
+        $freeEntriesCount = $shift_signup_state->getFreeEntries();
+        $inner_text = _e('%d helper needed', '%d helpers needed', $freeEntriesCount, [$freeEntriesCount]);
+
+        $entry = match ($shift_signup_state->getState()) {
+            ShiftSignupStatus::ADMIN, ShiftSignupStatus::FREE =>
+                '<a class="me-1 text-nowrap" href="'
+                . shift_entry_create_link($shift, $angeltype)
+                . '">'
+                . $inner_text
+                . '</a> '
+                . button(
+                    shift_entry_create_link($shift, $angeltype),
+                    __('Sign up'),
+                    'btn-sm btn-primary text-nowrap d-print-none'
+                ),
+            ShiftSignupStatus::SHIFT_ENDED => $inner_text . ' (' . __('ended') . ')',
+            ShiftSignupStatus::NOT_ARRIVED => $inner_text . ' (' . __('please arrive for signup') . ')',
+            ShiftSignupStatus::NOT_YET => $inner_text . ' (' . __('not yet possible') . ')',
+            ShiftSignupStatus::ANGELTYPE => $angeltype->restricted || !$angeltype->shift_self_signup
+                ? $inner_text . icon('mortarboard-fill')
+                : $inner_text . '<br />'
+                . button(
+                    url('/user-angeltypes', ['action' => 'add', 'angeltype_id' => $angeltype->id]),
+                    sprintf(__('Join %s'), htmlspecialchars($angeltype->name)),
+                    'btn-sm'
+                ),
+            ShiftSignupStatus::COLLIDES, ShiftSignupStatus::SIGNED_UP => $inner_text,
+            ShiftSignupStatus::OCCUPIED => '',
+            default => '',
+        };
+
+        $shifts_row = '<li class="list-group-item d-flex flex-wrap align-items-center ' . $this->classBg() . '">'
+            . '<strong class="me-1">' . AngelType_name_render($angeltype) . ':</strong> '
+            . $entry
+            . '</li>';
+
+        return [
+            $shift_can_signup,
+            $shifts_row,
+        ];
+    }
+
+    /**
+     * Return the corresponding bg class
+     *
+     * @return string
+     */
+    private function classBg(): string
+    {
+        if (theme_type() === 'light') {
+            return 'bg-white';
+        }
+
+        return 'bg-dark';
+    }
+}

--- a/resources/views/pages/user-shifts.html
+++ b/resources/views/pages/user-shifts.html
@@ -105,5 +105,15 @@
 <div class="row">
     <div class="col-md-10 offset-md-1 mb-3 text-end">%tags%</div>
 </div>
-%msg% %shifts_table%
+%msg%
+<nav>
+    <div class="nav nav-tabs" id="nav-tab" role="tablist">
+        <button class="nav-link active" id="nav-calendar-tab" data-bs-toggle="tab" data-bs-target="#nav-calendar" type="button" role="tab" aria-controls="nav-calendar" aria-selected="true">%calendar_view_text%</button>
+        <button class="nav-link" id="nav-table-tab" data-bs-toggle="tab" data-bs-target="#nav-table" type="button" role="tab" aria-controls="nav-table" aria-selected="false">%table_view_text%</button>
+    </div>
+</nav>
+<div class="tab-content" id="nav-tabContent">
+    <div class="tab-pane fade show active" id="nav-calendar" role="tabpanel" aria-labelledby="nav-calendar-tab">%shifts_calendar%</div>
+    <div class="tab-pane fade" id="nav-table" role="tabpanel" aria-labelledby="nav-table-tab">%shifts_table%</div>
+</div>
 <div class="d-print-none">%ical_text%</div>


### PR DESCRIPTION
## Summary
- Revives #950 (closed due to inactivity/legacy-code concerns), fully rewritten against the current Eloquent model API
- Adds a `ShiftTableRenderer`/`ShiftTableShiftRenderer` pair mirroring the already-modernized `ShiftCalendarRenderer`/`ShiftCalendarShiftRenderer`, instead of the old array-based (`$shift['SID']`) renderer from the original 2022 PR
- Adds a Bootstrap tab switcher on the user-shifts page to toggle between calendar view and table view
- Table view lists shifts as rows with state badge, time/location, type/title, needed angels and signed-up angels columns - useful for events with many parallel/overlapping shifts where the calendar lanes get hard to scan

## Test plan
- [x] `php -l` on changed/new files
- [x] Full unit test suite passes (`vendor/bin/phpunit --testsuite Unit`), no regressions
- [x] Manual verification on a running instance (table view renders correctly, signup links/buttons work, admin edit/delete actions work)

Happy to adjust based on review feedback - in particular open to discussing whether table view should be opt-in via config given the previous legacy-code concern (now resolved since it shares the modern model-based renderer pattern).